### PR TITLE
Adding multi-input dependencies for Exec command

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
@@ -61,6 +61,12 @@ FunctionExec::FunctionExec()
 		return false; // GetNodeList will have emitted an error
 	}
 
+	Dependencies additionalDependencies;
+	if (!GetNodeList(funcStartIter, ".ExecAdditionalDependencies", additionalDependencies, false))
+	{
+		return false; // GetNodeList will have emitted an error
+	}
+
 	// get executable node
 	Node * exeNode = ng.FindNode( executableV->GetString() );
 	if ( exeNode == nullptr )
@@ -96,7 +102,8 @@ FunctionExec::FunctionExec()
 										   arguments,
 										   workingDir, 
 										   expectedReturnCode,
-										   preBuildDependencies );
+										   preBuildDependencies,
+										   additionalDependencies);
 	
 	return ProcessAlias( funcStartIter, outputNode );
 }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
@@ -32,13 +32,11 @@ FunctionExec::FunctionExec()
 	// make sure all required variables are defined
 	const BFFVariable * outputV;
 	const BFFVariable * executableV;
-	const BFFVariable * inputV;
 	const BFFVariable * argsV;
 	const BFFVariable * workingDirV;
 	int32_t expectedReturnCode;
 	if ( !GetString( funcStartIter, outputV,		".ExecOutput", true ) ||
 		 !GetString( funcStartIter, executableV,	".ExecExecutable", true ) ||
-		 !GetString( funcStartIter, inputV,			".ExecInput", true ) ||
 		 !GetString( funcStartIter, argsV,			".ExecArguments" ) ||
 		 !GetString( funcStartIter, workingDirV,	".ExecWorkingDir" ) ||
 		 !GetInt( funcStartIter, expectedReturnCode, ".ExecReturnCode", 0, false ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -25,19 +25,22 @@ ExecNode::ExecNode( const AString & dstFileName,
 						const AString & arguments,
 						const AString & workingDir,
 						int32_t expectedReturnCode,
-						const Dependencies & preBuildDependencies )
+						const Dependencies & preBuildDependencies,
+						const Dependencies & additionalDependencies )
 : FileNode( dstFileName, Node::FLAG_NONE )
 , m_SourceFile( sourceFile )
 , m_Executable( executable )
 , m_Arguments( arguments )
 , m_WorkingDir( workingDir )
 , m_ExpectedReturnCode( expectedReturnCode )
+, m_AdditionalDependencies( additionalDependencies )
 {
 	ASSERT( sourceFile );
 	ASSERT( executable );
 	m_StaticDependencies.SetCapacity( 2 );
 	m_StaticDependencies.Append( Dependency( sourceFile ) );
 	m_StaticDependencies.Append( Dependency( executable ) );
+	m_StaticDependencies.Append( additionalDependencies );
 	m_Type = EXEC_NODE;
 
 	m_PreBuildDependencies = preBuildDependencies;
@@ -113,6 +116,7 @@ ExecNode::~ExecNode()
 	NODE_LOAD( AStackString<>,	workingDir );
 	NODE_LOAD( int32_t,			expectedReturnCode );
 	NODE_LOAD_DEPS( 0,			preBuildDependencies );
+	NODE_LOAD_DEPS( 0,			additionalDependencies );
 
 	NodeGraph & ng = FBuild::Get().GetDependencyGraph();
 	Node * srcNode = ng.FindNode( sourceFile );
@@ -127,7 +131,8 @@ ExecNode::~ExecNode()
 								  arguments,
 								  workingDir,
 								  expectedReturnCode,
-								  preBuildDependencies );
+								  preBuildDependencies,
+								  additionalDependencies );
 	ASSERT( n );
 
 	return n;
@@ -144,6 +149,7 @@ ExecNode::~ExecNode()
 	NODE_SAVE( m_WorkingDir );
 	NODE_SAVE( m_ExpectedReturnCode );
 	NODE_SAVE_DEPS( m_PreBuildDependencies );
