### PR TITLE
New function Export()

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/errors.html
+++ b/Code/Tools/FBuild/Documentation/docs/errors.html
@@ -676,6 +676,24 @@ Unity( "name" )
 </div>
 </div>
 
+<!--------------- 1060 --------------->
+    <div class='newsitemheader'>1060 - Can't modify frozen variable '%s'.</div>
+    <div class='newsitembody'>
+An attempt was made to assign a value to a frozen variable.
+<h4>Example Config:</h4>
+<div class='code'>.Array = { 'a', 'b', 'c' }
+ForEach( .Item in .Array )
+{
+  ^Array + 'loop variables are frozen'
+}
+</div>
+<h4>Example Output:</h4>
+<div class='output'>C:\Test\fbuild.bff(4,3): FASTBuild Error #1060 - Can't modify frozen variable '.Array'
+  ^Array + 'loop variables are frozen'
+  ^
+  \--here
+</div>
+</div>
 
 
 <h2 id='1100'>1100 - 1199 : Function Parameter Errors</h2>

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -183,11 +183,6 @@ bool BFFParser::Parse( BFFIterator & iter )
 
 	// find the end of the variable name
 	iter.SkipVariableName();
-	if ( iter.IsAtEnd() )
-	{
-		Error::Error_1012_UnexpectedEndOfFile( iter );
-		return false;
-	}
 	const BFFIterator varNameEnd = iter;
 
 	// sanity check it is a sensible length

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -9,8 +9,9 @@
 #include "BFFIterator.h"
 
 #include "Core/Env/Assert.h"
-#include "Core/Strings/AString.h"
 #include "Core/Env/Types.h"
+#include "Core/Strings/AStackString.h"
+#include "Core/Strings/AString.h"
 
 // Forward Declarations
 //------------------------------------------------------------------------------
@@ -54,12 +55,12 @@ public:
 	enum { MAX_DIRECTIVE_NAME_LENGTH = 64 };
 
 	static bool PerformVariableSubstitutions( const BFFIterator & startIter, const BFFIterator & endIter, AString & value );
+	static bool ParseVariableName( BFFIterator & iter, AString & name );
 
 private:
 	bool ParseUnnamedVariableConcatenation( BFFIterator & iter );
 	bool ParseNamedVariableDeclaration( BFFIterator & parseIndex );
-	bool ParseVariableDeclaration( BFFIterator & iter, const BFFIterator & varNameStart,
-													   const BFFIterator & varNameEnd );
+	bool ParseVariableDeclaration( BFFIterator & iter, const AString & varName );
 	bool ParseFunction( BFFIterator & parseIndex );
 	bool ParseUnnamedScope( BFFIterator & iter );
 	bool ParsePreprocessorDirective( BFFIterator & iter );
@@ -71,18 +72,15 @@ private:
 	bool CheckIfCondition( const BFFIterator & conditionStart, const BFFIterator & conditionEnd, bool & result );
 	bool ParseImportDirective( const BFFIterator & directiveStart, BFFIterator & iter );
 
