### PR TITLE
Fixing error messages from the ToolManifest class

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
@@ -477,14 +477,14 @@ bool ToolManifest::LoadFile( const AString & fileName, void * & content, uint32_
 	FileStream fs;
 	if ( fs.Open( fileName.Get(), FileStream::READ_ONLY ) == false )
 	{
-		FLOG_ERROR( "Error opening file '%s' in Compiler ToolManifest\n", fileName.Get() );
+		FLOG_ERROR( "Error: opening file '%s' in Compiler ToolManifest\n", fileName.Get() );
 		return false;
 	}
 	contentSize = (uint32_t)fs.GetFileSize();
 	AutoPtr< void > mem( ALLOC( contentSize ) );
 	if ( fs.Read( mem.Get(), contentSize ) != contentSize )
 	{
-		FLOG_ERROR( "Error reading file '%s' in Compiler ToolManifest\n", fileName.Get() );
+		FLOG_ERROR( "Error: reading file '%s' in Compiler ToolManifest\n", fileName.Get() );
 		return false;
 	}
 


### PR DESCRIPTION
Fixing error messages from the ToolManifest class so they appear in MSVC when shown.

Without this change, if fbuild can't find the required tools, then it will display this:
> error : BUILD FAILED: All-x64-Debug
> error MSB3073: The command "cd V:\Development\Cmake-Fastbuild\fastbuild\Code\Tools\FBuild\\..\..\ & fbuild -vs -dist -cache All-x64-Debug" exited with code -1.

With this change, we get the more helpful information as well:
> error : opening file 'V:\Development\Cmake-Fastbuild\fastbuild\External\SDK\Windows8.1\Bin\x86\RC.exe' in Compiler ToolManifest
> error : opening file 'V:\Development\Cmake-Fastbuild\fastbuild\External\SDK\VS13.4\VC\bin\x86_amd64\cl.exe' in Compiler ToolManifest
> error : BUILD FAILED: All-x64-Debug
> error MSB3073: The command "cd V:\Development\Cmake-Fastbuild\fastbuild\Code\Tools\FBuild\\..\..\ & fbuild -vs -dist -cache All-x64-Debug" exited with code -1.