### PR TITLE
New RemoveDir() function

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -18,6 +18,7 @@
 #include "FunctionLibrary.h"
 #include "FunctionObjectList.h"
 #include "FunctionPrint.h"
+#include "FunctionRemoveDir.h"
 #include "FunctionSettings.h"
 #include "FunctionSLN.h"
 #include "FunctionTest.h"
@@ -115,6 +116,7 @@ Function::~Function()
 	FNEW( FunctionForEach );
 	FNEW( FunctionLibrary );
 	FNEW( FunctionPrint );
+	FNEW( FunctionRemoveDir );
 	FNEW( FunctionSettings );
 	FNEW( FunctionSLN );
 	FNEW( FunctionTest );
@@ -388,7 +390,7 @@ bool Function::GetInt( const BFFIterator & iter, int32_t & var, const char * nam
 // GetNodeList
 //------------------------------------------------------------------------------
 bool Function::GetNodeList( const BFFIterator & iter, const char * name, Dependencies & nodes, bool required,
-							bool allowCopyDirNodes, bool allowUnityNodes ) const
+							bool allowCopyDirNodes, bool allowUnityNodes, bool allowRemoveDirNodes ) const
 {
 	ASSERT( name );
 
@@ -419,7 +421,7 @@ bool Function::GetNodeList( const BFFIterator & iter, const char * name, Depende
 				return false;
 			}
 
-			if ( !GetNodeListRecurse( iter, name, nodes, *it, allowCopyDirNodes, allowUnityNodes ) )
+			if ( !GetNodeListRecurse( iter, name, nodes, *it, allowCopyDirNodes, allowUnityNodes, allowRemoveDirNodes ) )
 			{
 				// child func will have emitted error
 				return false;
@@ -434,7 +436,7 @@ bool Function::GetNodeList( const BFFIterator & iter, const char * name, Depende
 			return false;
 		}
 
-		if ( !GetNodeListRecurse( iter, name, nodes, var->GetString(), allowCopyDirNodes, allowUnityNodes ) )
+		if ( !GetNodeListRecurse( iter, name, nodes, var->GetString(), allowCopyDirNodes, allowUnityNodes, allowRemoveDirNodes ) )
 		{
 			// child func will have emitted error
 			return false;
@@ -577,7 +579,7 @@ bool Function::GetObjectListNodes( const BFFIterator & iter,
 // GetNodeListRecurse
 //------------------------------------------------------------------------------
 bool Function::GetNodeListRecurse( const BFFIterator & iter, const char * name, Dependencies & nodes, const AString & nodeName,
-								   bool allowCopyDirNodes, bool allowUnityNodes ) const
+								   bool allowCopyDirNodes, bool allowUnityNodes, bool allowRemoveDirNodes ) const
 {
 	NodeGraph & ng = FBuild::Get().GetDependencyGraph();
 
@@ -618,6 +620,16 @@ bool Function::GetNodeListRecurse( const BFFIterator & iter, const char * name, 
 			return true;
 		}
 	}
+	if ( allowRemoveDirNodes )
+	{
+		// found - is it a RemoveDirNode?
+		if ( n->GetType() == Node::REMOVE_DIR_NODE )
+		{
+			// use as-is
+			nodes.Append( Dependency( n ) );
+			return true;
+		}
+	}
 	if ( allowUnityNodes )
 	{
 		// found - is it an ObjectList?
@@ -639,7 +651,7 @@ bool Function::GetNodeListRecurse( const BFFIterator & iter, const char * name, 
 			// TODO:C by passing as string we'll be looking up again for no reason
 			const AString & subName = it->GetNode()->GetName();
 
-			if ( !GetNodeListRecurse( iter, name, nodes, subName, allowCopyDirNodes, allowUnityNodes ) )
+			if ( !GetNodeListRecurse( iter, name, nodes, subName, allowCopyDirNodes, allowUnityNodes, allowRemoveDirNodes ) )
 			{
 				return false;
 			}

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
@@ -81,7 +81,7 @@ public:
                              Dependencies & nodes ) const;
 
 	bool GetNodeList( const BFFIterator & iter, const char * name, Dependencies & nodes, bool required = false,
-					  bool allowCopyDirNodes = false, bool allowUnityNodes = false ) const;
+					  bool allowCopyDirNodes = false, bool allowUnityNodes = false, bool allowRemoveDirNodes = false ) const;
 
 private:
 	Function *	m_NextFunction;
@@ -121,7 +121,7 @@ protected:
 	bool PopulatePathAndFileHelper( const BFFIterator & iter, const Meta_Path * pathMD, const Meta_File * fileMD, const AString & variableName, const AString & originalValue, AString & valueToFix ) const;
 private:
 	bool GetNodeListRecurse( const BFFIterator & iter, const char * name, Dependencies & nodes, const AString & nodeName,
-							 bool allowCopyDirNodes, bool allowUnityNodes ) const;
+							 bool allowCopyDirNodes, bool allowUnityNodes, bool allowRemoveDirNodes ) const;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionAlias.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionAlias.cpp
@@ -41,7 +41,8 @@ FunctionAlias::FunctionAlias()
 	const bool required = true;
 	const bool allowCopyDirNodes = true;
 	const bool allowUnityNodes = true;
-	if ( !GetNodeList( funcStartIter, ".Targets", targetNodes, required, allowCopyDirNodes, allowUnityNodes ) )
+	const bool allowRemoveDirNodes = true;
+	if ( !GetNodeList( funcStartIter, ".Targets", targetNodes, required, allowCopyDirNodes, allowUnityNodes, allowRemoveDirNodes ) )
 	{
 		return false; // GetNodeList will have emitted an error
 	}

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
@@ -1,0 +1,94 @@
+// FunctionRemoveDir
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
+
+#include "FunctionRemoveDir.h"
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+#include "Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h"
+#include "Tools/FBuild/FBuildCore/BFF/BFFVariable.h"
+#include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+
+// Core
+#include "Core/FileIO/PathUtils.h"
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+FunctionRemoveDir::FunctionRemoveDir()
+: Function( "RemoveDir" )
+{
+}
+
+// AcceptsHeader
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionRemoveDir::AcceptsHeader() const
+{
+    return true;
+}
+
+// Commit
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionRemoveDir::Commit( const BFFIterator & funcStartIter ) const
+{
+    // Get input paths
+    Array< AString > inputPaths;
+    if ( !GetFolderPaths( funcStartIter, inputPaths, ".Paths", true ) )
+    {
+        return false; // GetFolderPaths will have emitted an error
+    }
+
+    // get the optional params
+    AStackString<> pattern;
+    bool recurse = true;
+    Array< AString > excludePaths;
+    if ( !GetString( funcStartIter, pattern, ".PathsPattern" ) ||
+         !GetBool( funcStartIter, recurse, ".PathsRecurse", true ) || // recursive by default
+         !GetStrings( funcStartIter, excludePaths, ".ExcludePaths" ) )
+    {
+        return false; // Get* will have emitted error
+    }
+    if ( pattern.IsEmpty() )
+    {
+        pattern = "*";
+    }
+
+    // convert input paths to DirectoryListNodes
+    Dependencies staticDeps( inputPaths.GetSize() );
+    if ( !GetDirectoryListNodeList( funcStartIter, inputPaths, excludePaths, Array< AString >(), recurse, pattern, ".Paths", staticDeps ) )
+    {
+        return false; // GetDirectoryListNodeList will have emitted an error
+    }
+
+    // Pre-build dependencies
+    Dependencies preBuildDeps;
+    bool allowCopyDirNodes = true;
+    bool allowUnityNodes = false;
+    bool allowRemoveDirNodes = true;
+    if ( !GetNodeList( funcStartIter, ".PreBuildDependencies", preBuildDeps, false, allowCopyDirNodes, allowUnityNodes, allowRemoveDirNodes ) )
+    {
+        return false; // GetNodeList will have emitted an error
+    }
+
+    // sanity check we defined something useful
+    if ( staticDeps.IsEmpty() )
+    {
+        Error::Error_1006_NothingToBuild( funcStartIter, this );
+        return false;
+    }
+
+    // check node doesn't already exist
+    NodeGraph & ng = FBuild::Get().GetDependencyGraph();
+    if ( ng.FindNode( m_AliasForFunction ) )
+    {
+        Error::Error_1100_AlreadyDefined( funcStartIter, this, m_AliasForFunction );
+        return false;
+    }
+
+    // create our node
+    ng.CreateRemoveDirNode( m_AliasForFunction, staticDeps, preBuildDeps );
+    return true;
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
@@ -40,23 +40,23 @@ FunctionRemoveDir::FunctionRemoveDir()
     }
 
     // get the optional params
-    AStackString<> pattern;
+    Array< AString > patterns;
     bool recurse = true;
     Array< AString > excludePaths;
-    if ( !GetString( funcStartIter, pattern, ".PathsPattern" ) ||
+    if ( !GetStrings( funcStartIter, patterns, ".PathsPattern" ) ||
          !GetBool( funcStartIter, recurse, ".PathsRecurse", true ) || // recursive by default
          !GetStrings( funcStartIter, excludePaths, ".ExcludePaths" ) )
     {
         return false; // Get* will have emitted error
     }
-    if ( pattern.IsEmpty() )
+    if ( patterns.IsEmpty() )
     {
-        pattern = "*";
+        patterns.Append( AStackString<>( "*" ) );
     }
 
     // convert input paths to DirectoryListNodes
     Dependencies staticDeps( inputPaths.GetSize() );
-    if ( !GetDirectoryListNodeList( funcStartIter, inputPaths, excludePaths, Array< AString >(), recurse, pattern, ".Paths", staticDeps ) )
+    if ( !GetDirectoryListNodeList( funcStartIter, inputPaths, excludePaths, Array< AString >(), recurse, patterns.IsEmpty() ? nullptr : &patterns, ".Paths", staticDeps ) )
     {
         return false; // GetDirectoryListNodeList will have emitted an error
     }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.h
@@ -1,0 +1,28 @@
+// FunctionRemoveDir
+//------------------------------------------------------------------------------
+#pragma once
+#ifndef FBUILD_FUNCTIONS_FUNCTIONREMOVEDIR_H
+#define FBUILD_FUNCTIONS_FUNCTIONREMOVEDIR_H
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Function.h"
+
+// Core
+//#include "Core/Containers/Array.h"
+
+// FunctionRemoveDir
+//------------------------------------------------------------------------------
+class FunctionRemoveDir : public Function
+{
+public:
+    explicit        FunctionRemoveDir();
+    inline virtual ~FunctionRemoveDir() {}
+
+protected:
+    virtual bool AcceptsHeader() const;
+    virtual bool Commit( const BFFIterator & funcStartIter ) const;
+};
+
+//------------------------------------------------------------------------------
+#endif // FBUILD_FUNCTIONS_FUNCTIONREMOVEDIR_H

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -25,6 +25,7 @@
 #include "Tools/FBuild/FBuildCore/Graph/NodeProxy.h"
 #include "Tools/FBuild/FBuildCore/Graph/ObjectListNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/ObjectNode.h"
+#include "Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/SLNNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/TestNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/UnityNode.h"
@@ -47,7 +48,7 @@
 
 // Static Data
 //------------------------------------------------------------------------------
-/*static*/ const char * const Node::s_NodeTypeNames[] = 
+/*static*/ const char * const Node::s_NodeTypeNames[Node::NUM_NODE_TYPES] = 
 {
 	"Proxy",
 	"Copy",
@@ -66,6 +67,7 @@
 	"VCXProj",
 	"ObjectList",
 	"CopyDirNode",
+	"RemoveDirNode",
 	"SLN",
 };
 
@@ -420,6 +422,7 @@ void Node::SaveNode( IOStream & fileStream, const Node * node ) const
 		case Node::VCXPROJECT_NODE:		n = VCXProjectNode::Load( stream );		break;
 		case Node::OBJECT_LIST_NODE:	n = ObjectListNode::Load( stream );		break;
 		case Node::COPY_DIR_NODE:		n = CopyDirNode::Load( stream );		break;
+		case Node::REMOVE_DIR_NODE:		n = RemoveDirNode::Load( stream );		break;
 		case Node::SLN_NODE:			n = SLNNode::Load( stream );			break;
 		case Node::NUM_NODE_TYPES:		ASSERT( false );						break;
 	}

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -73,7 +73,9 @@ public:
 		VCXPROJECT_NODE		= 14,
 		OBJECT_LIST_NODE	= 15,
 		COPY_DIR_NODE		= 16,
-		SLN_NODE 			= 17,
+		REMOVE_DIR_NODE		= 17,
+		SLN_NODE 		= 18,
+
 		// Make sure you update 's_NodeTypeNames' in the cpp
 		NUM_NODE_TYPES		// leave this last
 	};

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -26,6 +26,7 @@
 #include "LibraryNode.h"
 #include "ObjectListNode.h"
 #include "ObjectNode.h"
+#include "RemoveDirNode.h"
 #include "SLNNode.h"
 #include "TestNode.h"
 #include "UnityNode.h"
@@ -548,6 +549,19 @@ CopyDirNode * NodeGraph::CreateCopyDirNode( const AString & nodeName,
 	ASSERT( Thread::IsMainThread() );
 
 	CopyDirNode * node = FNEW( CopyDirNode( nodeName, staticDeps, destPath, preBuildDependencies ) );
+	AddNode( node );
+	return node;
+}
+
+// CreateRemoveDirNode
+//------------------------------------------------------------------------------
+RemoveDirNode * NodeGraph::CreateRemoveDirNode( const AString & nodeName, 
+												Dependencies & staticDeps,
+												const Dependencies & preBuildDependencies )
+{
+	ASSERT( Thread::IsMainThread() );
+
+	RemoveDirNode * node = FNEW( RemoveDirNode( nodeName, staticDeps, preBuildDependencies ) );
 	AddNode( node );
 	return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -34,6 +34,7 @@ class LinkerNode;
 class Node;
 class ObjectListNode;
 class ObjectNode;
+class RemoveDirNode;
 class SLNNode;
 class TestNode;
 class UnityNode;
@@ -93,6 +94,9 @@ public:
 									 Dependencies & staticDeps,
 									 const AString & destPath,
 									 const Dependencies & preBuildDependencies );
+	RemoveDirNode * CreateRemoveDirNode(const AString & nodeName,
+									 	Dependencies & staticDeps,
+									 	const Dependencies & preBuildDependencies );
 	ExecNode * CreateExecNode( const AString & dstFileName, 
 							   const Dependencies & inputFiles, 
 							   FileNode * executable, 

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
@@ -1,0 +1,110 @@
+// RemoveDirNode.cpp
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
+
+#include "RemoveDirNode.h"
+
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+#include "Tools/FBuild/FBuildCore/FLog.h"
+#include "Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h"
+#include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+
+#include "Core/Env/Env.h"
+#include "Core/Strings/AStackString.h"
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+RemoveDirNode::RemoveDirNode( const AString & name,
+                              Dependencies & staticDeps,
+                              const Dependencies & preBuildDeps )
+: Node( name, Node::REMOVE_DIR_NODE, Node::FLAG_NONE )
+{
+    m_StaticDependencies.Append( staticDeps );
+    m_PreBuildDependencies = preBuildDeps;
+}
+
+// DESTRUCTOR
+//------------------------------------------------------------------------------
+RemoveDirNode::~RemoveDirNode()
+{
+}
+
+// IsAFile
+//------------------------------------------------------------------------------
+/*virtual*/ bool RemoveDirNode::IsAFile() const
+{
+    return false;
+}
+
+// DoBuild
+//------------------------------------------------------------------------------
+/*virtual*/ Node::BuildResult RemoveDirNode::DoBuild( Job * UNUSED( job ) )
+{
+    ASSERT( !m_StaticDependencies.IsEmpty() );
+
+    m_Stamp = 0; // Trigger DoBuild() every time
+
+    // Iterate all the DirectoryListNodes
+    const Dependency * const depEnd = m_StaticDependencies.End();
+    for ( const Dependency * dep = m_StaticDependencies.Begin();
+          dep != depEnd;
+          ++dep )
+    {
+        // Grab the files
+        DirectoryListNode * dln = dep->GetNode()->CastTo< DirectoryListNode >();
+        const Array< FileIO::FileInfo > & files = dln->GetFiles();
+        const FileIO::FileInfo * const fEnd = files.End();
+        for ( const FileIO::FileInfo * fIt = files.Begin();
+              fIt != fEnd;
+              ++fIt )
+        {
+            // source file (full path)
+            const AString & srcFile = fIt->m_Name;
+
+            // remove the file
+            if ( FileIO::FileDelete( srcFile.Get() ) == false )
+            {
+                FLOG_ERROR( "Remove failed (error %i) '%s'", Env::GetLastErr(), srcFile.Get() );
+                return NODE_RESULT_FAILED; // remove failed
+            }
+
+            // we combine everything into one string to ensure it is contiguous in
+            // the output
+            AStackString<> output;
+            output += "Remove: ";
+            output += srcFile;
+            output += '\n';
+            FLOG_BUILD_DIRECT( output.Get() );
+        }
+    }
+
+    return NODE_RESULT_OK;
+}
+
+// Load
+//------------------------------------------------------------------------------
+/*static*/ Node * RemoveDirNode::Load( IOStream & stream )
+{
+    NODE_LOAD( AStackString<>,  name);
+    NODE_LOAD_DEPS( 4,          staticDeps );
+    NODE_LOAD_DEPS( 0,          preBuildDeps );
+
+    NodeGraph & ng = FBuild::Get().GetDependencyGraph();
+    RemoveDirNode * n = ng.CreateRemoveDirNode( name, staticDeps, preBuildDeps );
+    ASSERT( n );
+    return n;
+}
+
+// Save
+//------------------------------------------------------------------------------
+/*virtual*/ void RemoveDirNode::Save( IOStream & stream ) const
+{
+    NODE_SAVE( m_Name );
+    NODE_SAVE_DEPS( m_StaticDependencies );
+    NODE_SAVE_DEPS( m_PreBuildDependencies );
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
@@ -1,0 +1,35 @@
+// RemoveDirNode.h - a node that removes one or more directories
+//------------------------------------------------------------------------------
+#pragma once
+#ifndef FBUILD_GRAPH_REMOVEDIRNODE_H
+#define FBUILD_GRAPH_REMOVEDIRNODE_H
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Node.h"
+
+// Forward Declarations
+//------------------------------------------------------------------------------
+
+// RemoveDirNode
+//------------------------------------------------------------------------------
+class RemoveDirNode : public Node
+{
+public:
+    explicit RemoveDirNode( const AString & name,
+                            Dependencies & staticDeps,
+                            const Dependencies & preBuildDeps );
+    virtual ~RemoveDirNode();
+
+    static inline Node::Type GetTypeS() { return Node::REMOVE_DIR_NODE; }
+    virtual bool IsAFile() const;
+
+    static Node * Load( IOStream & stream );
+    virtual void Save( IOStream & stream ) const;
+
+private:
+    virtual BuildResult DoBuild( Job * job );
+};
+
+//------------------------------------------------------------------------------
+#endif // FBUILD_GRAPH_REMOVEDIRNODE_H

--- a/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
@@ -27,25 +27,27 @@
 
 // Globals
 //------------------------------------------------------------------------------
-uint32_t g_ReportNodeColors[] = { 0x000000, // PROXY_NODE (never seen)
-								  0xFFFFFF, // COPY_NODE
-								  0xAAAAAA, // DIRECTORY_LIST_NODE
-								  0x000000, // EXEC_NODE
-								  0x888888, // FILE_NODE
-								  0x88FF88, // LIBRARY_NODE
-								  0xFF8888, // OBJECT_NODE
-								  0x228B22, // ALIAS_NODE
-								  0xFFFF88, // EXE_NODE
-								  0x88AAFF, // UNITY_NODE
-								  0x88CCFF,	// CS_NODE
-								  0xFFAAFF, // TEST_NODE
-								  0xDDA0DD, // COMPILER_NODE
-								  0xFFCC88, // DLL_NODE
-								  0xFFFFFF, // VCXPROJ_NODE
-								  0x444444, // OBJECT_LIST_NODE
-								  0x000000, // COPY_DIR_NODE (never seen)
-								  0x77DDAA, // SLN_NODE
-								};
+uint32_t g_ReportNodeColors[Node::NUM_NODE_TYPES] = {
+	0x000000, // PROXY_NODE (never seen)
+	0xFFFFFF, // COPY_NODE
+	0xAAAAAA, // DIRECTORY_LIST_NODE
+	0x000000, // EXEC_NODE
+	0x888888, // FILE_NODE
+	0x88FF88, // LIBRARY_NODE
+	0xFF8888, // OBJECT_NODE
+	0x228B22, // ALIAS_NODE
+	0xFFFF88, // EXE_NODE
+	0x88AAFF, // UNITY_NODE
+	0x88CCFF,	// CS_NODE
+	0xFFAAFF, // TEST_NODE
+	0xDDA0DD, // COMPILER_NODE
+	0xFFCC88, // DLL_NODE
+	0xFFFFFF, // VCXPROJ_NODE
+	0x444444, // OBJECT_LIST_NODE
+	0x000000, // COPY_DIR_NODE (never seen)
+	0xFF3030, // REMOVE_DIR_NODE
+	0x77DDAA, // SLN_NODE
+};
 
 // CONSTRUCTOR
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Remove files in a directory.
Same usage than CopyDir :
````
RemoveDir( 'name' ) // Name (required)
{
  // Basic options
  .Paths              			// Directories to search

  // Filtering options
  .PathsPattern       			// (optional) Wilcard pattern to filter files (default: "*")
  .PathsRecurse       		 // (optional) Recurse into sub-directories? (default: true)
  .ExcludePaths          // (optional) Directories to ignore when recursing

  // Additional options
  .PreBuildDependencies  // (optional) Force targets to be built before this RemoveDir
}
````
Usefull to handle explicit cleaning of a target.