-	bool StoreVariableString( const char * varNameStart, const char * varNameEnd, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableArray( const char * varNameStart, const char * varNameEnd, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableStruct( const char * varNameStart, const char * varNameEnd, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableBool( const char * varNameStart, const char * varNameEnd, bool value );
-	bool StoreVariableInt( const char * varNameStart, const char * varNameEnd, int value );
-	bool StoreVariableToVariable( const char * varNameDstStart, const char * varNameDstEnd,
-						  		  const BFFIterator & varNameSrcStart, const BFFIterator & varNameSrcEnd,
-								  const BFFIterator & operatorIter );
+	bool StoreVariableString( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
+	bool StoreVariableArray( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
+	bool StoreVariableStruct( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
+	bool StoreVariableBool( const AString & name, bool value );
+	bool StoreVariableInt( const AString & name, int value );
+	bool StoreVariableToVariable( const AString & dstName, BFFIterator & varNameSrcStart, const BFFIterator & operatorIter );
 	// store the last seen variable
 	bool m_SeenAVariable;
-	BFFIterator m_LastVarNameStart;
-	BFFIterator m_LastVarNameEnd;
+	AStackString< MAX_VARIABLE_NAME_LENGTH > m_LastVarName;
 
 	// track recursion depth to detect recursion or excessive complexity
 	static uint32_t s_Depth;

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -16,6 +16,7 @@
 // Forward Declarations
 //------------------------------------------------------------------------------
 class FileStream;
+class BFFStackFrame;
 
 // BFFParser
 //------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ public:
 	enum { BFF_COMMENT_SEMICOLON = ';' };
 	enum { BFF_COMMENT_SLASH = '/' };
 	enum { BFF_DECLARE_VAR_INTERNAL = '.' };
+	enum { BFF_DECLARE_VAR_PARENT = '^' };
 	enum { BFF_VARIABLE_ASSIGNMENT = '=' };
 	enum { BFF_VARIABLE_CONCATENATION = '+' };
 	enum { BFF_START_ARRAY = '{' };
@@ -55,12 +57,12 @@ public:
 	enum { MAX_DIRECTIVE_NAME_LENGTH = 64 };
 
 	static bool PerformVariableSubstitutions( const BFFIterator & startIter, const BFFIterator & endIter, AString & value );
-	static bool ParseVariableName( BFFIterator & iter, AString & name );
+	static bool ParseVariableName( BFFIterator & iter, AString & name, bool & parentScope );
 
 private:
 	bool ParseUnnamedVariableConcatenation( BFFIterator & iter );
 	bool ParseNamedVariableDeclaration( BFFIterator & parseIndex );
-	bool ParseVariableDeclaration( BFFIterator & iter, const AString & varName );
+	bool ParseVariableDeclaration( BFFIterator & iter, const AString & varName, BFFStackFrame * frame );
 	bool ParseFunction( BFFIterator & parseIndex );
 	bool ParseUnnamedScope( BFFIterator & iter );
 	bool ParsePreprocessorDirective( BFFIterator & iter );
@@ -72,15 +74,16 @@ private:
 	bool CheckIfCondition( const BFFIterator & conditionStart, const BFFIterator & conditionEnd, bool & result );
 	bool ParseImportDirective( const BFFIterator & directiveStart, BFFIterator & iter );
 
-	bool StoreVariableString( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableArray( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableStruct( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
-	bool StoreVariableBool( const AString & name, bool value );
-	bool StoreVariableInt( const AString & name, int value );
-	bool StoreVariableToVariable( const AString & dstName, BFFIterator & varNameSrcStart, const BFFIterator & operatorIter );
+	bool StoreVariableString( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
+	bool StoreVariableArray( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
+	bool StoreVariableStruct( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
+	bool StoreVariableBool( const AString & name, bool value, BFFStackFrame * frame );
+	bool StoreVariableInt( const AString & name, int value, BFFStackFrame * frame );
+	bool StoreVariableToVariable( const AString & dstName, BFFIterator & varNameSrcStart, const BFFIterator & operatorIter, BFFStackFrame * dstFrame );
 	// store the last seen variable
 	bool m_SeenAVariable;
 	AStackString< MAX_VARIABLE_NAME_LENGTH > m_LastVarName;
+	BFFStackFrame * m_LastVarFrame;
 
 	// track recursion depth to detect recursion or excessive complexity
 	static uint32_t s_Depth;

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
@@ -199,21 +199,29 @@ BFFVariable * BFFStackFrame::ConcatVars( const AString & name,
 
 // GetVar
 //------------------------------------------------------------------------------
-/*static*/ const BFFVariable * BFFStackFrame::GetVar( const char * name )
+/*static*/ const BFFVariable * BFFStackFrame::GetVar( const char * name, BFFStackFrame * frame )
 {
 	AStackString<> strName( name );
-	return GetVar( strName );
+	return GetVar( strName, frame );
 }
 
 // GetVar
 //------------------------------------------------------------------------------
-/*static*/ const BFFVariable * BFFStackFrame::GetVar( const AString & name )
+/*static*/ const BFFVariable * BFFStackFrame::GetVar( const AString & name, BFFStackFrame * frame )
 {
 	// we shouldn't be calling this if there aren't any stack frames
 	ASSERT( s_StackHead );
 
-	// recurse up the stack
-	return s_StackHead->GetVariableRecurse( name );
+	if ( frame )
+	{
+		// no recursion, specific frame provided
+		return frame->GetVarMutableNoRecurse( name );
+	}
+	else
+	{
+		// recurse up the stack
+		return s_StackHead->GetVariableRecurse( name );
+	}
 }
 
 // GetVariableRecurse
@@ -239,6 +247,43 @@ const BFFVariable * BFFStackFrame::GetVariableRecurse( const AString & name ) co
 
 	// not found
 	return nullptr;
+}
+
+// GetLocalVar
+//------------------------------------------------------------------------------
+const BFFVariable * BFFStackFrame::GetLocalVar( const AString & name ) const
+{
+	// look at this scope level
+	return GetVarNoRecurse( name );
+}
+
+// GetParentDeclaration
+//------------------------------------------------------------------------------
+/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const char * name, BFFStackFrame * frame )
+{
+	AStackString<> strName( name );
+	return GetParentDeclaration( strName, frame );
+}
+
+// GetParentDeclaration
+//------------------------------------------------------------------------------
+/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const AString & name, BFFStackFrame * frame )
+{
+	// we shouldn't be calling this if there aren't any stack frames
+	ASSERT( s_StackHead );
+
+	BFFStackFrame * parentFrame = frame ? frame->GetParent() : GetCurrent()->GetParent();
+
+	// look for the scope containing the original variable
+    for ( ; parentFrame; parentFrame = parentFrame->GetParent() )
+    {
+        if ( parentFrame->GetLocalVar( name ) != nullptr )
+        {
+            return parentFrame;
+        }
+    }
+
+    return nullptr;
 }
 
 // GetVarAny
@@ -285,6 +330,26 @@ const BFFVariable * BFFStackFrame::GetVariableRecurse( const AString & nameOnly,
 	}
 
 	// not found
+	return nullptr;
+}
+
+// GetVarNoRecurse
+//------------------------------------------------------------------------------
+const BFFVariable * BFFStackFrame::GetVarNoRecurse( const AString & name ) const
+{
+	ASSERT( s_StackHead ); // we shouldn't be calling this if there aren't any stack frames
+
+	// look at this scope level
+	Array< BFFVariable * >::Iter i = m_Variables.Begin();
+	Array< BFFVariable * >::Iter end = m_Variables.End();
+	for( ; i < end ; ++i )
+	{
+		if ( ( *i )->GetName() == name )
+		{
+			return *i;
+		}
+	}
+
 	return nullptr;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
@@ -259,30 +259,33 @@ const BFFVariable * BFFStackFrame::GetLocalVar( const AString & name ) const
 
 // GetParentDeclaration
 //------------------------------------------------------------------------------
-/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const char * name, BFFStackFrame * frame )
+/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const char * name, BFFStackFrame * frame, const BFFVariable *& variable )
 {
 	AStackString<> strName( name );
-	return GetParentDeclaration( strName, frame );
+	return GetParentDeclaration( strName, frame, variable );
 }
 
 // GetParentDeclaration
 //------------------------------------------------------------------------------
-/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const AString & name, BFFStackFrame * frame )
+/*static*/ BFFStackFrame * BFFStackFrame::GetParentDeclaration( const AString & name, BFFStackFrame * frame, const BFFVariable *& variable )
 {
 	// we shouldn't be calling this if there aren't any stack frames
 	ASSERT( s_StackHead );
+
+	variable = nullptr;
 
 	BFFStackFrame * parentFrame = frame ? frame->GetParent() : GetCurrent()->GetParent();
 
 	// look for the scope containing the original variable
     for ( ; parentFrame; parentFrame = parentFrame->GetParent() )
     {
-        if ( parentFrame->GetLocalVar( name ) != nullptr )
+        if ( ( variable = parentFrame->GetLocalVar( name ) ) != nullptr )
         {
             return parentFrame;
         }
     }
 
+    ASSERT( nullptr == variable );
     return nullptr;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
@@ -24,43 +24,49 @@ public:
 	// set the value of a variable
 	static void SetVarString( const AString & name,
 							  const AString & value,
-							  BFFStackFrame * frame = nullptr );
+							  BFFStackFrame * frame );
 	static void SetVarArrayOfStrings( const AString & name,
 									  const Array< AString > & values,
-									  BFFStackFrame * frame = nullptr );
+									  BFFStackFrame * frame );
 	static void SetVarBool( const AString & name,
 							bool value,
-							BFFStackFrame * frame = nullptr );
+							BFFStackFrame * frame );
 	static void SetVarInt( const AString & name,
 						   int value,
-						   BFFStackFrame * frame = nullptr );
+						   BFFStackFrame * frame );
 	static void SetVarStruct( const AString & name,
 							  const Array< const BFFVariable * > & members,
-							  BFFStackFrame * frame = nullptr );
+							  BFFStackFrame * frame );
 	static void SetVarArrayOfStructs( const AString & name,
 									  const Array< const BFFVariable * > & structs,
-									  BFFStackFrame * frame = nullptr );
+									  BFFStackFrame * frame );
 
 	// set from an existing variable
-	static void SetVar( const BFFVariable * var, BFFStackFrame * frame = nullptr );
+	static void SetVar( const BFFVariable * var, BFFStackFrame * frame );
 
     // set from two existing variable
     static BFFVariable * ConcatVars( const AString & name,
                                      const BFFVariable * lhs,
                                      const BFFVariable * rhs,
-                                     BFFStackFrame * frame = nullptr );
+                                     BFFStackFrame * frame );
 
 	// get a variable (caller passes complete name indicating type (user vs system))
-	static const BFFVariable * GetVar( const char * name );
-	static const BFFVariable * GetVar( const AString & name );
+	static const BFFVariable * GetVar( const char * name, BFFStackFrame * frame = nullptr );
+	static const BFFVariable * GetVar( const AString & name, BFFStackFrame * frame = nullptr );
 
 	// get a variable by name, either user or system
 	static const BFFVariable * GetVarAny( const AString & name );
 
-	// get all variables ar this stack level only
+	// get all variables at this stack level only
 	const Array< const BFFVariable * > & GetLocalVariables() const { RETURN_CONSTIFIED_BFF_VARIABLE_ARRAY( m_Variables ); }
 
+	// get a variable at this stack level only
+	const BFFVariable * GetLocalVar( const AString & name ) const;
+
 	static BFFStackFrame * GetCurrent() { return s_StackHead; }
+
+	static BFFStackFrame * GetParentDeclaration( const char * name, BFFStackFrame * frame );
+	static BFFStackFrame * GetParentDeclaration( const AString & name, BFFStackFrame * frame );
 
 	BFFStackFrame * GetParent() const { return m_Next; }
 
@@ -70,6 +76,8 @@ private:
 
 	const BFFVariable * GetVariableRecurse( const AString & nameOnly, 
 									  BFFVariable::VarType type ) const;
+
+	const BFFVariable * GetVarNoRecurse( const AString & name ) const;
 	BFFVariable * GetVarMutableNoRecurse( const AString & name );
 
     void CreateOrReplaceVarMutableNoRecurse( BFFVariable * var );

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
@@ -65,8 +65,8 @@ public:
 
 	static BFFStackFrame * GetCurrent() { return s_StackHead; }
 
-	static BFFStackFrame * GetParentDeclaration( const char * name, BFFStackFrame * frame );
-	static BFFStackFrame * GetParentDeclaration( const AString & name, BFFStackFrame * frame );
+	static BFFStackFrame * GetParentDeclaration( const char * name, BFFStackFrame * frame, const BFFVariable *& variable );
+	static BFFStackFrame * GetParentDeclaration( const AString & name, BFFStackFrame * frame, const BFFVariable *& variable );
 
 	BFFStackFrame * GetParent() const { return m_Next; }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
@@ -28,6 +28,7 @@
 BFFVariable::BFFVariable( const AString & name, VarType type )
 : m_Name( name )
 , m_Type( type )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, true )
