### PR TITLE
Check hash of BFF file if its timestamp differs from one saved in the node DB

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -33,6 +33,7 @@ public:
 			    uint32_t sizeExcludingSentinel,
 				const char * fileName,
 				uint64_t fileTimeStamp,
+				uint64_t fileDataHash,
 				bool pushStackFrame = true );
 	bool Parse( BFFIterator & iterator );
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -209,8 +209,8 @@ bool NodeGraph::Load( IOStream & stream, bool & needReparsing )
 		const uint64_t dataHash = xxHash::Calc64( mem.Get(), size );
 		if ( dataHash == m_UsedFiles[ i ].m_DataHash )
 		{
-			// set file modification time to the one saved in the DB to save time on the next run
-			FileIO::SetFileLastWriteTime( fileName, timeStamp );
+			// file didn't change, update stored timestamp to save time on the next run
+			m_UsedFiles[ i ].m_TimeStamp = timeStamp;
 			continue;
 		}
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -124,11 +124,12 @@ bool NodeGraph::Initialize( const char * bffFile,
 			FLOG_ERROR( "Error reading BFF '%s'", bffFile );
 			return false;
 		}
+		const uint64_t rootBFFDataHash = xxHash::Calc64( data.Get(), size );
 
 		// re-parse the BFF from scratch, clean build will result
 		BFFParser bffParser;
 		data.Get()[ size ] = '\0'; // data passed to parser must be NULL terminated
-		return bffParser.Parse( data.Get(), size, bffFile, rootBFFTimeStamp ); // pass size excluding sentinel
+		return bffParser.Parse( data.Get(), size, bffFile, rootBFFTimeStamp, rootBFFDataHash ); // pass size excluding sentinel
 	}
 
 	return true;
@@ -187,12 +188,35 @@ bool NodeGraph::Load( IOStream & stream, bool & needReparsing )
 	{
 		const AString & fileName = m_UsedFiles[ i ].m_FileName;
 		const uint64_t timeStamp = FileIO::GetFileLastWriteTime( fileName );
-		if ( timeStamp != m_UsedFiles[ i ].m_TimeStamp )
+		if ( timeStamp == m_UsedFiles[ i ].m_TimeStamp )
+			continue; // timestamps match, no need to check hashes
+
+		FileStream fs;
+		if ( fs.Open( fileName.Get(), FileStream::READ_ONLY ) == false )	
 		{
-			FLOG_WARN( "BFF file '%s' has changed (reparsing will occur).", fileName.Get() );
+			FLOG_INFO( "BFF file '%s' missing or unopenable (clean build will result).", fileName.Get() );
 			needReparsing = true;
-			return true;
+			return true; // not opening the file is not an error, it could be not needed anymore
 		}
+
+		const size_t size = (size_t)fs.GetFileSize();
+		AutoPtr< void > mem( ALLOC( size ) );
+		if ( fs.Read( mem.Get(), size ) != size )
+		{
+			return false; // error reading
+		}
+
+		const uint64_t dataHash = xxHash::Calc64( mem.Get(), size );
+		if ( dataHash == m_UsedFiles[ i ].m_DataHash )
+		{
+			// set file modification time to the one saved in the DB to save time on the next run
+			FileIO::SetFileLastWriteTime( fileName, timeStamp );
+			continue;
+		}
+
+		FLOG_WARN( "BFF file '%s' has changed (reparsing will occur).", fileName.Get() );
+		needReparsing = true;
+		return true;
 	}
 
 	// TODO:C The serialization of these settings doesn't really belong here (not part of node graph)
@@ -391,6 +415,8 @@ void NodeGraph::Save( IOStream & stream ) const
 		stream.Write( fileName.Get(), fileNameLen );
 		uint64_t timeStamp( m_UsedFiles[ i ].m_TimeStamp );
 		stream.Write( timeStamp );
+		uint64_t dataHash( m_UsedFiles[ i ].m_DataHash );
+		stream.Write( dataHash );
 	}
 
 	// TODO:C The serialization of these settings doesn't really belong here (not part of node graph)
@@ -1402,7 +1428,7 @@ void NodeGraph::DoBuildPass( Node * nodeToBuild )
 
 // AddUsedFile
 //------------------------------------------------------------------------------
-void NodeGraph::AddUsedFile( const AString & fileName, uint64_t timeStamp )
+void NodeGraph::AddUsedFile( const AString & fileName, uint64_t timeStamp, uint64_t dataHash )
 {
 	const size_t numFiles = m_UsedFiles.GetSize();
 	for ( size_t i=0 ;i<numFiles; ++i )
@@ -1413,7 +1439,7 @@ void NodeGraph::AddUsedFile( const AString & fileName, uint64_t timeStamp )
 			return;
 		}
 	}
