### PR TITLE
Increase maximum variable length

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.h
@@ -54,7 +54,7 @@ public:
 	enum { BFF_STRUCT_CLOSE = ']' };
 	enum { BFF_PREPROCESSOR_START = '#' };
 
-	enum { MAX_VARIABLE_NAME_LENGTH = 64 };
+	enum { MAX_VARIABLE_NAME_LENGTH = 256 };
 	enum { MAX_FUNCTION_NAME_LENGTH = 64 };
 	enum { MAX_DIRECTIVE_NAME_LENGTH = 64 };
 


### PR DESCRIPTION
From 64 to 256.
The limit on MSVC/ICC in 2048, and GCC has no limit.

I hit this problem with generated variable names and had to rise the limit.