### PR TITLE
Added templates support

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -51,6 +51,9 @@ public:
 	enum { BFF_STRUCT_OPEN = '[' };
 	enum { BFF_STRUCT_CLOSE = ']' };
 	enum { BFF_PREPROCESSOR_START = '#' };
+	enum { BFF_TEMPLATE_OPEN = '(' };
+	enum { BFF_TEMPLATE_CLOSE = ')' };
+	enum { BFF_TEMPLATE_INSTANCIATION = '$' };
 
 	enum { MAX_VARIABLE_NAME_LENGTH = 64 };
 	enum { MAX_FUNCTION_NAME_LENGTH = 64 };
@@ -73,6 +76,7 @@ private:
 	bool ParseEndIfDirective( const BFFIterator & directiveStart );
 	bool CheckIfCondition( const BFFIterator & conditionStart, const BFFIterator & conditionEnd, bool & result );
 	bool ParseImportDirective( const BFFIterator & directiveStart, BFFIterator & iter );
+	bool ParseTemplateInstanciation( BFFIterator & iter);
 
 	bool StoreVariableString( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
 	bool StoreVariableArray( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
@@ -80,6 +84,7 @@ private:
 	bool StoreVariableBool( const AString & name, bool value, BFFStackFrame * frame );
 	bool StoreVariableInt( const AString & name, int value, BFFStackFrame * frame );
 	bool StoreVariableToVariable( const AString & dstName, BFFIterator & varNameSrcStart, const BFFIterator & operatorIter, BFFStackFrame * dstFrame );
+	bool StoreVariableTemplate( const AString & name, const BFFIterator & valueStart, const BFFIterator & valueEnd, const BFFIterator & operatorIter, BFFStackFrame * frame );
 	// store the last seen variable
 	bool m_SeenAVariable;
 	AStackString< MAX_VARIABLE_NAME_LENGTH > m_LastVarName;

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.cpp
@@ -156,6 +156,27 @@ BFFStackFrame::~BFFStackFrame()
 	frame->m_Variables.Append( v );
 }
 
+// SetVarTemplate
+//------------------------------------------------------------------------------
+/*static*/ void BFFStackFrame::SetVarTemplate( const AString & name,
+											   const BFFTemplate & tpl,
+											   BFFStackFrame * frame )
+{
+	frame = frame ? frame : s_StackHead;
+
+	BFFVariable * var = frame->GetVarMutableNoRecurse( name );
+
+	if ( var )
+	{
+		var->SetValueTemplate( tpl );
+		return;
+	}
+
+	// variable not found at this level, so create it
+	BFFVariable * v = FNEW( BFFVariable( name, tpl) );
+	frame->m_Variables.Append( v );
+}
+
 
 // SetVar
 //------------------------------------------------------------------------------
@@ -166,7 +187,7 @@ BFFStackFrame::~BFFStackFrame()
 	ASSERT( var );
 
 	switch ( var->GetType() )
-	{		
+	{
 		case BFFVariable::VAR_ANY:				ASSERT( false ); break;
 		case BFFVariable::VAR_STRING:			SetVarString( var->GetName(), var->GetString(), frame ); break;
 		case BFFVariable::VAR_BOOL:				SetVarBool( var->GetName(), var->GetBool(), frame ); break;
@@ -174,6 +195,7 @@ BFFStackFrame::~BFFStackFrame()
 		case BFFVariable::VAR_INT:				SetVarInt( var->GetName(), var->GetInt(), frame ); break;
 		case BFFVariable::VAR_STRUCT:			SetVarStruct( var->GetName(), var->GetStructMembers(), frame ); break;
 		case BFFVariable::VAR_ARRAY_OF_STRUCTS:	SetVarArrayOfStructs( var->GetName(), var->GetArrayOfStructs(), frame ); break;
+		case BFFVariable::VAR_TEMPLATE:			SetVarTemplate( var->GetName(), var->GetTemplate(), frame ); break;
 		case BFFVariable::MAX_VAR_TYPES: ASSERT( false ); break;
 	}
 }

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFStackFrame.h
@@ -41,6 +41,10 @@ public:
 									  const Array< const BFFVariable * > & structs,
 									  BFFStackFrame * frame );
 
