### PR TITLE
Improve variable handling logic

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
@@ -209,6 +209,35 @@ bool BFFIterator::ParseToMatchingBrace( char openBrace, char closeBrace )
 	return false;
 }
 
+// ParseExactString
+//------------------------------------------------------------------------------
+bool BFFIterator::ParseExactString( const char * string )
+{
+	const char * const originalPos = m_Pos;
+
+	const char * stringPos = string; // stores pointer to the next character to be checked for presence in our sequence
+	while ( !IsAtEnd() && *stringPos != '\000' )
+	{
+		if ( *m_Pos != *stringPos )
+			break;
+		m_Pos++;
+		stringPos++;
+	}
+
+	if ( *stringPos == '\000' )
+	{
+		// we are at the end of string, that means all characters have successfuly matched
+		return true;
+	}
+	else
+	{
+		// we are not at the end of string, that means either our sequence ended, or there is non matching character
+		// restore our pos before returning
+		m_Pos = originalPos;
+		return false;
+	}
+}
+
 // IsAtValidVariableNameCharacter
 //------------------------------------------------------------------------------
 bool BFFIterator::IsAtValidVariableNameCharacter() const

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.h
@@ -35,6 +35,7 @@ public:
 	void operator = ( const BFFIterator & iter );
 
 	void operator ++ (int) { ASSERT( m_Pos < m_MaxPos ); m_Pos++; }
+	void operator -- (int) { ASSERT( m_Pos > m_MinPos ); m_Pos--; }
 	inline bool operator < ( const BFFIterator & other ) const { return ( m_Pos < other.m_Pos ); }
 	inline bool operator > ( const BFFIterator & other ) const { return ( m_Pos > other.m_Pos ); }
 	char operator *() const { return *m_Pos; }

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.h
@@ -48,6 +48,7 @@ public:
 	void SkipDirectiveName();
 	bool ParseToNext( char c );
 	bool ParseToMatchingBrace( char openBrace, char closeBrace );