+	NODE_SAVE_DEPS( m_AdditionalDependencies );
 }
 
 // EmitCompilationMessage

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -34,7 +34,7 @@ ExecNode::ExecNode( const AString & dstFileName,
 , m_ExpectedReturnCode( expectedReturnCode )
 {
 	ASSERT( executable );
-	m_StaticDependencies.SetCapacity( 2 );
+	m_StaticDependencies.SetCapacity( m_InputFiles.GetSize() + 1 );
 	m_StaticDependencies.Append(m_InputFiles);
 	m_StaticDependencies.Append( Dependency( executable ) );
 	m_Type = EXEC_NODE;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -18,13 +18,12 @@ class ExecNode : public FileNode
 {
 public:
 	explicit ExecNode( const AString & dstFileName,
-					    FileNode * sourceFile,
+						const Dependencies & inputFiles,
 						FileNode * executable,
 						const AString & arguments,
 						const AString & workingDir,
 						int32_t expectedReturnCode,
-						const Dependencies & preBuildDependencies,
-						const Dependencies & additionalDependencies );
+						const Dependencies & preBuildDependencies );
 	virtual ~ExecNode();
 
 	static inline Node::Type GetTypeS() { return Node::EXEC_NODE; }
@@ -34,14 +33,16 @@ public:
 private:
 	virtual BuildResult DoBuild( Job * job );
 
+	void GetFullArgs(AString & fullArgs) const;
+	void GetInputFiles(AString & fullArgs, const AString & pre, const AString & post) const;
+
 	void EmitCompilationMessage( const AString & args ) const;
 
-	FileNode * m_SourceFile;
+	Dependencies m_InputFiles;
 	FileNode * m_Executable;
 	AString		m_Arguments;
 	AString		m_WorkingDir;
 	int32_t		m_ExpectedReturnCode;
-	Dependencies m_AdditionalDependencies;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -23,7 +23,8 @@ public:
 						const AString & arguments,
 						const AString & workingDir,
 						int32_t expectedReturnCode,
-						const Dependencies & preBuildDependencies );
+						const Dependencies & preBuildDependencies,
+						const Dependencies & additionalDependencies );
 	virtual ~ExecNode();
 
 	static inline Node::Type GetTypeS() { return Node::EXEC_NODE; }
@@ -40,6 +41,7 @@ private:
 	AString		m_Arguments;
 	AString		m_WorkingDir;
 	int32_t		m_ExpectedReturnCode;
+	Dependencies m_AdditionalDependencies;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -502,20 +502,19 @@ CopyDirNode * NodeGraph::CreateCopyDirNode( const AString & nodeName,
 // CreateCopyNode
 //------------------------------------------------------------------------------
 ExecNode * NodeGraph::CreateExecNode( const AString & dstFileName, 
-									  FileNode * sourceFile, 
+									  const Dependencies & inputFiles, 
 									  FileNode * executable, 
 									  const AString & arguments,									  
 									  const AString & workingDir,
 									  int32_t expectedReturnCode,
-									  const Dependencies & preBuildDependencies,
-									  const Dependencies & additionalDependencies )
+									  const Dependencies & preBuildDependencies )
 {
 	ASSERT( Thread::IsMainThread() );
 
 	AStackString< 512 > fullPath;
 	CleanPath( dstFileName, fullPath );
 
-	ExecNode * node = FNEW( ExecNode( fullPath, sourceFile, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies, additionalDependencies ) );
+	ExecNode * node = FNEW( ExecNode( fullPath, inputFiles, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies ) );
 	AddNode( node );
 	return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -507,14 +507,15 @@ ExecNode * NodeGraph::CreateExecNode( const AString & dstFileName,
 									  const AString & arguments,									  
 									  const AString & workingDir,
 									  int32_t expectedReturnCode,
-									  const Dependencies & preBuildDependencies )
+									  const Dependencies & preBuildDependencies,
+									  const Dependencies & additionalDependencies )
 {
 	ASSERT( Thread::IsMainThread() );
 
 	AStackString< 512 > fullPath;
 	CleanPath( dstFileName, fullPath );
 
-	ExecNode * node = FNEW( ExecNode( fullPath, sourceFile, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies ) );
+	ExecNode * node = FNEW( ExecNode( fullPath, sourceFile, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies, additionalDependencies ) );
 	AddNode( node );
 	return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -92,13 +92,12 @@ public:
 									 const AString & destPath,
 									 const Dependencies & preBuildDependencies );
 	ExecNode * CreateExecNode( const AString & dstFileName, 
-							   FileNode * sourceFile, 
+							   const Dependencies & inputFiles, 
 							   FileNode * executable, 
 							   const AString & arguments, 
 							   const AString & workingDir,
 							   int32_t expectedReturnCode,
-							   const Dependencies & preBuildDependencies,
-							   const Dependencies & additionalDependencies );
+							   const Dependencies & preBuildDependencies );
 	FileNode * CreateFileNode( const AString & fileName, bool cleanPath = true );
 	DirectoryListNode * CreateDirectoryListNode( const AString & name,
 												 const AString & path,

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -51,7 +51,7 @@ public:
 	}
 	inline ~NodeGraphHeader() {}
 