+	static void SetVarTemplate( const AString & name,
+								const BFFTemplate & tpl,
+								BFFStackFrame * frame );
+
 	// set from an existing variable
 	static void SetVar( const BFFVariable * var, BFFStackFrame * frame );
 
@@ -84,6 +88,9 @@ private:
 
 	// variables at current scope
 	Array< BFFVariable * > m_Variables;
+
+	// Template being instanciated
+	BFFTemplate* m_Template;;
 
 	// pointer to parent scope
 	BFFStackFrame * m_Next;

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFTemplate.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFTemplate.cpp
@@ -1,0 +1,43 @@
+// BFFStackFrame
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
+
+#include "BFFTemplate.h"
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+BFFTemplate::BFFTemplate()
+: m_DefStart()
+, m_DefEnd()
+{
+
+}
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+BFFTemplate::BFFTemplate(const BFFTemplate& rhs)
+: m_DefStart(rhs.m_DefStart)
+, m_DefEnd(rhs.m_DefEnd)
+{
+
+}
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+BFFTemplate::BFFTemplate(const BFFIterator& defStart, const BFFIterator& defEnd)
+: m_DefStart(defStart)
+, m_DefEnd(defEnd)
+{
+
+}
+
+// DESTRUCTOR
+//------------------------------------------------------------------------------
+BFFTemplate::~BFFTemplate()
+{
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFTemplate.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFTemplate.h
@@ -1,0 +1,36 @@
+// BFFTemplate - Lazily evalues inner scope
+//------------------------------------------------------------------------------
+#pragma once
+#ifndef FBUILD_BFFTEMPLATE_H
+#define FBUILD_BFFTEMPLATE_H
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Core/Containers/Array.h"
+#include "BFFIterator.h"
+
+// Forward Declarations
+//------------------------------------------------------------------------------
+class AString;
+
+// BFFTemplate
+//------------------------------------------------------------------------------
+class BFFTemplate
+{
+public:
+	BFFTemplate();
+	BFFTemplate(const BFFTemplate& rhs);
+	explicit BFFTemplate(const BFFIterator& defStart, const BFFIterator& defEnd);
+	~BFFTemplate();
+
+	const BFFIterator & DefStart() const { return m_DefStart; }
+	const BFFIterator & DefEnd() const { return m_DefEnd; }
+
+private:
+	BFFIterator m_DefStart;
+	BFFIterator m_DefEnd;
+};
+
+//------------------------------------------------------------------------------
+#endif // FBUILD_BFFTEMPLATE_H
+ 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
@@ -20,7 +20,8 @@
 	"ArrayOfStrings",
 	"Int",
 	"Struct",
-	"ArrayOfStructs"
+	"ArrayOfStructs",
+	"Template"
 };
 
 // CONSTRUCTOR
@@ -60,6 +61,7 @@ BFFVariable::BFFVariable( const BFFVariable & other )
 		case VAR_INT:				SetValueInt( other.GetInt() ); break;
 		case VAR_STRUCT:			SetValueStruct( other.GetStructMembers() ); break;
 		case VAR_ARRAY_OF_STRUCTS:	SetValueArrayOfStructs( other.GetArrayOfStructs() ); break;
+		case VAR_TEMPLATE		:	SetValueTemplate( other.GetTemplate() ); break;
 		case MAX_VAR_TYPES:	ASSERT( false ); break;
 	}
 }