+	bool ParseExactString( const char * string );
 
 	inline size_t GetDistTo( const BFFIterator & other ) const { ASSERT( other.m_Pos >= m_Pos ); return (size_t)( other.m_Pos - m_Pos ); }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1440,7 +1440,8 @@ bool BFFParser::StoreVariableStruct( const AString & name,
 									 BFFStackFrame * frame )
 {
 	// are we concatenating?
-	if ( *operatorIter == BFF_VARIABLE_CONCATENATION )
+	if ( ( *operatorIter == BFF_VARIABLE_CONCATENATION ) ||
+		 ( *operatorIter == BFF_VARIABLE_SUBTRACTION ) )
 	{
 		// concatenation of structs not supported
 		Error::Error_1027_CannotModify( operatorIter, name, BFFVariable::VAR_STRUCT, BFFVariable::VAR_ANY );

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1655,7 +1655,7 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
 	{
 		// Matching Src and Dst
 
-		if ( srcType == BFFVariable::VAR_STRING && !subtract )
+		if ( srcType == BFFVariable::VAR_STRING )
 		{
 			if ( concat )
 			{
@@ -1663,6 +1663,17 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
 				finalValue += varSrc->GetString();
 				BFFStackFrame::SetVarString( dstName, finalValue, dstFrame );
 				FLOG_INFO( "Appending '%s' (value of %s) to <String> variable '%s' with result '%s'",
+							varSrc->GetString().Get(),
+							srcName.Get(),
+							dstName.Get(),
+							finalValue.Get() );
+			}
+			else if ( subtract )
+			{
+				AStackString< 2048 > finalValue(varDst->GetString());
+				finalValue.Replace( varSrc->GetString().Get(), "" );
+				BFFStackFrame::SetVarString( dstName, finalValue, dstFrame );
+				FLOG_INFO( "Removing '%s' (value of %s) from <String> variable '%s' with result '%s'",
 							varSrc->GetString().Get(),
 							srcName.Get(),
 							dstName.Get(),

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1455,6 +1455,9 @@ bool BFFParser::StoreVariableStruct( const AString & name,
 									 const BFFIterator & operatorIter,
 									 BFFStackFrame * frame )
 {
+	// find existing
+	const BFFVariable * var = BFFStackFrame::GetVar( name, frame );
+
 	// are we concatenating?
 	if ( ( *operatorIter == BFF_VARIABLE_CONCATENATION ) ||
 		 ( *operatorIter == BFF_VARIABLE_SUBTRACTION ) )
@@ -1462,6 +1465,15 @@ bool BFFParser::StoreVariableStruct( const AString & name,
 		// concatenation of structs not supported
 		Error::Error_1027_CannotModify( operatorIter, name, BFFVariable::VAR_STRUCT, BFFVariable::VAR_ANY );
 		return false;
+	}
+	else
+	{
+		// variable must be new or a struct
+		if (! ( var == nullptr || var->IsStruct() ) )
+		{
+			Error::Error_1034_OperationNotSupported( valueStart, var->GetType(), BFFVariable::VAR_STRUCT, operatorIter );
+			return false;
+		}
 	}
 
 	// create stack frame to capture variables

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/integers.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/integers.bff
@@ -9,6 +9,18 @@
 4
 .IntE                =                          5
 
+; addition
+.IntF = 2 + 4 ; ==6
+.IntG = .IntA + 6 ; ==7
+.IntH = 5 + .IntC ; ==8
+.IntI = .IntD + .IntE ; ==9
+
+; subtraction
+.IntJ = 1 - 2 ; ==-1
+.IntK = .IntD - 6; ==-2
+.IntL = 4 - .IntG; ==-3
+.IntM = .IntA - .IntE; ==-4
+
 ; big int
 .IntBig = 1234567890
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/operator_minus.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/operator_minus.bff
@@ -38,3 +38,8 @@ Print( .String ) // Should print 'Good '
 .Strings = { 'Good', 'BAD', 'Good' }
 		 - 'BAD'
 Print( .Strings ) // Should print { 'Good', 'Good' }
+
+// Remove from Array of Strings using variable
+.Strings = { 'Good', 'BAD', 'Good' }
+		 - .BAD
+Print( .Strings ) // Should print { 'Good', 'Good' }

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/operator_minus.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/operator_minus.bff
@@ -2,14 +2,26 @@
 // Operator -
 //
 
+.BAD = 'BAD'
+
 // Substring removal
 .String = "Good BAD Good"
 .String - 'BAD'
 Print( .String ) // Should print 'Good  Good'
 
+// Substring removal using variable
+.String = "Good BAD Good"
+.String - .BAD
+Print( .String ) // Should print 'Good  Good'
+
 // Multiple Removals
 .String = "Good BAD Good BAD BAD Good"
 .String - 'BAD'
+Print( .String ) // Should print 'Good  Good   Good'
+
+// Multiple Removals using variable
+.String = "Good BAD Good BAD BAD Good"
+.String - .BAD
 Print( .String ) // Should print 'Good  Good   Good'
 
 // Remove not found

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/parent_scope.bff
@@ -72,7 +72,7 @@
 
 ; struct with parent scope
 
-.var = 12
+.var = 'first definition'
 .struct =
 [
     .value = ^var


### PR DESCRIPTION
This series of commits bans most ways for a variable to change its type, which were discovered in #113, by adding checks that ensure that variable to be modified has same or compatible type.

It also fixes some others bugs/inconsistencies discovered along the way:
   - Subtraction operator wasn't handled properly in many cases. In operations where right operand was variable or explicit structure it worked like assignment. With this changes:
      1. Subtractions of structs are banned.
      2. Subtractions like `.String1 - .String2` work like `.String1 - "explicit string"`, removing occurrences of `.String2` from `.String1`.
      3. Subtractions like `.ArrayOfStrings - .String` work like `.ArrayOfStrings - "explicit string"`, removing elements that are equal to `.String` from `.ArrayOfStrings`.
      4. Added subtractions for integers (that was easier than adding error message :) ).
      5. Other subtractions are banned (bool and arrays).
   - Integer addition only worked when right operand was a variable. With this changes it will work with explicit values as well.

I have also changed bool value parsing to be more clear and not use cryptic constructions like `iter.ParseToNext( 'e' )`.

I must also mention that with these fixes code structured like that (which probably used by many people) now produces an error:
```
$ cat test.bff 
.EnabledX = { "Foo" "Bar" }
.Array = {}
ForEach( .X in .EnabledX )
{
        .Struct =
        [
                .A = .X
                .B = "-option $X$"
        ]
        ^Array + { .Struct }
}
$ fbuild -verbose -config test.bff
Registered <ArrayOfStrings> variable '.EnabledX' with 2 elements
Registered <ArrayOfStrings> variable '.Array' with 0 elements
Function call 'ForEach'
Freezing loop array '.EnabledX' of type <ArrayOfStrings>
Registered <string> variable '.A' with value 'Foo'
Registered <string> variable '.B' with value '-option Foo'
Registered <struct> variable '.Struct' with 2 members
/home/dummyunit/fastbuild/Code/test.bff(10,13): FASTBuild Error #1034 - Operation not supported: 'ArrayOfStrings' + 'Struct'.
        ^Array + { .Struct }
                   ^
                   \--here
```
So, if this will be merged, something must done to support empty arrays — either updated version of #110 or different internal type for fresh empty arrays (like I described in comment 3 in #110), or something else.