### PR TITLE
Implemented global mutex name creation based on working directory.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -348,7 +348,7 @@ bool FBuild::Build( Node * nodeToBuild )
 		{
 			if ( m_Options.m_WrapperChild )
 			{
-				SystemMutex wrapperMutex( "Global\\FASTBuild" );
+                SystemMutex wrapperMutex( m_Options.GetMainProcessMutexName().Get() );
 				if ( wrapperMutex.TryLock() )
 				{
 					// parent process has terminated

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -11,6 +11,7 @@
 // Core
 #include "Core/Env/Env.h"
 #include "Core/FileIO/PathUtils.h"
+#include "Core/Math/CRC32.h"
 
 // CONSTRUCTOR - FBuildOptions
 //------------------------------------------------------------------------------
@@ -71,6 +72,36 @@ void FBuildOptions::SetWorkingDir( const AString & path )
 			m_WorkingDir[ 0 ] = ( 'A' + ( m_WorkingDir[ 0 ] - 'a' ) );
 		}
 	#endif
+}
+
+AString FBuildOptions::GetMainProcessMutexName() const
+{
+    AString result;
+    if(m_WorkingDir.IsEmpty())
+    {
+        result = "Global\\FASTBuild";
+    }
+    else
+    {
+        uint32_t workingDirCRC = CRC32::CalcLower(m_WorkingDir);
+        result.Format("Global\\FASTBuild-0x%08x", workingDirCRC);
+    }
+    return result;
+}
+
+AString FBuildOptions::GetFinalProcessMutexName() const
+{
+    AString result;
+    if (m_WorkingDir.IsEmpty())
+    {
+        result = "Global\\FASTBuild_Final";
+    }
+    else
+    {
+        uint32_t workingDirCRC = CRC32::CalcLower(m_WorkingDir);
+        result.Format("Global\\FASTBuild_Final-0x%08x", workingDirCRC);
+    }
+    return result;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -39,6 +39,9 @@ public:
 	uint32_t m_NumWorkerThreads;
 	AString m_ConfigFile;
 
+    AString GetMainProcessMutexName() const;
+    AString GetFinalProcessMutexName() const;
+
 private:
 	AString m_WorkingDir;
 };


### PR DESCRIPTION
This let us launch fastbuild for different code trees in the same time.
For example: compiling one project and generating VS project files for another. Or compiling small changes in one project while still compiling long big second project in the same time.