### PR TITLE
Perform variable substitutions in #include path

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -636,7 +636,13 @@ bool BFFParser::ParseIncludeDirective( BFFIterator & iter )
 		return false;
 	}
 
-	AStackString<> include( stringStart.GetCurrent(), iter.GetCurrent() );
+	// unescape and subsitute embedded variables
+	AStackString<> include;
+	if ( PerformVariableSubstitutions( stringStart, iter, include ) == false )
+	{
+		return false;
+	}
+
 	iter++; // skip closing quote before returning
 
 	FLOG_INFO( "Including: %s\n", include.Get() );


### PR DESCRIPTION
Variable substitutions are performed in #include directives.

This allows flow control in BFF language :
````
.projectA = [ .Tasks = { 'library' }           ]
.projectB = [ .Tasks = { 'dll', 'vcxproject' } ]
.allProjects = { .projectA, .projectB }
ForEach( .project in .allProjects )
{
	Using( .project )
	ForEach( .task in .Tasks )
	{
#		include "Tasks/$task$.bff"
	}
}
````

Environment variables can also change execution flow :
````
#import VISUAL_STUDIO_VERSION
#include "Visual/$VISUAL_STUDIO_VERSION$.bff"
````
