### PR TITLE
New function Eval()

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -10,6 +10,7 @@
 #include "FunctionCopyDir.h"
 #include "FunctionCSAssembly.h"
 #include "FunctionDLL.h"
+#include "FunctionEval.h"
 #include "FunctionError.h"
 #include "FunctionExec.h"
 #include "FunctionExecutable.h"
@@ -98,6 +99,7 @@ Function::~Function() = default;
     g_Functions.Append( FNEW( FunctionCSAssembly ) );
     g_Functions.Append( FNEW( FunctionDLL ) );
     g_Functions.Append( FNEW( FunctionError ) );
+    g_Functions.Append( FNEW( FunctionEval ) );
     g_Functions.Append( FNEW( FunctionExec ) );
     g_Functions.Append( FNEW( FunctionExecutable ));
     g_Functions.Append( FNEW( FunctionForEach ) );

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionEval.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionEval.cpp
@@ -1,0 +1,205 @@
+// FunctionEval
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "FunctionEval.h"
+#include "Tools/FBuild/FBuildCore/BFF/BFFParser.h"
+#include "Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h"
+#include "Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFTokenRange.h"
+#include "Tools/FBuild/FBuildCore/FLog.h"
+#include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+FunctionEval::FunctionEval()
+: Function( "Eval" )
+{
+}
+
+// AcceptsHeader
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionEval::AcceptsHeader() const
+{
+    return true;
+}
+
+// NeedsHeader
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionEval::NeedsHeader() const
+{
+    return true;
+}
+
+// NeedsBody
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionEval::NeedsBody() const
+{
+    return false;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionEval::ParseFunction(   NodeGraph & nodeGraph,
+                                                BFFParser & parser,
+                                                const BFFToken * functionNameStart,
+                                                const BFFTokenRange & headerRange,
+                                                const BFFTokenRange & bodyRange ) const
+{
+    (void)nodeGraph;
+    (void)parser;
+    (void)functionNameStart;
+    (void)headerRange;
+    (void)bodyRange;
+
+    // we want 1 frame above this function
+    BFFStackFrame * parentFrame = BFFStackFrame::GetCurrent()->GetParent();
+    ASSERT( parentFrame );
+
+    // parse it all out
+    BFFTokenRange headerIter = headerRange;
+    while ( headerIter.IsAtEnd() == false )
+    {
+        // Expect an existing source variable
+        {
+            const BFFToken * localVarToken = headerIter.GetCurrent();
+            headerIter++;
+            if ( localVarToken->IsVariable() == false )
+            {
+                Error::Error_1200_ExpectedVar( localVarToken, this );
+                return false;
+            }
+
+            // Resolve the name of the local variable
+            AStackString< BFFParser::MAX_VARIABLE_NAME_LENGTH > localName;
+            bool localParentScope = false;
+            if ( BFFParser::ParseVariableName( localVarToken, localName, localParentScope ) == false )
+            {
+                return false;
+            }
+
+            // find variable
+            const BFFVariable * v = nullptr;
+            BFFStackFrame * const varFrame = ( localParentScope )
+                ? BFFStackFrame::GetParentDeclaration( localName, parentFrame, v )
+                : parentFrame;
+
+            if ( false == localParentScope )
+            {
+                v = BFFStackFrame::GetVar( localName, nullptr );
+            }
+
+            if ( ( localParentScope && ( nullptr == varFrame ) ) || ( nullptr == v ) )
+            {
+                Error::Error_1009_UnknownVariable( localVarToken, this, localName );
+                return false;
+            }
+
+            if ( PerformVariableSubstitutions( *localVarToken, v, varFrame ) == false )
+            {
+                return false;
+            }
+        }
+
+        // skip optional separator
+        if ( headerIter->IsOperator( "," ) )
+        {
+            headerIter++;
+        }
+    }
+
+    return true;
+}
+
+// PerformVariableSubstitutions
+//------------------------------------------------------------------------------
+bool FunctionEval::PerformVariableSubstitutions( const BFFToken & iter,
+                                                 const BFFVariable * v,
+                                                 BFFStackFrame * frame ) const
+{
+    if ( v->IsString() )
+    {
+        AStackString< > expandedString;
+        const BFFToken stringExpansion( iter.GetSourceFile(), iter.GetSourcePos(), BFFTokenType::String, v->GetString() );
+
+        if ( BFFParser::PerformVariableSubstitutions( &stringExpansion, expandedString ) )
+        {
+            BFFStackFrame::SetVarString( v->GetName(), expandedString, frame );
+            FLOG_INFO( "Registered <string> variable '%s' with value '%s'", v->GetName().Get(), expandedString.Get() );
+
+            return true;
+        }
+    }
+    else if ( v->IsArrayOfStrings() )
+    {
+        const Array< AString > & src = v->GetArrayOfStrings();
+        const size_t srcSize = src.GetSize();
+
+        Array< AString > expandedStrings( srcSize, false );
+        expandedStrings.SetSize( srcSize );
+
+        for ( size_t i = 0 ; i < srcSize ; i++ )
+        {
+            const BFFToken stringExpansion( iter.GetSourceFile(), iter.GetSourcePos(), BFFTokenType::String, src[i] );
+
+            if ( false == BFFParser::PerformVariableSubstitutions( &stringExpansion, expandedStrings[i] ) )
+            {
+                return false;
+            }
+        }
+
+        BFFStackFrame::SetVarArrayOfStrings( v->GetName(), expandedStrings, frame );
+        FLOG_INFO( "Registered <ArrayOfStrings> variable '%s' with %u elements", v->GetName().Get(), (uint32_t)expandedStrings.GetSize() );
+
+        return true;
+    }
+    else if ( v->IsStruct() || v->IsArrayOfStructs() )
+    {
+        BFFStackFrame stackFrame;
+
+        const Array< const BFFVariable * > & src = ( v->IsArrayOfStructs()
+            ? v->GetArrayOfStructs()
+            : v->GetStructMembers() );
+
+        const size_t srcSize = src.GetSize();
+        for ( size_t i = 0 ; i < srcSize ; i++ )
+        {
+            if ( false == PerformVariableSubstitutions( iter, src[i], &stackFrame ) )
+            {
+                return false;
+            }
+        }
+
+        Array< BFFVariable * >& expandedVars = stackFrame.GetLocalVariables();
+
+        if ( v->IsArrayOfStructs() )
+        {
+            // (PQU) #TODO this function signature will probably change in the future (following BFFStackFrame::SetVarStruct)
+            // and we should then remove this glue code :
+            StackArray<const BFFVariable *> constValues;
+            constValues.Append( expandedVars );
+            BFFStackFrame::SetVarArrayOfStructs( v->GetName(), constValues, frame );
+
+            FLOG_INFO( "Registered <ArrayOfStructs> variable '%s' with %u elements", v->GetName().Get(), (uint32_t)expandedVars.GetSize() );
+        }
+        else
+        {
+            ASSERT( v->IsStruct() );
+
+            BFFStackFrame::SetVarStruct( v->GetName(), Move(expandedVars), frame );
+            FLOG_INFO( "Registered <struct> variable '%s' with %u members", v->GetName().Get(), (uint32_t)expandedVars.GetSize() );
+        }
+
+        return true;
+    }
+    else
+    {
+        // simply copy variables without substitutions :
+        BFFStackFrame::SetVar( v, frame );
+
+        return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionEval.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionEval.h
@@ -1,0 +1,42 @@
+// FunctionUsing
+//------------------------------------------------------------------------------
+#pragma once
+#ifndef FBUILD_FUNCTIONS_FUNCTIONEVAL_H
+#define FBUILD_FUNCTIONS_FUNCTIONEVAL_H
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Function.h"
+
+// Forward Declare
+//------------------------------------------------------------------------------
+class BFFStackFrame;
+class BFFVariable;
+
+// FunctionEval
+//------------------------------------------------------------------------------
+class FunctionEval : public Function
+{
+public:
+    explicit        FunctionEval();
+    inline virtual ~FunctionEval() {}
+
+protected:
+    virtual bool AcceptsHeader() const;
+    virtual bool NeedsHeader() const;
+    virtual bool NeedsBody() const;
+
+    virtual bool ParseFunction( NodeGraph & nodeGraph,
+                                BFFParser & parser,
+                                const BFFToken * functionNameStart,
+                                const BFFTokenRange & headerRange,
+                                const BFFTokenRange & bodyRange ) const;
+
+private:
+    bool PerformVariableSubstitutions( const BFFToken & iter,
+                                       const BFFVariable * v,
+                                       BFFStackFrame * frame ) const;
+};
+
+//------------------------------------------------------------------------------
+#endif // FBUILD_FUNCTIONS_FUNCTIONEVAL_H


### PR DESCRIPTION
Eval( .var ) performs variable substitutions on the given String, ArrayOfStrings, Struct or ArrayOfStructs :

``` javascript
.Foobar = "foo bar"
.Barfoo = "^$Foobar^$ 42" // '^$' is already parsed as '$' on master thanks to escaping
Print( .Barfoo ) // "$Foobar$ 42" 

Eval( .Barfoo )
Print( .Barfoo ) // "foo bar 42"

.Barfoos = { "^$Foobar^$", "^$Barfoo^$" }
Print( .Barfoos ) // { "$Foobar$", "$Barfoo$" } 

Eval( .Barfoos )
Print( .Barfoos ) // { "foo bar", "foo bar 42" }

.Foofoo = 
[
    .Foo = [ .a =  '^$Foobar^' ]
    .Bar = [ .b =  { "^$Foobar^$", "^$Barfoo^$" } ]
    .All = { .Foo, .Bar }
]
Eval( .Foofoo )
Print( .Foofoo ) // [ 
                 // .Foo = [ .a = "foo bar" ] .
                 // .Bar = [ .b = { "foo bar", "foo bar 42" } ] 
                 // .All = { [ .a = "foo bar" ], [ .b = { "foo bar", "foo bar 42" } ] }
                 // ]
```

Allows the following BFF configuration :

``` javascript
.BuildA =
[
    .Platform   = "Win32"
    .Config     = "Debug"
]
.BuildB =
[
    .Platform   = "Win32"
    .Config     = "Release"
]

.AllBuilds = { .BuildA, .BuildB }

.ProjectOutput = "MyExe-^$Platform^$-^$Config^$.exe"
.Libraries = 'MyLib-^$Platform^$-^$Config^$'
.Libpaths = { 'Bin/^$Platform^$/^$Config^$', 'External/^$Platform^$/^$Config^$' }

ForEach( .Build in .AllBuilds )
{
    Using( .Build )

    Eval( .ProjectOutput )
    Print( .ProjectOutput ) // "MyExe-Win32-Debug.exe"
                            // "MyExe-Win32-Release.exe"

    Eval( .Libraries )
    Print( .Libraries ) // "MyLib-Win32-Debug"
                        // "MyLib-Win32-Release"

    Eval( .Libpaths )
    Print( .Libpaths )  // { 'Bin/Win32/Debug', 'External/Win32/Debug' }
                        // { 'Bin/Win32/Release', 'External/Win32/Release' }
}
```
