### PR TITLE
Revert "Uniquify database using root bff filename"

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -430,7 +430,7 @@ int Main(int argc, char * argv[])
 	}
 
 	// load the dependency graph if available
-	if ( !fBuild.Initialize() )
+	if ( !fBuild.Initialize( FBuild::GetDependencyGraphFileName() ) )
 	{
 		if ( sharedData )
 		{

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -141,16 +141,7 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
 
 	const char * bffFile = m_Options.m_ConfigFile.IsEmpty() ? GetDefaultBFFFileName()
 														    : m_Options.m_ConfigFile.Get();
-	if ( nodeGraphDBFile != nullptr )
-	{
-		m_DependencyGraphFile = nodeGraphDBFile;
-	}
-	else
-	{
-		m_DependencyGraphFile.Format("%s.fdb", bffFile);
-	}
-
-	if ( m_DependencyGraph->Initialize( bffFile, m_DependencyGraphFile.Get() ) == false )
+	if ( m_DependencyGraph->Initialize( bffFile, nodeGraphDBFile ) == false )
 	{
 		return false;
 	}
@@ -279,9 +270,9 @@ bool FBuild::Build( const Array< AString > & targets )
 //------------------------------------------------------------------------------
 bool FBuild::SaveDependencyGraph( const char * nodeGraphDBFile ) const
 {
-	ASSERT( nodeGraphDBFile != nullptr );
+    PROFILE_FUNCTION
 
-	PROFILE_FUNCTION
+	nodeGraphDBFile = nodeGraphDBFile ? nodeGraphDBFile : GetDependencyGraphFileName();
 
 	FLOG_INFO( "Saving DepGraph '%s'", nodeGraphDBFile );
 
@@ -426,7 +417,7 @@ bool FBuild::Build( Node * nodeToBuild )
 	// - it will record the items that did build, so they won't build again
 	if ( m_Options.m_SaveDBOnCompletion )
 	{
-		SaveDependencyGraph(m_DependencyGraphFile.Get());
+		SaveDependencyGraph();
 	}
 
 	// TODO:C Move this into BuildStats
@@ -575,6 +566,13 @@ void FBuild::UpdateBuildStatus( const Node * node )
 
 	FLog::OutputProgress( timeNow, m_SmoothedProgressCurrent, numJobs, numJobsActive, numJobsDist, numJobsDistActive );
 	m_LastProgressOutputTime = timeNow;
+}
+
+// GetDependencyGraphFileName
+//------------------------------------------------------------------------------
+/*static*/ const char * FBuild::GetDependencyGraphFileName()
+{
+	return "fbuild.fdb";
 }
 
 // GetDefaultBFFFileName

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -44,13 +44,14 @@ public:
 	bool Build( Node * nodeToBuild );
 
 	// after a build we can store progress/parsed rules for next time
-	bool SaveDependencyGraph( const char * nodeGraphDBFile ) const;
+	bool SaveDependencyGraph( const char * nodeGraphDBFile = nullptr ) const;
 
 	const FBuildOptions & GetOptions() const { return m_Options; }
 	NodeGraph & GetDependencyGraph() const { return *m_DependencyGraph; }
 	
 	const AString & GetWorkingDir() const { return m_Options.GetWorkingDir(); }
 
+	static const char * GetDependencyGraphFileName();
 	static const char * GetDefaultBFFFileName();
 
 	const AString & GetCachePath() const { return m_CachePath; }
@@ -113,7 +114,6 @@ private:
 	JobQueue * m_JobQueue;
 	Client * m_Client; // manage connections to worker servers
 
-	AString m_DependencyGraphFile;
 	AString m_CachePluginDLL;
 	AString m_CachePath;
 	ICache * m_Cache;

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -88,7 +88,6 @@ bool NodeGraph::Initialize( const char * bffFile,
     PROFILE_FUNCTION
 
 	ASSERT( bffFile ); // must be supplied (or left as default)
-	ASSERT( nodeGraphDBFile ); // must be supplied (or left as default)
 
 	ASSERT( m_UsedFiles.IsEmpty() ); // NodeGraph cannot be recycled
 


### PR DESCRIPTION
Reverts fastbuild/fastbuild#96

This change introduces a stack corruption in the unit tests which needs investigating.