@@ -160,6 +162,22 @@ BFFVariable::BFFVariable( const AString & name,
 	ASSERT( type == VAR_ARRAY_OF_STRUCTS ); (void)type;
 
 	SetValueArrayOfStructs( structs );
+}
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+BFFVariable::BFFVariable( const AString & name, const BFFTemplate& tpl)
+: m_Name( name )
+, m_Type( VAR_TEMPLATE )
+, m_Frozen( false )
+//, m_StringValue() // default construct this
+, m_BoolValue( false )
+, m_ArrayValues( 0, false )
+, m_IntValue( 0 )
+, m_StructMembers( 0, false )
+, m_ArrayOfStructs( 0, false )
+, m_TemplateValue(tpl)
+{
 }
 
 // DESTRUCTOR
@@ -280,6 +298,15 @@ void BFFVariable::SetValueArrayOfStructs( const Array< const BFFVariable * > & v
 	}
 
 	m_ArrayOfStructs.Swap( newVars );
+}
+
+// SetValueTemplate
+//------------------------------------------------------------------------------
+void BFFVariable::SetValueTemplate( const BFFTemplate& tpl)
+{
+    ASSERT( false == m_Frozen );
+	m_Type = VAR_TEMPLATE;
+	m_TemplateValue = tpl;
 }
 
 // GetMemberByName

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
@@ -8,9 +8,11 @@
 //------------------------------------------------------------------------------
 #include "Core/Containers/Array.h"
 #include "Core/Strings/AString.h"
+#include "Tools/FBuild/FBuildCore/BFF/BFFTemplate.h"
 
 // Forward Declarations
 //------------------------------------------------------------------------------
+class BFFTemplate;
 
 // Helpers
 //------------------------------------------------------------------------------
@@ -38,6 +40,7 @@ public:
 	bool GetBool() const { return m_BoolValue; }
 	const Array< const BFFVariable * > & GetStructMembers() const { RETURN_CONSTIFIED_BFF_VARIABLE_ARRAY( m_StructMembers ); }
 	const Array< const BFFVariable * > & GetArrayOfStructs() const { RETURN_CONSTIFIED_BFF_VARIABLE_ARRAY( m_ArrayOfStructs ); }
+	const BFFTemplate& GetTemplate() const { return m_TemplateValue; }
 
 	enum VarType
 	{
@@ -48,6 +51,7 @@ public:
 		VAR_INT		= 4,
 		VAR_STRUCT	= 5,
 		VAR_ARRAY_OF_STRUCTS = 6,
+		VAR_TEMPLATE = 7,
 		MAX_VAR_TYPES	 // NOTE: Be sure to update s_TypeNames when adding to here
 	};
 
@@ -60,6 +64,7 @@ public:
 	inline bool IsInt() const		{ return m_Type == BFFVariable::VAR_INT; }
 	inline bool IsStruct() const	{ return m_Type == BFFVariable::VAR_STRUCT; }
 	inline bool IsArrayOfStructs() const { return m_Type == BFFVariable::VAR_ARRAY_OF_STRUCTS; }
+	inline bool IsTemplate() const { return m_Type == BFFVariable::VAR_TEMPLATE; }
 
 	inline bool Frozen() const { return m_Frozen; }
 	inline void Freeze() const { ASSERT( false == m_Frozen ); m_Frozen = true; }
@@ -79,6 +84,7 @@ private:
 	explicit BFFVariable( const AString & name, int i );
 	explicit BFFVariable( const AString & name, const Array< const BFFVariable * > & values );
 	explicit BFFVariable( const AString & name, const Array< const BFFVariable * > & structs, VarType type ); // type for disambiguation
+	explicit BFFVariable( const AString & name, const BFFTemplate& tpl);
 	~BFFVariable();
 
 	void SetValueString( const AString & value );
@@ -87,6 +93,7 @@ private:
 	void SetValueInt( int i );
 	void SetValueStruct( const Array< const BFFVariable * > & members );
 	void SetValueArrayOfStructs( const Array< const BFFVariable * > & values );
