### PR TITLE
Uniquify database using root bff filename

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -430,7 +430,7 @@ int Main(int argc, char * argv[])
 	}
 
 	// load the dependency graph if available
-	if ( !fBuild.Initialize( FBuild::GetDependencyGraphFileName() ) )
+	if ( !fBuild.Initialize() )
 	{
 		if ( sharedData )
 		{

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -141,7 +141,16 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
 
 	const char * bffFile = m_Options.m_ConfigFile.IsEmpty() ? GetDefaultBFFFileName()
 														    : m_Options.m_ConfigFile.Get();
-	if ( m_DependencyGraph->Initialize( bffFile, nodeGraphDBFile ) == false )
+    if ( nodeGraphDBFile != nullptr )
+    {
+        m_DependencyGraphFile = nodeGraphDBFile;
+    }
+    else
+    {
+        m_DependencyGraphFile.Format("%s.fdb", bffFile);
+    }
+
+	if ( m_DependencyGraph->Initialize( bffFile, m_DependencyGraphFile.Get() ) == false )
 	{
 		return false;
 	}
@@ -270,9 +279,9 @@ bool FBuild::Build( const Array< AString > & targets )
 //------------------------------------------------------------------------------
 bool FBuild::SaveDependencyGraph( const char * nodeGraphDBFile ) const
 {
-    PROFILE_FUNCTION
+    ASSERT( nodeGraphDBFile != nullptr );
 
-	nodeGraphDBFile = nodeGraphDBFile ? nodeGraphDBFile : GetDependencyGraphFileName();
+    PROFILE_FUNCTION
 
 	FLOG_INFO( "Saving DepGraph '%s'", nodeGraphDBFile );
 
@@ -417,7 +426,7 @@ bool FBuild::Build( Node * nodeToBuild )
 	// - it will record the items that did build, so they won't build again
 	if ( m_Options.m_SaveDBOnCompletion )
 	{
-		SaveDependencyGraph();
+		SaveDependencyGraph(m_DependencyGraphFile.Get());
 	}
 
 	// TODO:C Move this into BuildStats
@@ -566,13 +575,6 @@ void FBuild::UpdateBuildStatus( const Node * node )
 
 	FLog::OutputProgress( timeNow, m_SmoothedProgressCurrent, numJobs, numJobsActive, numJobsDist, numJobsDistActive );
 	m_LastProgressOutputTime = timeNow;
-}
-
-// GetDependencyGraphFileName
-//------------------------------------------------------------------------------
-/*static*/ const char * FBuild::GetDependencyGraphFileName()
-{
-	return "fbuild.fdb";
 }
 
 // GetDefaultBFFFileName

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -141,14 +141,14 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
 
 	const char * bffFile = m_Options.m_ConfigFile.IsEmpty() ? GetDefaultBFFFileName()
 														    : m_Options.m_ConfigFile.Get();
-    if ( nodeGraphDBFile != nullptr )
-    {
-        m_DependencyGraphFile = nodeGraphDBFile;
-    }
-    else
-    {
-        m_DependencyGraphFile.Format("%s.fdb", bffFile);
-    }
+	if ( nodeGraphDBFile != nullptr )
+	{
+		m_DependencyGraphFile = nodeGraphDBFile;
+	}
+	else
+	{
+		m_DependencyGraphFile.Format("%s.fdb", bffFile);
+	}
 
 	if ( m_DependencyGraph->Initialize( bffFile, m_DependencyGraphFile.Get() ) == false )
 	{
@@ -279,9 +279,9 @@ bool FBuild::Build( const Array< AString > & targets )
 //------------------------------------------------------------------------------
 bool FBuild::SaveDependencyGraph( const char * nodeGraphDBFile ) const
 {
-    ASSERT( nodeGraphDBFile != nullptr );
+	ASSERT( nodeGraphDBFile != nullptr );
 
-    PROFILE_FUNCTION
+	PROFILE_FUNCTION
 
 	FLOG_INFO( "Saving DepGraph '%s'", nodeGraphDBFile );
 

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -113,7 +113,7 @@ private:
 	JobQueue * m_JobQueue;
 	Client * m_Client; // manage connections to worker servers
 
-    AString m_DependencyGraphFile;
+	AString m_DependencyGraphFile;
 	AString m_CachePluginDLL;
 	AString m_CachePath;
 	ICache * m_Cache;
@@ -133,7 +133,7 @@ private:
 	Array< AString > m_WorkerList;
 
 	AString m_OldWorkingDir;
-    
+
 	// a double-null terminated string
 	char *		m_EnvironmentString;
 	uint32_t	m_EnvironmentStringSize; // size excluding last null

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -44,14 +44,13 @@ public:
 	bool Build( Node * nodeToBuild );
 
 	// after a build we can store progress/parsed rules for next time
-	bool SaveDependencyGraph( const char * nodeGraphDBFile = nullptr ) const;
+	bool SaveDependencyGraph( const char * nodeGraphDBFile ) const;
 
 	const FBuildOptions & GetOptions() const { return m_Options; }
 	NodeGraph & GetDependencyGraph() const { return *m_DependencyGraph; }
 	
 	const AString & GetWorkingDir() const { return m_Options.GetWorkingDir(); }
 
-	static const char * GetDependencyGraphFileName();
 	static const char * GetDefaultBFFFileName();
 
 	const AString & GetCachePath() const { return m_CachePath; }
@@ -114,6 +113,7 @@ private:
 	JobQueue * m_JobQueue;
 	Client * m_Client; // manage connections to worker servers
 
+    AString m_DependencyGraphFile;
 	AString m_CachePluginDLL;
 	AString m_CachePath;
 	ICache * m_Cache;
@@ -133,7 +133,7 @@ private:
 	Array< AString > m_WorkerList;
 
 	AString m_OldWorkingDir;
-
+    
 	// a double-null terminated string
 	char *		m_EnvironmentString;
 	uint32_t	m_EnvironmentStringSize; // size excluding last null

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -88,7 +88,7 @@ bool NodeGraph::Initialize( const char * bffFile,
     PROFILE_FUNCTION
 
 	ASSERT( bffFile ); // must be supplied (or left as default)
-    ASSERT( nodeGraphDBFile ); // must be supplied (or left as default)
+	ASSERT( nodeGraphDBFile ); // must be supplied (or left as default)
 
 	ASSERT( m_UsedFiles.IsEmpty() ); // NodeGraph cannot be recycled
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -88,6 +88,7 @@ bool NodeGraph::Initialize( const char * bffFile,
     PROFILE_FUNCTION
 
 	ASSERT( bffFile ); // must be supplied (or left as default)
+    ASSERT( nodeGraphDBFile ); // must be supplied (or left as default)
 
 	ASSERT( m_UsedFiles.IsEmpty() ); // NodeGraph cannot be recycled
 


### PR DESCRIPTION
Instead of invalidating the cache when building using different bff file I enforce one fdb by bff by adding .fdb to the bff file.
Since flushing the fdb file would not be necessary, It would be more efficient this way and it covers our prod use cases.

Tested on Rainbow6 with the following scenario:
 * folder containing fbuild.vs2012.bff & fbuild.vs2015.bff
 * switching between the two files and making sure that the fdb file gets properly created and updated
 * checking that file time-stamp comparison on the list of files on the fdb is still working

Unfortunately I could not run the FBuiltTests since I hacked very minimally the FBuild root bff to get a non dist build work with VS2012.