### PR TITLE
Fix Visual Studio project GUID generation

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
@@ -140,27 +140,29 @@ void SLNGenerator::WriteProjectListings(    const AString& solutionBasePath,
         // check if this project is the master project
         const bool projectIsActive = ( solutionBuildProject.CompareI( (*it)->GetName() ) == 0 );
 
-        // project relative path
         AStackString<> projectPath( (*it)->GetName() );
-        projectPath.Replace( solutionBasePath.Get(), "" );
 
         // get project base name only
-        const char * p1 = projectPath.FindLast( NATIVE_SLASH );
-        const char * p2 = projectPath.FindLast( '.' );
-        AStackString<> projectName( p1 ? p1 + 1 : projectPath.Get(),
-                                    p2 ? p2 : projectPath.GetEnd() );
+        const char * lastSlash  = projectPath.FindLast( NATIVE_SLASH );
+        const char * lastPeriod = projectPath.FindLast( '.' );
+        AStackString<> projectName( lastSlash  ? lastSlash + 1  : projectPath.Get(),
+									lastPeriod ? lastPeriod		: projectPath.GetEnd() );
 
         // retrieve projectGuid
         AStackString<> projectGuid;
         if ( (*it)->GetProjectGuid().GetLength() == 0 )
         {
-            AStackString<> projectNameForGuid( p1 ? p1 : projectName.Get() );
+			// For backward compatibility, keep the preceding slash and .vcxproj extension for GUID generation
+            AStackString<> projectNameForGuid( lastSlash ? lastSlash : projectPath.Get() );
             VSProjectGenerator::FormatDeterministicProjectGUID( projectGuid, projectNameForGuid );
         }
         else
         {
             projectGuid = (*it)->GetProjectGuid();
         }
+
+		// make project path relative
+		projectPath.Replace(solutionBasePath.Get(), "");
 
         // projectGuid must be uppercase (visual does that, it changes the .sln otherwise)
         projectGuid.ToUpper();

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
@@ -86,7 +86,10 @@ void VSProjectGenerator::AddFiles( const Array< AString > & files, bool filterBy
 //------------------------------------------------------------------------------
 /*static*/ void VSProjectGenerator::FormatDeterministicProjectGUID( AString & guid, const AString & projectName )
 {
-	guid.Format( "{%08x-6c94-4f93-bc2a-7f5284b7d434}", CRC32::Calc( projectName ) );
+	// Replace native slash with Windows-style slash for GUID generation to keep GUIDs consistent across platforms
+	AStackString<> projectNameNormalized( projectName );
+	projectNameNormalized.Replace( NATIVE_SLASH, BACK_SLASH );
+	guid.Format( "{%08x-6c94-4f93-bc2a-7f5284b7d434}", CRC32::Calc( projectNameNormalized ) );
 }
 
 // GenerateVCXProj

--- a/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/fbuild.bff
@@ -23,13 +23,13 @@
 ]
 .DebugPS3 =
 [
-	.Platform						= 'X64'
+	.Platform						= 'x64'
 	.Config							= 'Debug'
 	.LocalDebuggerCommand			= 'output/Executable_d64.exe'
 ]
 .ReleasePS3 =
 [
-	.Platform						= 'X64'
+	.Platform						= 'x64'
 	.Config							= 'Release'
 	.LocalDebuggerCommand			= 'output/Executable64.exe'
 ]
@@ -52,3 +52,11 @@ VCXProject( 'TestProj' )
 	// configuration/specific options
 	.ProjectConfigs				= { .DebugX86, .ReleaseX86, .DebugPS3, .ReleasePS3 }
 }
+
+VSSolution( 'TestSln' )
+{
+	.SolutionProjects				= { 'TestProj' }
+	.SolutionBuildProject 			= 'TestProj'
+	.SolutionOutput					= "$Out$\Test\ProjectGeneration\testsln.sln"
+}
+

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -137,8 +137,10 @@ void TestProjectGeneration::Test() const
 void TestProjectGeneration::TestFunction() const
 {
 	AStackString<> project( "../../../../ftmp/Test/ProjectGeneration/testproj.vcxproj" );
+	AStackString<> solution( "../../../../ftmp/Test/ProjectGeneration/testsln.sln" );
 	AStackString<> filters( "../../../../ftmp/Test/ProjectGeneration/testproj.vcxproj.filters" );
 	EnsureFileDoesNotExist( project );
+	EnsureFileDoesNotExist( solution );
 	EnsureFileDoesNotExist( filters );
 
 	FBuildOptions options;
@@ -149,17 +151,20 @@ void TestProjectGeneration::TestFunction() const
 	TEST_ASSERT( fBuild.Initialize() );
 
 	TEST_ASSERT( fBuild.Build( AStackString<>( "TestProj" ) ) );
+	TEST_ASSERT( fBuild.Build( AStackString<>( "TestSln" ) ) );
 	TEST_ASSERT( fBuild.SaveDependencyGraph( "../../../../ftmp/Test/ProjectGeneration/fbuild.fdb" ) );
 
 	EnsureFileExists( project );
+	EnsureFileExists( solution );
 	EnsureFileExists( filters );
 
 	// Check stats
 	//				 Seen,	Built,	Type
 	CheckStatsNode ( 1,		1,		Node::DIRECTORY_LIST_NODE );
 	CheckStatsNode ( 1,		1,		Node::VCXPROJECT_NODE );
-	CheckStatsNode ( 1,		1,		Node::ALIAS_NODE );
-	CheckStatsTotal( 3,		3 );
+	CheckStatsNode ( 1,		1,		Node::SLN_NODE );
+	CheckStatsNode ( 2,		2,		Node::ALIAS_NODE );
+	CheckStatsTotal( 8,		8 );
 }
 
 // TestFunction_NoRebuild


### PR DESCRIPTION
This commit fixes GUID generation so that identical project GUIDs are generated for .sln and .vcxproj files. If the full path to a project is "my/path/projectName.vcxproj", the GUID is generated based ond the string "projectName". 

Root of the problem was that 
- VCXProjectNode.cpp generated the GUID from the string "projectName.vcxproj"
- SLNGenerator.cpp generated the GUID from the string "\\projectName"

Updated TestProjectGeneration/fbuild.bff to include a generated solution. Ideally the unit test would verify that GUIDs between the solution and project match, but couldn't find a way to do this quickly.