-	m_UsedFiles.Append( UsedFile( fileName, timeStamp ) );
+	m_UsedFiles.Append( UsedFile( fileName, timeStamp, dataHash ) );
 }
 
 // IsOneUseFile
@@ -1669,8 +1695,13 @@ bool NodeGraph::ReadHeaderAndUsedFiles( IOStream & nodeGraphStream, Array< UsedF
 		{
 			return false;
 		}
+		uint64_t dataHash;
+		if ( !nodeGraphStream.Read( dataHash ) )
+		{
+			return false;
+		}
 
-		files.Append( UsedFile( fileName, timeStamp ) );
+		files.Append( UsedFile( fileName, timeStamp, dataHash ) );
 	}
 
 	return true;

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -55,7 +55,7 @@ public:
 	}
 	inline ~NodeGraphHeader() {}
 
-	enum { NODE_GRAPH_CURRENT_VERSION = 75 };
+	enum { NODE_GRAPH_CURRENT_VERSION = 76 };
 
 	bool IsValid() const
 	{
@@ -232,7 +232,7 @@ public:
 	static void CleanPath( const AString & name, AString & fullPath );
 
 	// as BFF files are encountered during parsing, we track them
-	void AddUsedFile( const AString & fileName, uint64_t timeStamp );
+	void AddUsedFile( const AString & fileName, uint64_t timeStamp, uint64_t dataHash );
 	bool IsOneUseFile( const AString & fileName ) const;
 	void SetCurrentFileAsOneUse();
 
@@ -287,9 +287,10 @@ private:
 	// each file used in the generation of the node graph is tracked
 	struct UsedFile
 	{
-		explicit UsedFile( const AString & fileName, uint64_t timeStamp ) : m_FileName( fileName ), m_TimeStamp( timeStamp ), m_Once( false ) {}
+		explicit UsedFile( const AString & fileName, uint64_t timeStamp, uint64_t dataHash ) : m_FileName( fileName ), m_TimeStamp( timeStamp ), m_DataHash(dataHash) , m_Once( false ) {}
 		AString		m_FileName;
 		uint64_t	m_TimeStamp;
+		uint64_t	m_DataHash;
 		bool		m_Once;
 	};
 	Array< UsedFile > m_UsedFiles;

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestBFFParsing.cpp
@@ -86,7 +86,7 @@ void TestBFFParsing::Empty() const
 	// an empty file should pass without problem
 	char buffer[ 1 ] = { '\000' }; // post data sentinel
 	BFFParser p;
-	TEST_ASSERT( p.Parse( buffer, 0, "empty.bff", 0 ) );
+	TEST_ASSERT( p.Parse( buffer, 0, "empty.bff", 0, 0 ) );
 }
 
 // AlmostEmpty
@@ -96,7 +96,7 @@ void TestBFFParsing::AlmostEmpty() const
 	// an empty file should pass without problem
 	const char * buffer = "\r\n\000"; // empty line + post data sentinel
 	BFFParser p;
-	TEST_ASSERT( p.Parse( buffer, 2, "empty.bff", 0 ) );
+	TEST_ASSERT( p.Parse( buffer, 2, "empty.bff", 0, 0 ) );
 }
 
 // Comments
@@ -196,7 +196,7 @@ void TestBFFParsing::Parse( const char * fileName, bool expectFailure ) const
 
 	FBuild fBuild;
 	BFFParser p;
-	bool parseResult = p.Parse( mem.Get(), fileSize, fileName, 0 );
+	bool parseResult = p.Parse( mem.Get(), fileSize, fileName, 0, 0 );
 	if ( expectFailure )
 	{
 		TEST_ASSERT( parseResult == false ); // Make sure it failed as expected

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCompiler.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCompiler.cpp
@@ -76,7 +76,7 @@ void TestCompiler::Parse( const char * fileName, bool expectFailure ) const
 
 	FBuild fBuild;
 	BFFParser p;
-	bool parseResult = p.Parse( mem.Get(), fileSize, fileName, 0 );
+	bool parseResult = p.Parse( mem.Get(), fileSize, fileName, 0, 0 );
 	if ( expectFailure )
 	{
 		TEST_ASSERT( parseResult == false ); // Make sure it failed as expected


### PR DESCRIPTION
This commit adds hash-based check in addition to time stamp check to determine if .bff is actually changed before deciding that re-parsing is needed. It should prevent unnecessary rebuilds caused by saving .bff without changing it or by git modifying file time stamp when switching branches back and forth, etc.
This should help mitigate "FASTbuild wants to rebuild everything" situations while re-factoring (mentioned in #55) that should bring more fine grained rebuilding rules is under way.