@@ -42,6 +43,7 @@ BFFVariable::BFFVariable( const AString & name, VarType type )
 BFFVariable::BFFVariable( const BFFVariable & other )
 : m_Name( other.m_Name )
 , m_Type( other.m_Type )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, true )
@@ -67,6 +69,7 @@ BFFVariable::BFFVariable( const BFFVariable & other )
 BFFVariable::BFFVariable( const AString & name, const AString & value )
 : m_Name( name )
 , m_Type( VAR_STRING )
+, m_Frozen( false )
 , m_StringValue( value )
 , m_BoolValue( false )
 , m_ArrayValues( 0, false )
@@ -81,6 +84,7 @@ BFFVariable::BFFVariable( const AString & name, const AString & value )
 BFFVariable::BFFVariable( const AString & name, bool value )
 : m_Name( name )
 , m_Type( VAR_BOOL )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( value )
 , m_ArrayValues( 0, false )
@@ -95,6 +99,7 @@ BFFVariable::BFFVariable( const AString & name, bool value )
 BFFVariable::BFFVariable( const AString & name, const Array< AString > & values )
 : m_Name( name )
 , m_Type( VAR_ARRAY_OF_STRINGS )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, true )
@@ -110,6 +115,7 @@ BFFVariable::BFFVariable( const AString & name, const Array< AString > & values 
 BFFVariable::BFFVariable( const AString & name, int i )
 : m_Name( name )
 , m_Type( VAR_INT )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, true )
