### PR TITLE
Allow concatenation/assigning of empty arrays to other arrays

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/arrays.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/arrays.bff
@@ -60,3 +60,77 @@
 // Concat to empty array
 .AnotherEmptyArray = {} // should default to array of strings
 .AnotherEmptyArray + "string"
+
+// Operations with ArrayOfStrings and empty arrays
+{
+	.X = "str"
+	.Array = { .X }
+
+	// concatentation to empty array
+	.T1 = {} + .X
+	.T2 = {} + { .X }
+	.T3 = {} + .Array
+	.T4 = {} + { .Array }
+
+	// concatentation of empty array
+	.T5 = .Array + .EmptyArray
+
+	// concatentation of inplace empty array
+	.T6 = .Array + {}
+
+	// concatentation of empty array wrapped in inplace array
+	.T7 = .Array + { .EmptyArray }
+
+	// assignment to empty array
+	.T8 = {}
+	.T8 = .Array
+
+	// assignment of empty array to non-empty
+	.T9 = .Array
+	.T9 = .EmptyArray
+
+	// assignment of inplace empty array to non-empty
+	.T10 = .Array
+	.T10 = {}
+
+	// assignment of empty array wrapped in inplace array to non-empty
+	.T11 = .Array
+	.T11 = { .EmptyArray }
+}
+
+// Operations with ArrayOfStructs and empty arrays
+{
+	.X = [ .Y = 42 ]
+	.Array = { .X }
+
+	// concatentation to empty array
+	.T1 = {} + .X
+	.T2 = {} + { .X }
+	.T3 = {} + .Array
+	.T4 = {} + { .Array }
+
+	// concatentation of empty array
+	.T5 = .Array + .EmptyArray
+
+	// concatentation of inplace empty array
+	.T6 = .Array + {}
+
+	// concatentation of empty array wrapped in inplace array
+	.T7 = .Array + { .EmptyArray }
+
+	// assignment to empty array
+	.T8 = {}
+	.T8 = .Array
+
+	// assignment of empty array to non-empty
+	.T9 = .Array
+	.T9 = .EmptyArray
+
+	// assignment of inplace empty array to non-empty
+	.T10 = .Array
+	.T10 = {}
+
+	// assignment of empty array wrapped in inplace array to non-empty
+	.T11 = .Array
+	.T11 = { .EmptyArray }
+}


### PR DESCRIPTION
Following statements are valid when .X is a string but not when it's a
struct:
```
.E = {}
.A = { .X }
.T1 = {} + .X
.T2 = {} + { .X }
.T3 = {} + .A
.T4 = {} + { .A }
.T5 = { .X } + {}
.T6 = { .X } + .E
.T7 = { .X } + { .E }
```
This is a side effect of empty arrays being stored as ArrayOfStrings.

This change allows treatment of empty ArrayOfStrings as empty
ArrayOfStructs and vice versa, making those statements valid when .X is
a struct as well.