### PR TITLE
Add missing header for memset

### DIFF
--- a/Code/Core/Network/Network.cpp
+++ b/Code/Core/Network/Network.cpp
@@ -21,6 +21,7 @@
 #if defined( __LINUX__ ) || defined( __APPLE__ )
     #include <arpa/inet.h>
     #include <netdb.h>
+    #include <string.h>
     #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Right now "non-unity" build (all files are writeable and `.UnityInputIsolateWritableFiles = true`) is broken at least on Linux:
```
$ fbuild Core-x64Linux-Debug 
1> Obj: /home/dummyunit/fastbuild/tmp/x64Linux-Debug/Core/Network/Network.o
1> WARNING: /home/dummyunit/fastbuild/tmp/x64Linux-Debug/Core/Network/Network.o
/home/dummyunit/fastbuild/Code/Core/Network/Network.cpp: In static member function 'static uint32_t Network::NameResolutionThreadFunc(void*)':
/home/dummyunit/fastbuild/Code/Core/Network/Network.cpp:151:37: error: 'memset' was not declared in this scope
    memset( &hints, 0, sizeof(hints) );
                                     ^
compilation terminated due to -Wfatal-errors.
```
This fixes it by adding required header.