### PR TITLE
MSVC can use the lib command OR the link /LIB command (lib apparently…

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LibraryNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LibraryNode.cpp
@@ -248,7 +248,9 @@ void LibraryNode::GetFullArgs( AString & fullArgs ) const
 {
 	uint32_t flags = 0;
 	if ( librarianName.EndsWithI("lib.exe") ||
-		 librarianName.EndsWithI("lib") )
+		librarianName.EndsWithI("lib") ||
+		librarianName.EndsWithI("link.exe") ||
+		librarianName.EndsWithI("link"))
 	{
 		flags |= LIB_FLAG_LIB;
 	}


### PR DESCRIPTION
Hi Franta,

Here is a small change to fix a discrepancy that I noticed whilst implementing the "LinkerType" parameter. This flag only appears to affect response file usage in this command, but it probably should be fixed anyway? It looks like Cmake only ever uses the link.exe command style for libraries.

Thanks