### PR TITLE
Unity timestamp

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -22,6 +22,17 @@
 #include "Core/Process/Process.h"
 #include "Core/Strings/AStackString.h"
 
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+struct FileAndOriginCompare
+{
+    bool operator ()(   const UnityNode::FileAndOrigin& lhs,
+                        const UnityNode::FileAndOrigin& rhs ) const
+    {
+        return lhs.GetName() < rhs.GetName();
+    }
+};
+
 // Reflection
 //------------------------------------------------------------------------------
 REFLECT_BEGIN( UnityNode, Node, MetaNone() )
@@ -142,7 +153,8 @@ UnityNode::~UnityNode()
         return NODE_RESULT_FAILED; // GetFiles will have emitted an error
     }
 
-    // TODO:A Sort files for consistent ordering across file systems/platforms
+    // sort files for consistent ordering across file systems/platforms
+    files.Sort( FileAndOriginCompare() );
     
 	// how many files should go in each unity file?
 	const size_t numFiles = files.GetSize();

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -43,6 +43,7 @@ public:
         {}
 
         inline const AString &              GetName() const             { return m_Info->m_Name; }
+        inline uint64_t                     GetLastWriteTime() const    { return m_Info->m_LastWriteTime; }
         inline bool                         IsReadOnly() const          { return m_Info->IsReadOnly(); }
         inline const DirectoryListNode *    GetDirListOrigin() const    { return m_DirListOrigin; }
 


### PR DESCRIPTION
If any included file was written later than current unity, the last write time of the unity file will be updated.
This will trigger the compiler, avoiding false-positive clean state.

Sadly this cannot handle included headers, since UnityNode only knows about project source files.
But explicitly including project headers in unity files might fix that, and still prevent a costly compiler call.