+	void SetValueTemplate( const BFFTemplate& tpl);
 
     static const BFFVariable ** GetMemberByName( const AString & name, const Array< const BFFVariable * > & members );
 
@@ -102,6 +109,7 @@ private:
 	int					m_IntValue;
 	Array< BFFVariable * > m_StructMembers;
 	Array< BFFVariable * > m_ArrayOfStructs;
+	BFFTemplate         m_TemplateValue;
 
 	static const char * s_TypeNames[ MAX_VAR_TYPES ];
 };

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.cpp
@@ -188,6 +188,11 @@ FunctionPrint::FunctionPrint()
 			FLOG_BUILD( "%s}\n", indentStr.Get() );
 			break;
 		}
+		case BFFVariable::VAR_TEMPLATE:
+		{
+			FLOG_BUILD( "%s (template)\n", var.GetName().Get());
+			break;
+		}
 		case BFFVariable::MAX_VAR_TYPES: ASSERT( false ); break; // Something is terribly wrong
 	}
 }

--- a/Code/Tools/FBuild/FBuildCore/Error.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Error.cpp
@@ -356,6 +356,21 @@
 	FormatError( iter, 1040u, nullptr, "#undef of built-in token not allowed." );
 }
 
+// Error_1041_TemplateNotFound
+//------------------------------------------------------------------------------
+void Error::Error_1041_TemplateNotFound( const BFFIterator & iter, const AString& variableName)
+{
+
+	FormatError( iter, 1040u, nullptr, "Template %s was not declared.", variableName.Get());
+}
+
+// Error_1042_VariableIsNotATemplate
+//------------------------------------------------------------------------------
+void Error::Error_1042_VariableIsNotATemplate( const BFFIterator & iter, const AString& variableName)
+{
+	FormatError( iter, 1040u, nullptr, "%s is not a template", variableName.Get());
+}
+
 // Error_1050_PropertyMustBeString
 //------------------------------------------------------------------------------
 /*static*/ void Error::Error_1050_PropertyMustBeOfType( const BFFIterator & iter,

--- a/Code/Tools/FBuild/FBuildCore/Error.h
+++ b/Code/Tools/FBuild/FBuildCore/Error.h
@@ -102,6 +102,8 @@ public:
 	static void Error_1038_OverwritingTokenInDefine( const BFFIterator & iter );
 	static void Error_1039_UnknownTokenInUndef( const BFFIterator & iter );
 	static void Error_1040_UndefOfBuiltInTokenNotAllowed( const BFFIterator & iter );
+	static void Error_1041_TemplateNotFound( const BFFIterator & iter, const AString& variableName);
+	static void Error_1042_VariableIsNotATemplate( const BFFIterator & iter, const AString& variableName);
 
 	// 1050 - 1099 : Variable type errors
 	//------------------------------------------------------------------------------


### PR DESCRIPTION
Allowing the declaration of "templates" variables with the following syntax :
<pre><code> .TemplateName =
(
 	Stuff here
)
</code></pre>
Wich can be further instanciated :
<pre><code> $TemplateName </code></pre>
This will evaluate the content of the template in a new scope. This allow config factorisation like this :
<pre><code>.Executable =
(
    ForEach( .CompileConfig in .ProjectCompileConfigs )
    {
        Using( .CompileConfig )
        Executable( '$ProjectName$-$Config$-$Platform$' )
        {
            .LinkerOutput = "Output/$Config$/$Platform$/$ProjectBinaryName$.exe"
            ; ...
        }
     }
     ; ....
)
.ProjectName = 'MyProject'
.ProjectBinaryName = 'MyBinaryName'
$Executable

.ProjectName = 'MyProject2'
.ProjectBinaryName = 'MyBinaryName2'
$Executable
</code></pre>
So very much like including files at the template's instanciation places, except using templates doesn't imply knowing their definition place, and it allow more flexible config repartition in .bff files.