### PR TITLE
Adds -isolateallfiles CL option

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -107,6 +107,7 @@ int Main(int argc, char * argv[])
 	bool fixupErrorPaths = false;
 	bool waitMode = false;
 	bool noStopOnError = false;
+	bool isolateAllFiles = false;
 	int32_t numWorkers = -1;
 	WrapperMode wrapperMode( WRAPPER_MODE_NONE );
 	AStackString<> args;
@@ -203,6 +204,11 @@ int Main(int argc, char * argv[])
 			else if ( thisArg == "-nostoponerror")
 			{
 				noStopOnError = true;
+				continue;
+			}
+			else if ( thisArg == "-isolateallfiles" )
+			{
+				isolateAllFiles = true;
 				continue;
 			}
 			else if ( thisArg == "-report" )
@@ -412,6 +418,7 @@ int Main(int argc, char * argv[])
 	{
 		options.m_StopOnFirstError = false; // when building multiple targets, try to build as much as possible
 	}
+	options.m_IsolateAllFiles = isolateAllFiles;
 	FBuild fBuild( options );
 
 	if ( targets.IsEmpty() )
@@ -475,6 +482,7 @@ void DisplayHelp()
             " -ide           Enable multiple options when building from an IDE.\n"
             "                Enables: -noprogress, -fixuperrorpaths &\n"
 			"                -wrapper (Windows)\n"
+			" -isolateallfiles       Build all files individualy.\n"
 			" -j[x]          Explicitly set LOCAL worker thread count X, instead of\n"
 			"                default of hardware thread count.\n"
 			" -noprogress    Don't show the progress bar while building.\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -37,6 +37,7 @@ FBuildOptions::FBuildOptions()
 , m_WrapperChild( false )
 , m_FixupErrorPaths( false )
 , m_StopOnFirstError( true )
+, m_IsolateAllFiles( false )
 , m_WorkingDirHash( 0 )
 {
 #ifdef DEBUG

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -35,6 +35,7 @@ public:
 	bool m_WrapperChild;
 	bool m_FixupErrorPaths;
 	bool m_StopOnFirstError;
+	bool m_IsolateAllFiles;
 	uint32_t m_NumWorkerThreads;
 	AString m_ConfigFile;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -161,6 +161,13 @@ UnityNode::~UnityNode()
 			output += "\"\r\n\r\n";
 		}
 
+		// need to isolate all files?
+		bool isolateAllFiles = false;
+		if ( FBuild::Get().GetOptions().m_IsolateAllFiles )
+		{
+			isolateAllFiles = true;
+		}
+	
 		// make sure any remaining files are added to the last unity to account
 		// for floating point imprecision
 
@@ -183,8 +190,8 @@ UnityNode::~UnityNode()
 			// files which are modified (writable) can optionally be excluded from the unity
 			if ( m_IsolateWritableFiles )
 			{
-				// is the file writable?
-				if ( files[ index ].IsReadOnly() == false )
+				// is the file writable? need to isolate all files?
+				if ( files[ index ].IsReadOnly() == false || isolateAllFiles )
 				{
 					numIsolated++;
 				}
@@ -213,8 +220,8 @@ UnityNode::~UnityNode()
 			// files which are modified (writable) can optionally be excluded from the unity
 			if ( m_IsolateWritableFiles && ( ( m_MaxIsolatedFiles == 0 ) || ( numIsolated <= m_MaxIsolatedFiles ) ) )
 			{
-				// is the file writable?
-				if ( file->IsReadOnly() == false )
+				// is the file writable? need to isolate all files?
+				if ( file->IsReadOnly() == false || isolateAllFiles )
 				{
 					// disable compilation of this file (comment it out)
 					output += "//";


### PR DESCRIPTION
Adds a command line option to perform non-blob compilation with all files isolated.

This option is used to check for missing include statements or forward declarations that can be undetected when using unity files.UnityInputIsolateWritableFiles is not always enough as there are still ways to introduce missing includes/forward declarations. 