-	enum { NODE_GRAPH_CURRENT_VERSION = 59 };
+	enum { NODE_GRAPH_CURRENT_VERSION = 60 };
 
 	bool IsValid() const
 	{
@@ -97,7 +97,8 @@ public:
 							   const AString & arguments, 
 							   const AString & workingDir,
 							   int32_t expectedReturnCode,
-							   const Dependencies & preBuildDependencies );
+							   const Dependencies & preBuildDependencies,
+							   const Dependencies & additionalDependencies );
 	FileNode * CreateFileNode( const AString & fileName, bool cleanPath = true );
 	DirectoryListNode * CreateDirectoryListNode( const AString & name,
 												 const AString & path,

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -123,7 +123,7 @@ void TestGraph::TestNodeTypes() const
 
 	{
 		Dependencies empty;
-		Node * n = ng.CreateExecNode( AStackString<>( "dst" ), fn, fn, AStackString<>( "args" ), AStackString<>( "workingDir" ), 0, empty );
+		Node * n = ng.CreateExecNode( AStackString<>( "dst" ), fn, fn, AStackString<>( "args" ), AStackString<>( "workingDir" ), 0, empty, empty );
 		TEST_ASSERT( n->GetType() == Node::EXEC_NODE );
 		TEST_ASSERT( ExecNode::GetTypeS() == Node::EXEC_NODE);
 		TEST_ASSERT( AStackString<>( "Exec" ) == n->GetTypeName() );
@@ -266,7 +266,7 @@ void TestGraph::TestExecNode() const
 	FileNode * srcNode = ng.CreateFileNode( srcFile );
 	FileNode * exe = ng.CreateFileNode( exeName, false ); // false == don't clean the path
 	Dependencies empty;
-	ExecNode * execNode = ng.CreateExecNode( dstFile, srcNode, exe, exeArgs, workingDir, 1, empty );
+	ExecNode * execNode = ng.CreateExecNode( dstFile, srcNode, exe, exeArgs, workingDir, 1, empty, empty );
 
 	// build and verify
 	TEST_ASSERT( fb.Build( execNode ) );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -123,7 +123,9 @@ void TestGraph::TestNodeTypes() const
 
 	{
 		Dependencies empty;
-		Node * n = ng.CreateExecNode( AStackString<>( "dst" ), fn, fn, AStackString<>( "args" ), AStackString<>( "workingDir" ), 0, empty, empty );
+		Dependencies inputs;
+		inputs.Append( Dependency( fn ) );
+		Node * n = ng.CreateExecNode( AStackString<>( "dst" ), inputs, fn, AStackString<>( "args" ), AStackString<>( "workingDir" ), 0, empty );
 		TEST_ASSERT( n->GetType() == Node::EXEC_NODE );
 		TEST_ASSERT( ExecNode::GetTypeS() == Node::EXEC_NODE);
 		TEST_ASSERT( AStackString<>( "Exec" ) == n->GetTypeName() );
@@ -266,7 +268,9 @@ void TestGraph::TestExecNode() const
 	FileNode * srcNode = ng.CreateFileNode( srcFile );
 	FileNode * exe = ng.CreateFileNode( exeName, false ); // false == don't clean the path
 	Dependencies empty;
-	ExecNode * execNode = ng.CreateExecNode( dstFile, srcNode, exe, exeArgs, workingDir, 1, empty, empty );
+	Dependencies inputFiles;
+	inputFiles.Append( Dependency(srcNode) );
+	ExecNode * execNode = ng.CreateExecNode( dstFile, inputFiles, exe, exeArgs, workingDir, 1, empty );
 
 	// build and verify
 	TEST_ASSERT( fb.Build( execNode ) );


### PR DESCRIPTION
Previously only one file could be defined that would invalidate the Exec command's output by timestamps. With this change, a list of files can be defined that will invalidate the Exec command's outputs.