@@ -124,6 +130,7 @@ BFFVariable::BFFVariable( const AString & name, int i )
 BFFVariable::BFFVariable( const AString & name, const Array< const BFFVariable * > & values )
 : m_Name( name )
 , m_Type( VAR_STRUCT )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, false )
@@ -141,6 +148,7 @@ BFFVariable::BFFVariable( const AString & name,
 						  VarType type ) // type for disambiguation
 : m_Name( name )
 , m_Type( VAR_ARRAY_OF_STRUCTS )
+, m_Frozen( false )
 //, m_StringValue() // default construct this
 , m_BoolValue( false )
 , m_ArrayValues( 0, false )
@@ -179,6 +187,7 @@ BFFVariable::~BFFVariable()
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueString( const AString & value )
 {
+    ASSERT( false == m_Frozen );
 	m_Type = VAR_STRING;
 	m_StringValue = value;
 }
@@ -187,6 +196,7 @@ void BFFVariable::SetValueString( const AString & value )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueBool( bool value )
 {
+    ASSERT( false == m_Frozen );
 	m_Type = VAR_BOOL;
 	m_BoolValue = value;
 }
@@ -195,6 +205,7 @@ void BFFVariable::SetValueBool( bool value )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueArrayOfStrings( const Array< AString > & values )
 {
+    ASSERT( false == m_Frozen );
 	m_Type = VAR_ARRAY_OF_STRINGS;
 	m_ArrayValues = values;
 }
@@ -203,6 +214,7 @@ void BFFVariable::SetValueArrayOfStrings( const Array< AString > & values )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueInt( int i )
 {
+    ASSERT( false == m_Frozen );
 	m_Type = VAR_INT;
 	m_IntValue = i;
 }
