### PR TITLE
Fixing a linker error in some project configurations where the implib destination dir does not exist

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.cpp
@@ -37,6 +37,21 @@ DLLNode::~DLLNode()
 {
 }
 
+// DoBuild
+//------------------------------------------------------------------------------
+/*virtual*/ Node::BuildResult DLLNode::DoBuild( Job * job )
+{
+	// Make sure the implib output directory exists
+	if ( m_ImportLibName.IsEmpty() == false)
+	{
+		AStackString<> cleanPath;
+		NodeGraph::CleanPath( m_ImportLibName, cleanPath );
+		EnsurePathExistsForFile( cleanPath );
+	}
+
+	return LinkerNode::DoBuild( job );
+}
+
 // GetImportLibName
 //------------------------------------------------------------------------------
 void DLLNode::GetImportLibName( AString & importLibName ) const

--- a/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.cpp
@@ -46,7 +46,12 @@ DLLNode::~DLLNode()
 	{
 		AStackString<> cleanPath;
 		NodeGraph::CleanPath( m_ImportLibName, cleanPath );
-		EnsurePathExistsForFile( cleanPath );
+
+		if ( EnsurePathExistsForFile( cleanPath ) == false )
+		{
+			// EnsurePathExistsForFile will have emitted error
+			return NODE_RESULT_FAILED; 
+		}
 	}
 
 	return LinkerNode::DoBuild( job );

--- a/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DLLNode.h
@@ -34,6 +34,7 @@ public:
 
 	static Node * Load( IOStream & stream );
 private:
+	virtual BuildResult DoBuild( Job * job ) override;
 	virtual void Save( IOStream & stream ) const;
 
 	AString m_ImportLibName;


### PR DESCRIPTION
Fixing a linker error in some project configurations where the implib is stored in a directory that does not yet exist. The DLL command will now make sure that the implib destination directory will exist before executing the linker.