### PR TITLE
add .SolutionPlatform and .SolutionConfig

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionSLN.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionSLN.cpp
@@ -163,6 +163,9 @@ struct VCXProjectNodeComp
             // start with the base configuration
             VSProjectConfig newConfig( baseConfig );
 
+			GetStringFromStruct( s, ".SolutionPlatform", newConfig.m_SolutionPlatform );
+			GetStringFromStruct( s, ".SolutionConfig", newConfig.m_SolutionConfig );
+
             // .Platform must be provided
             if ( !GetStringFromStruct( s, ".Platform",  newConfig.m_Platform ) )
             {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
@@ -67,14 +67,18 @@ const AString & SLNGenerator::GenerateSLN(  const AString & solutionFile,
         solutionConfig.m_Config = projectConfig.m_Config;
         solutionConfig.m_Platform = projectConfig.m_Platform;
 
-        if ( projectConfig.m_Platform.MatchesI( "Win32" ) )
-        {
-            solutionConfig.m_SolutionPlatform = "x86";
-        }
-        else
-        {
-            solutionConfig.m_SolutionPlatform = projectConfig.m_Platform;
-        }
+		solutionConfig.m_SolutionPlatform = !projectConfig.m_SolutionPlatform.IsEmpty()
+			? projectConfig.m_SolutionPlatform
+			: projectConfig.m_Platform;
+
+		solutionConfig.m_SolutionConfig = !projectConfig.m_SolutionConfig.IsEmpty()
+			? projectConfig.m_SolutionConfig
+			: projectConfig.m_Config;
+
+		if (solutionConfig.m_SolutionPlatform.MatchesI("Win32"))
+		{
+			solutionConfig.m_SolutionPlatform = "x86";
+		}
     }
 
     // Sort again with substituted solution platforms
@@ -298,8 +302,8 @@ void SLNGenerator::WriteSolutionConfigurationPlatforms( const Array< SolutionCon
     for( const SolutionConfig * it = solutionConfigs.Begin() ; it != end ; ++it )
     {
         Write(  "\t\t%s|%s = %s|%s\r\n",
-                it->m_Config.Get(), it->m_SolutionPlatform.Get(),
-                it->m_Config.Get(), it->m_SolutionPlatform.Get() );
+                it->m_SolutionConfig.Get(), it->m_SolutionPlatform.Get(),
+                it->m_SolutionConfig.Get(), it->m_SolutionPlatform.Get() );
     }
 
     Write( "\tEndGlobalSection\r\n" );
@@ -325,14 +329,14 @@ void SLNGenerator::WriteProjectConfigurationPlatforms(  const AString & solution
         {
             Write(  "\t\t%s.%s|%s.ActiveCfg = %s|%s\r\n",
                     it->Get(),
-                    it2->m_Config.Get(), it2->m_SolutionPlatform.Get(),
+                    it2->m_SolutionConfig.Get(), it2->m_SolutionPlatform.Get(),
                     it2->m_Config.Get(), it2->m_Platform.Get() );
 
             if ( projectIsActive )
             {
                 Write(  "\t\t%s.%s|%s.Build.0 = %s|%s\r\n",
                         it->Get(),
-                        it2->m_Config.Get(), it2->m_SolutionPlatform.Get(),
+                        it2->m_SolutionConfig.Get(), it2->m_SolutionPlatform.Get(),
                         it2->m_Config.Get(), it2->m_Platform.Get() );
             }
         }

--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.h
@@ -34,6 +34,7 @@ struct SolutionConfig
     AString m_Config;
     AString m_Platform;
     AString m_SolutionPlatform;
+	AString m_SolutionConfig;
 
     bool operator < ( const SolutionConfig& other ) const
     {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
@@ -452,6 +452,9 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
 	{
 		const VSProjectConfig & cfg = configs[ i ];
 
+		stream.Write( cfg.m_SolutionPlatform );
+		stream.Write( cfg.m_SolutionConfig );
+
 		stream.Write( cfg.m_Platform );
 		stream.Write( cfg.m_Config );
 
@@ -500,6 +503,9 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
 	{
 		VSProjectConfig & cfg = configs[ i ];
 
+		if ( stream.Read( cfg.m_SolutionPlatform ) == false ) { return false; }
+		if ( stream.Read( cfg.m_SolutionConfig ) == false ) { return false;  }
+		
 		if ( stream.Read( cfg.m_Platform ) == false ) { return false; }
 		if ( stream.Read( cfg.m_Config ) == false ) { return false; }
 

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.h
@@ -18,6 +18,8 @@ class IOStream;
 class VSProjectConfig
 {
 public:
+	AString m_SolutionPlatform;
+	AString m_SolutionConfig;
 	AString m_Platform;
 	AString m_Config;
 


### PR DESCRIPTION
I'd like to add 2 parameters to VSSolution.SolutionConfigs:

.SolutionPlatform (optional default($Platform$))
.SolutionConfig (optional  default($Config$))

Consider the following:
```
VSSolution( 'alias' )
{
	.Win64 = [
		.Platform 'Win64'
		.Config = 'Debug'
	]

	.SolutionConfigs = { .Win64 }
}
```

This will generate an error in MSBuild due to Win64 being an unkown
platform. Microsoft.Cpp.targets -> Microsoft.Cpp.InvalidPlatform.targets.

By adding two additional parameters we are able to freely name our Platform/Configurations.
This is the same behavior visual studio is offering right now. http://i.imgur.com/bmPz6Y2.png

Use case0: free naming

Possible solution.bff:
```
VSSolution( 'alias' )
{
	.Win64_Debug = [
		.SolutionPlatform = 'Win64'
		.SolutionConfig = 'Debug'
		.Platform = 'x64'
		.Config = 'Debug_Win64'
	]
	.SolutionConfigs = { .Win64_Debug }
}
```

Resulting xyz.sln:
GlobalSection(SolutionConfigurationPlatforms) = preSolution
	debug|win64 = debug|win64
	master|win64 = master|win64
	profile|win64 = profile|win64
	release|win64 = release|win64

GlobalSection(ProjectConfigurationPlatforms) = postSolution
	{F5BCAE57-6C94-4F93-BC2A-7F5284B7D434}.debug|win64.ActiveCfg = win64_debug|x64
	{F5BCAE57-6C94-4F93-BC2A-7F5284B7D434}.master|win64.ActiveCfg = win64_master|x64
	{F5BCAE57-6C94-4F93-BC2A-7F5284B7D434}.profile|win64.ActiveCfg = win64_profile|x64
	{F5BCAE57-6C94-4F93-BC2A-7F5284B7D434}.release|win64.ActiveCfg = win64_release|x64

Use case1: platform duplication with slight modification
```
.Win64_Debug = [ 
	// some configuration
] 

.Win64_Debug_DX11 = [
	Using( .Win64_Debug )
	.SolutionPlatform = 'Win64'
	.SolutionConfig = 'Debug'
	.Platform = 'x64'
	.Config = 'Win64_Debug'
	.CompilerOptions + '/DRENDER_DX11 '
]

.Win64_Debug_OpenGL = [
	Using( .Win64_Debug )
	.SolutionPlatform = 'Ogl64'
	.SolutionConfig = 'Debug'
	.Platform = 'x64'
	.Config = 'Ogl64_Debug'
	.CompilerOptions = '/DRENDER_OPEN_GL '
]
```