@@ -211,6 +223,8 @@ void BFFVariable::SetValueInt( int i )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueStruct( const Array< const BFFVariable * > & values )
 {
+    ASSERT( false == m_Frozen );
+
 	// build list of new members, but don't touch old ones yet to gracefully
 	// handle self-assignment
 	Array< BFFVariable * > newVars( values.GetSize(), false );
@@ -241,6 +255,8 @@ void BFFVariable::SetValueStruct( const Array< const BFFVariable * > & values )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueArrayOfStructs( const Array< const BFFVariable * > & values )
 {
+    ASSERT( false == m_Frozen );
+
 	// build list of new members, but don't touch old ones yet to gracefully
 	// handle self-assignment
 	Array< BFFVariable * > newVars( values.GetSize(), false );
@@ -290,7 +306,7 @@ BFFVariable * BFFVariable::ConcatVarsRecurse( const AString & dstName, const BFF
 
     const VarType dstType = m_Type;
     const VarType srcType = other.m_Type;
-    
+
     // handle supported types
 
     if ( srcType != dstType )

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
@@ -61,6 +61,10 @@ public:
 	inline bool IsStruct() const	{ return m_Type == BFFVariable::VAR_STRUCT; }
 	inline bool IsArrayOfStructs() const { return m_Type == BFFVariable::VAR_ARRAY_OF_STRUCTS; }
 
+	inline bool Frozen() const { return m_Frozen; }
+	inline void Freeze() const { ASSERT( false == m_Frozen ); m_Frozen = true; }
+	inline void Unfreeze() const { ASSERT( m_Frozen ); m_Frozen = false; }
+
     BFFVariable * ConcatVarsRecurse( const AString & dstName, const BFFVariable & other ) const;
 
 private:
@@ -87,9 +91,11 @@ private:
     static const BFFVariable ** GetMemberByName( const AString & name, const Array< const BFFVariable * > & members );
 
 	AString m_Name;
+	VarType	m_Type;
+
+	mutable bool m_Frozen;
 
 	//
-	VarType				m_Type;
 	AString				m_StringValue;
 	bool				m_BoolValue;
 	Array< AString >	m_ArrayValues;

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
@@ -60,24 +60,14 @@ FunctionForEach::FunctionForEach()
 			Error::Error_1200_ExpectedVar( pos, this );
 			return false;
 		}
-		BFFIterator varNameStart( pos );
-		pos++;
-		if ( pos.IsAtValidVariableNameCharacter() == false )
-		{
-			Error::Error_1013_UnexpectedCharInVariableName( pos, this );
-			return false;
-		}
-		pos.SkipVariableName();
-		BFFIterator varNameEnd( pos );
 
-		// sanity check it is a sensible length
-		size_t varNameLen = varNameStart.GetDistTo( varNameEnd );
-		if ( varNameLen > BFFParser::MAX_VARIABLE_NAME_LENGTH )
+		const BFFIterator arrayVarNameBegin = pos;
+		AStackString< BFFParser::MAX_VARIABLE_NAME_LENGTH > localName;
+		if ( BFFParser::ParseVariableName( pos, localName ) == false )
 		{
-			Error::Error_1014_VariableNameIsTooLong( varNameStart, (uint32_t)varNameLen, (uint32_t)BFFParser::MAX_VARIABLE_NAME_LENGTH );
 			return false;
 		}
-		AStackString< BFFParser::MAX_VARIABLE_NAME_LENGTH > localName( varNameStart.GetCurrent(), varNameEnd.GetCurrent() );
+
 		localNames.Append( localName );
 
 		pos.SkipWhiteSpace();
@@ -100,29 +90,17 @@ FunctionForEach::FunctionForEach()
 		pos++;
 		pos.SkipWhiteSpace();
 
-		BFFIterator arrayVarNameBegin( pos );
 		if ( *pos != BFFParser::BFF_DECLARE_VAR_INTERNAL )
 		{
 			Error::Error_1202_ExpectedVarFollowingIn( pos, this );
 			return false;
 		}
-		pos++;
-		if ( pos.IsAtValidVariableNameCharacter() == false )
-		{
-			Error::Error_1013_UnexpectedCharInVariableName( pos, this );
-			return false;
-		}
-		pos.SkipVariableName();
-		BFFIterator arrayVarNameEnd( pos );
 
-		// sanity check it is a sensible length
-		size_t arrayVarNameLen = arrayVarNameBegin.GetDistTo( arrayVarNameEnd );
-		if ( arrayVarNameLen > BFFParser::MAX_VARIABLE_NAME_LENGTH )
+		AStackString< BFFParser::MAX_VARIABLE_NAME_LENGTH > arrayVarName;
+		if ( BFFParser::ParseVariableName( pos, arrayVarName ) == false )
 		{
-			Error::Error_1014_VariableNameIsTooLong( arrayVarNameBegin, (uint32_t)arrayVarNameLen, (uint32_t)BFFParser::MAX_VARIABLE_NAME_LENGTH );
 			return false;
 		}
-		AStackString< BFFParser::MAX_VARIABLE_NAME_LENGTH > arrayVarName( arrayVarNameBegin.GetCurrent(), arrayVarNameEnd.GetCurrent() );
 
 		const BFFVariable * var = BFFStackFrame::GetVar( arrayVarName );
 		if ( var == nullptr )

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
@@ -171,11 +171,11 @@ FunctionForEach::FunctionForEach()
 		{
 			if ( arrayVars[ j ]->GetType() == BFFVariable::VAR_ARRAY_OF_STRINGS )
 			{
-				loopStackFrame.SetVarString( localNames[ j ], arrayVars[ j ]->GetArrayOfStrings()[ i ] );
+				BFFStackFrame::SetVarString( localNames[ j ], arrayVars[ j ]->GetArrayOfStrings()[ i ], &loopStackFrame );
 			}
 			else if ( arrayVars[ j ]->GetType() == BFFVariable::VAR_ARRAY_OF_STRUCTS )
 			{
-				loopStackFrame.SetVarStruct( localNames[ j ], arrayVars[ j ]->GetArrayOfStructs()[ i ]->GetStructMembers() );
+				BFFStackFrame::SetVarStruct( localNames[ j ], arrayVars[ j ]->GetArrayOfStructs()[ i ]->GetStructMembers(), &loopStackFrame );
 			}
 			else
 			{

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionForEach.cpp
@@ -107,22 +107,21 @@ FunctionForEach::FunctionForEach()
 			return false;
 		}
 
+		const BFFVariable * var = nullptr;
 		BFFStackFrame * const arrayFrame = ( arrayParentScope )
-			? BFFStackFrame::GetParentDeclaration( arrayVarName, BFFStackFrame::GetCurrent()->GetParent() )
+			? BFFStackFrame::GetParentDeclaration( arrayVarName, BFFStackFrame::GetCurrent()->GetParent(), var )
 			: nullptr;
 
-		if ( arrayParentScope && nullptr == arrayFrame )
+		if ( false == arrayParentScope )
+		{
+			var = BFFStackFrame::GetVar( arrayVarName, nullptr );
+		}
+
+		if ( ( arrayParentScope && ( nullptr == arrayFrame ) ) || ( var == nullptr ) )
 	    {
 	    	Error::Error_1009_UnknownVariable( arrayNameStart, this );
 	    	return false;
 	    }
-
-		const BFFVariable * var = BFFStackFrame::GetVar( arrayVarName, arrayFrame );
-		if ( var == nullptr )
-		{
-			Error::Error_1009_UnknownVariable( arrayVarNameBegin, this );
-			return false;
-		}
 
 		// it can be of any supported type
 		if ( ( var->IsArrayOfStrings() == false ) && ( var->IsArrayOfStructs() == false ) )

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.cpp
@@ -93,23 +93,21 @@ FunctionPrint::FunctionPrint()
 
 			ASSERT( stop.GetCurrent() <= functionHeaderStopToken->GetCurrent() ); // should not be in this function if strings are not validly terminated
 
+			const BFFVariable * var = nullptr;
 			BFFStackFrame * const varFrame = ( parentScope )
-				? BFFStackFrame::GetParentDeclaration( varName, BFFStackFrame::GetCurrent()->GetParent() )
+				? BFFStackFrame::GetParentDeclaration( varName, BFFStackFrame::GetCurrent()->GetParent(), var )
 				: nullptr;
 
-			if ( parentScope && nullptr == varFrame )
+			if ( false == parentScope )
+			{
+				var = BFFStackFrame::GetVar( varName, nullptr );
+			}
+
+			if ( ( parentScope && ( nullptr == varFrame ) ) || ( nullptr == var ) )
 		    {
 		    	Error::Error_1009_UnknownVariable( start, this );
 		    	return false;
 		    }
-
-			// get the var
-			const BFFVariable * var = BFFStackFrame::GetVar( varName, varFrame );
-			if ( !var )
-			{
-				Error::Error_1009_UnknownVariable( start, this );
-				return false;
-			}
 
 			// dump the contents
 			PrintVarRecurse( *var, 0 );

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
@@ -68,10 +68,13 @@ FunctionUsing::FunctionUsing()
 
 		// find variable name
 		BFFIterator stop( start );
-		stop++;
-		stop.SkipVariableName();
-		ASSERT( stop.GetCurrent() <= functionHeaderStopToken->GetCurrent() ); // should not be in this function if strings are not validly terminated
 		AStackString<> varName( start.GetCurrent(), stop.GetCurrent() );
+		if ( BFFParser::ParseVariableName( stop, varName ) == false )
+		{
+			return false;
+		}
+
+		ASSERT( stop.GetCurrent() <= functionHeaderStopToken->GetCurrent() ); // should not be in this function if strings are not validly terminated
 
 		// find variable
 		const BFFVariable * v = BFFStackFrame::GetVar( varName );

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
@@ -82,23 +82,23 @@ FunctionUsing::FunctionUsing()
 
 		ASSERT( stop.GetCurrent() <= functionHeaderStopToken->GetCurrent() ); // should not be in this function if strings are not validly terminated
 
+		// find variable
+		const BFFVariable * v = nullptr;
 		BFFStackFrame * const varFrame = ( parentScope )
-			? BFFStackFrame::GetParentDeclaration( varName, frame )
+			? BFFStackFrame::GetParentDeclaration( varName, frame, v )
 			: nullptr;
 
-		if ( parentScope && nullptr == varFrame )
+		if ( false == parentScope )
+		{
+			v = BFFStackFrame::GetVar( varName, nullptr );
+		}
+
+		if ( ( parentScope && ( nullptr == varFrame ) ) || ( nullptr == v ) )
 	    {
 	    	Error::Error_1009_UnknownVariable( start, this );
 	    	return false;
 	    }
 
-		// find variable
-		const BFFVariable * v = BFFStackFrame::GetVar( varName, varFrame );
-		if ( v == nullptr )
-		{
-			Error::Error_1009_UnknownVariable( start, this );
-			return false;
-		}
 		if ( v->IsStruct() == false )
 		{
 			Error::Error_1008_VariableOfWrongType( start, this,

--- a/Code/Tools/FBuild/FBuildCore/Error.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Error.cpp
@@ -395,6 +395,13 @@
 									  rangeMin, rangeMax );
 }
 
+// Error_1060_CantModifyFrozenVar
+//------------------------------------------------------------------------------
+/*static*/ void Error::Error_1060_CantModifyFrozenVar( const BFFIterator & iter, const Function * function, const BFFVariable * var )
+{
+	FormatError( iter, 1060u, function, "Can't modify frozen variable '%s'", var->GetName().Get() );
+}
+
 // Error_1100_AlreadyDefined
 //------------------------------------------------------------------------------
 /*static*/ void Error::Error_1100_AlreadyDefined( const BFFIterator & iter,

--- a/Code/Tools/FBuild/FBuildCore/Error.h
+++ b/Code/Tools/FBuild/FBuildCore/Error.h
@@ -116,6 +116,9 @@ public:
 											const char * propertyName,
 											int rangeMin,
 											int rangeMax );
+	static void Error_1060_CantModifyFrozenVar( const BFFIterator & iter,
+												const Function * function,
+												const BFFVariable * var );
 
 	//
 	// 1100 - 1199 : General function definition errors

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/frozen_foreach.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/frozen_foreach.bff
@@ -1,0 +1,8 @@
+
+; loop variables are frozen
+
+.array = { 'a', 'b', 'c' }
+ForEach( .item in .array )
+{
+    ^array + 'd'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
@@ -98,6 +98,8 @@ ForEach( .item in .array )
     ^string + .item
 }
 
+.array = 'no more frozen'
+
 ; foreach with parent scope array
 
 .string = ''

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
@@ -1,0 +1,123 @@
+
+; parent scope assignation
+
+.varA = 'foo'
+.varB = 'bar'
+.varC = .varA
+{
+    .varB = 'test'
+    ^varC = 'foobar'
+
+    .varC = ^varB
+    .varA = ^varC
+    .varB = .varC
+
+    .varB + .varA
+    .varA + ^varA
+    ^varC + .varA
+    ^varB + ^varC
+}
+
+; parent scope priority
+
+.var = 'first definition'
+{
+    ^var = 'parent'
+    .var = 'child'
+}
+
+; parent scope recursive search
+
+.var = 'first definition'
+{
+    {{{{ ^var = 'parent' }}}}
+}
+
+; parent scope concatenation
+
+.array = { 'a', 'b', 'c' }
+{
+    ^array + 'd'
+}
+
+; parent scope unnamed concatenation
+
+.array = { 'a', 'b', 'c' }
+{
+    ^array + 'd'
+           + 'e'
+           + 'f'
+}
+
+; array of parent scope
+
+.array = {}
+.a = 'a'
+.b = 'b'
+.c = 'c'
+{
+    .array = { ^a }
+    .array = { ^a, ^b, ^c }
+    ^array = { ^a, ^b, ^c }
+    ^array = {^a,^b,^c}
+    ^array =
+        {
+        ^a
+        ,
+        ^b
+        ,
+        ^c
+        }
+}
+
+; struct with parent scope
+
+.var = 12
+.struct =
+[
+    .value = ^var
+    ^var = 'test'
+]
+
+; using struct with parent scope
+
+.struct =
+[
+    .value = 42
+]
+{
+    Using( ^struct )
+}
+
+; foreach with parent scope
+
+.string = ''
+.array = { 'a', 'b', 'c' }
+ForEach( .item in .array )
+{
+    ^string + .item
+}
+
+; foreach with parent scope array
+
+.string = ''
+.array = { 'a', 'b', 'c' }
+{
+    ForEach( .item in ^array )
+    {
+        ^string + .item
+    }
+}
+
+; print with parent scope
+
+.var = 'test'
+{
+    Print( ^var )
+}
+
+; assignation at then end of the file
+
+.varA = 'foo'
+.varB = 'bar'
+.varC = .varA

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope_unknown.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope_unknown.bff
@@ -1,0 +1,7 @@
+
+; unknown in parent scope
+
+{
+    .var = 'test'
+    ^var = 'undefined'
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
@@ -38,6 +38,8 @@ private:
 	void BadDefineDirective() const;
 	void BadUndefDirective() const;
 	void BadUndefBuiltInDirective() const;
+	void ParentScope() const;
+	void ParentScopeUnknown() const;
 
 	void Parse( const char * fileName, bool expectFailure = false ) const;
 };
@@ -65,6 +67,8 @@ REGISTER_TESTS_BEGIN( TestBFFParsing )
 	REGISTER_TEST( BadDefineDirective )
 	REGISTER_TEST( BadUndefDirective )
 	REGISTER_TEST( BadUndefBuiltInDirective )
+	REGISTER_TEST( ParentScope )
+	REGISTER_TEST( ParentScopeUnknown )
 REGISTER_TESTS_END
 
 // Empty
@@ -235,6 +239,21 @@ void TestBFFParsing::BadUndefDirective() const
 void TestBFFParsing::BadUndefBuiltInDirective() const
 {
 	Parse( "Data/TestBFFParsing/bad_undef_builtin.bff", true ); // expect failure
+}
+
+// ParentScope
+//------------------------------------------------------------------------------
+void TestBFFParsing::ParentScope() const
+{
+	Parse( "Data/TestBFFParsing/parent_scope.bff" );
+}
+
+// ParentScopeUnknown
+//------------------------------------------------------------------------------
+void TestBFFParsing::ParentScopeUnknown() const
+{
+	Parse( "Data/TestBFFParsing/parent_scope_unknown.bff", true ); // expect failure
+
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
@@ -40,6 +40,7 @@ private:
 	void BadUndefBuiltInDirective() const;
 	void ParentScope() const;
 	void ParentScopeUnknown() const;
+	void FrozenVariable() const;
 
 	void Parse( const char * fileName, bool expectFailure = false ) const;
 };
@@ -69,6 +70,7 @@ REGISTER_TESTS_BEGIN( TestBFFParsing )
 	REGISTER_TEST( BadUndefBuiltInDirective )
 	REGISTER_TEST( ParentScope )
 	REGISTER_TEST( ParentScopeUnknown )
+	REGISTER_TEST( FrozenVariable )
 REGISTER_TESTS_END
 
 // Empty
@@ -253,7 +255,13 @@ void TestBFFParsing::ParentScope() const
 void TestBFFParsing::ParentScopeUnknown() const
 {
 	Parse( "Data/TestBFFParsing/parent_scope_unknown.bff", true ); // expect failure
+}
 
+// FrozenVariable
+//------------------------------------------------------------------------------
+void TestBFFParsing::FrozenVariable() const
+{
+	Parse( "Data/TestBFFParsing/frozen_foreach.bff", true ); // expect failure
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestVariableStack.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestVariableStack.cpp
@@ -97,6 +97,8 @@ void TestVariableStack::TestStackFramesOverride() const
 //------------------------------------------------------------------------------
 void TestVariableStack::TestStackFramesParent() const
 {
+	const BFFVariable *v = nullptr;
+
 	// a stack frame with a variable
 	BFFStackFrame sf1;
 	BFFStackFrame::SetVarString( AStackString<>( "myVar" ), AStackString<>( "originalValue" ), nullptr );
@@ -105,8 +107,8 @@ void TestVariableStack::TestStackFramesParent() const
 	TEST_ASSERT( BFFStackFrame::GetVar( "myVar", &sf1 )->GetString() == "originalValue" );
 
 	// there is no previous declaration
-	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr ) == nullptr );
-	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf1 ) == nullptr );
+	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr, v ) == nullptr );
+	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf1, v ) == nullptr );
 
 	// another stack frame
 	{
@@ -126,17 +128,17 @@ void TestVariableStack::TestStackFramesParent() const
 		TEST_ASSERT( BFFStackFrame::GetVar( "myVar", &sf2 )->GetString() == "replacedValue" );
 
 		// but there is a previous declaration
-		TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr ) == &sf1 );
-		TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf2 ) == &sf1 );
+		TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr, v ) == &sf1 );
+		TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf2, v ) == &sf1 );
 
 		// another stack frame
 		{
 			BFFStackFrame sf3;
 
 			// but there is still a previous declaration
-			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr ) == &sf2 );
-			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf3 ) == &sf2 );
-			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf2 ) == &sf1 );
+			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr, v ) == &sf2 );
+			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf3, v ) == &sf2 );
+			TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf2, v ) == &sf1 );
 
 			// we should bet the original value
 			TEST_ASSERT( BFFStackFrame::GetVar( "myVar", &sf1 ) );
