### PR TITLE
add -define command line to control building and saved given defines to database

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -55,7 +55,7 @@ public:
 	}
 	inline ~NodeGraphHeader() {}
 
-	enum { NODE_GRAPH_CURRENT_VERSION = 75 };
+	enum { NODE_GRAPH_CURRENT_VERSION = 76 };
 
 	bool IsValid() const
 	{


### PR DESCRIPTION
see discussion in https://github.com/fastbuild/fastbuild/issues/80
add a command line option -define
save and load the given defines to the serialized database
if there's a change (addition or omission), cause a reparsing of the .bff file, similar to what happens when an imported environment variable is changed