### PR TITLE
Fixing incorrect compiler message error 1106, stating /c is missing

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionLibrary.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionLibrary.cpp
@@ -111,9 +111,10 @@ FunctionLibrary::FunctionLibrary()
         // check /c or -c
         if ( objFlags & ObjectNode::FLAG_MSVC )
         {
-            if ( args.Find( "/c" ) == nullptr )
+            if ( args.Find( "/c" ) == nullptr &&
+                args.Find( "-c" ) == nullptr)
             {
-		        Error::Error_1106_MissingRequiredToken( funcStartIter, this, ".CompilerOptions", "/c" );
+		        Error::Error_1106_MissingRequiredToken( funcStartIter, this, ".CompilerOptions", "/c or -c" );
 			    return false;
 		    }
         }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionObjectList.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionObjectList.cpp
@@ -103,9 +103,10 @@ FunctionObjectList::FunctionObjectList()
         // check /c or -c
         if ( objFlags & ObjectNode::FLAG_MSVC )
         {
-            if ( args.Find( "/c" ) == nullptr )
+            if ( args.Find( "/c" ) == nullptr &&
+				args.Find( "-c" ) == nullptr)
             {
-		        Error::Error_1106_MissingRequiredToken( funcStartIter, this, ".CompilerOptions", "/c" );
+		        Error::Error_1106_MissingRequiredToken( funcStartIter, this, ".CompilerOptions", "/c or -c" );
 			    return false;
 		    }
         }


### PR DESCRIPTION
Under msvc when -c is used, the incorrect error 1106 message appears. 
MSVC supports both - and / as parameter flags. 

Cmake makes heavy use of this assumption, so support isn't possible without resolving this issue.