### PR TITLE
Support for system environment variables expansion

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -852,7 +852,8 @@ bool BFFParser::ParseImportDirective( const BFFIterator & directiveStart, BFFIte
 
 	// look for varName in system environment
 	AStackString<> varValue;
-	if ( Env::GetEnvVariable( varName.Get(), varValue ) == false )
+	uint32_t varHash = 0;
+	if ( FBuild::Get().ImportEnvironmentVar( varName.Get(), varValue, varHash ) == false )
 	{
 		Error::Error_1009_UnknownVariable( varNameStart, nullptr );
 		return false;

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -67,6 +67,7 @@ private:
 	bool ParseIfDirective( const BFFIterator & directiveStart, BFFIterator & iter );
 	bool ParseEndIfDirective( const BFFIterator & directiveStart );
 	bool CheckIfCondition( const BFFIterator & conditionStart, const BFFIterator & conditionEnd, bool & result );
+	bool ParseImportDirective( const BFFIterator & directiveStart, BFFIterator & iter );
 
 	bool StoreVariableString( const char * varNameStart, const char * varNameEnd, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );
 	bool StoreVariableArray( const char * varNameStart, const char * varNameEnd, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter );

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -28,6 +28,7 @@
 #include "Core/FileIO/FileIO.h"
 #include "Core/FileIO/FileStream.h"
 #include "Core/FileIO/MemoryStream.h"
+#include "Core/Math/Murmur3.h"
 #include "Core/Process/SystemMutex.h"
 #include "Core/Profile/Profile.h"
 #include "Core/Strings/AStackString.h"
@@ -57,6 +58,7 @@ FBuild::FBuild( const FBuildOptions & options )
 	, m_WorkerList( 0, true )
 	, m_EnvironmentString( nullptr )
 	, m_EnvironmentStringSize( 0 )
+	, m_ImportedEnvironmentVars( 0, true )
 {
 	#ifdef DEBUG_CRT_MEMORY_USAGE
 		_CrtSetDbgFlag( _CRTDBG_ALLOC_MEM_DF | 
@@ -416,6 +418,48 @@ void FBuild::SetEnvironmentString( const char * envString, uint32_t size, const 
 	m_EnvironmentStringSize = size;
 	AString::Copy( envString, m_EnvironmentString, size );
 	m_LibEnvVar = libEnvVar;
+}
+
+// ImportEnvironmentVar
+//------------------------------------------------------------------------------
+bool FBuild::ImportEnvironmentVar( const char * name, AString & value, uint32_t & hash )
+{
+	// check if system environment contains the variable
+	if ( Env::GetEnvVariable( name, value ) == false )
+	{
+		FLOG_ERROR( "Could not import environment variable '%s'", name );
+		return false;
+	}
+
+	// compute hash value for actual value
+	hash = Murmur3::Calc32( value );
+
+	// check if the environment var was already imported
+	const EnvironmentVarAndHash * it = m_ImportedEnvironmentVars.Begin();
+	const EnvironmentVarAndHash * const end = m_ImportedEnvironmentVars.End();
+	while ( it < end )
+	{
+		if ( it->GetName() == name )
+		{
+			// check if imported environment changed since last import
+			if ( it->GetHash() != hash )
+			{
+				FLOG_ERROR( "Overwriting imported environment variable '%s' with a different value = '%s'",
+							name, value.Get() );
+				return false;
+			}
+
+			// skip registration when already imported with same hash value
+			return true;
+		}
+		it++;
+	}
+
+	// import new variable name with its hash value
+	const EnvironmentVarAndHash var( name, hash );
+	m_ImportedEnvironmentVars.Append( var );
+
+	return true;
 }
 
 // GetLibEnvVar

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -69,6 +69,25 @@ public:
 	inline const char * GetEnvironmentString() const			{ return m_EnvironmentString; }
 	inline uint32_t		GetEnvironmentStringSize() const		{ return m_EnvironmentStringSize; }
 
+	class EnvironmentVarAndHash
+    {
+    public:
+        EnvironmentVarAndHash( const char * name, uint32_t hash )
+         : m_Name( name )
+         , m_Hash( hash )
+        {}
+
+        inline const AString &              GetName() const             { return m_Name; }
+        inline uint32_t                     GetHash() const          	{ return m_Hash; }
+
+    protected:
+        AString		m_Name;
+        uint32_t 	m_Hash;
+    };
+
+    bool ImportEnvironmentVar( const char * name, AString & value, uint32_t & hash );
+    const Array< EnvironmentVarAndHash > & GetImportedEnvironmentVars() const { return m_ImportedEnvironmentVars; }
+
 	void GetLibEnvVar( AString & libEnvVar ) const;
 
 	// stats - read access
@@ -116,6 +135,8 @@ private:
 	char *		m_EnvironmentString;
 	uint32_t	m_EnvironmentStringSize; // size excluding last null
 	AString		m_LibEnvVar; // LIB= value
+
+	Array< EnvironmentVarAndHash > m_ImportedEnvironmentVars;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -234,6 +234,46 @@ bool NodeGraph::Load( IOStream & stream, bool & needReparsing )
 			FBuild::Get().SetEnvironmentString( envString.Get(), envStringSize, libEnvVar );
 		}
 
+		// imported environment variables
+		uint32_t importedEnvironmentsVarsSize = 0;
+		if ( stream.Read( importedEnvironmentsVarsSize ) == false )
+		{
+			return false;
+		}
+		if ( importedEnvironmentsVarsSize > 0 )
+		{
+			AStackString<> varName;
+			AStackString<> varValue;
+			uint32_t savedVarHash = 0;
+			uint32_t importedVarHash = 0;
+
+			for ( uint32_t i = 0; i < importedEnvironmentsVarsSize; ++i )
+			{
+				if ( stream.Read( varName ) == false )
+				{
+					return false;
+				}
+				if ( stream.Read( savedVarHash ) == false )
+				{
+					return false;
+				}
+				if ( FBuild::Get().ImportEnvironmentVar( varName.Get(), varValue, importedVarHash ) == false )
+				{
+					// make sure the user knows why some things might re-build
+					FLOG_WARN( "'%s' Environment variable was not found - BFF will be re-parsed\n", varName.Get() );
+					needReparsing = true;
+					return true;
+				}
+				if ( importedVarHash != savedVarHash )
+				{
+					// make sure the user knows why some things might re-build
+					FLOG_WARN( "'%s' Environment variable has changed - BFF will be re-parsed\n", varName.Get() );
+					needReparsing = true;
+					return true;
+				}
+			}
+		}
+
 		// check if 'LIB' env variable has changed
 		uint32_t libEnvVarHashInDB( 0 );
 		if ( stream.Read( libEnvVarHashInDB ) == false )
@@ -366,6 +406,18 @@ void NodeGraph::Save( IOStream & stream ) const
 			AStackString<> libEnvVar;
 			FBuild::Get().GetLibEnvVar( libEnvVar );
 			stream.Write( libEnvVar );
+		}
+
+		// imported environment variables
+		const Array< FBuild::EnvironmentVarAndHash > & importedEnvironmentsVars = FBuild::Get().GetImportedEnvironmentVars();
+		const uint32_t importedEnvironmentsVarsSize = static_cast<uint32_t>( importedEnvironmentsVars.GetSize() );
+		ASSERT( importedEnvironmentsVarsSize == importedEnvironmentsVars.GetSize() );
+		stream.Write( importedEnvironmentsVarsSize );
+		for ( uint32_t i = 0; i < importedEnvironmentsVarsSize; ++i )
+		{
+			const FBuild::EnvironmentVarAndHash & varAndHash = importedEnvironmentsVars[i];
+			stream.Write( varAndHash.GetName() );
+			stream.Write( varAndHash.GetHash() );
 		}
 
 		// 'LIB' env var hash

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -51,7 +51,7 @@ public:
 	}
 	inline ~NodeGraphHeader() {}
 
-	enum { NODE_GRAPH_CURRENT_VERSION = 59 };
+	enum { NODE_GRAPH_CURRENT_VERSION = 60 };
 
 	bool IsValid() const
 	{


### PR DESCRIPTION
Uses the std::getenv() function, so the behavior is the same on all platform.
A 1009 error will be raised if the variable is not found in system environment.

Allows :
```
.VSBasePath	= '%VS120COMNTOOLS%..\..\'
```