@@ -153,8 +155,8 @@ void TestVariableStack::TestStackFramesParent() const
 	TEST_ASSERT( BFFStackFrame::GetVar( "myVar", nullptr )->GetString() == "originalValue" );
 
 	// there is still no previous declaration
-	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr ) == nullptr );
-	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf1 ) == nullptr );
+	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", nullptr, v ) == nullptr );
+	TEST_ASSERT( BFFStackFrame::GetParentDeclaration( "myVar", &sf1, v ) == nullptr );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Export( .var ) is the counter part of Using( .var ).
It will update the previous definition of .var in the first ancestor scope declaring it.
If a previous declaration of .var is not found the parent scope will be used to declare a new .var.

This addition allows the following idiom :
```
.Defines = { '_DEBUG', 'SOMETHING=1' }
.CompilerOptions = ''

#if __WINDOWS__
ForEach( .name in .Defines )
{
   .CompilerOptions + ' /D "$name$"'
   Export( .CompilerOptions )
}
#endif

#if __LINUX__
ForEach( .name in .Defines )
{
   .CompilerOptions + ' -D$name$'
   Export( .CompilerOptions )
}
#endif

Print( "$CompilerOptions$" ) ; windows : ' /D "_DEBUG" /D "SOMETHING=1"'
                             ; linux   : ' /D_DEBUG -DSOMETHING=1'
```