### PR TITLE
integers and booleans can be formated into strings

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1739,12 +1739,25 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
 					Error::Error_1009_UnknownVariable( startName, nullptr );
 					return false; 
 				}
-				if ( var->IsString() == false )
+				if ( var->IsBool() == true )
+				{
+					output += ( ( var->GetBool() ) ? "true" : "false" );
+				}
+				else if ( var->IsInt() == true )
+				{
+					AStackString<> str;
+					str.Format( "%i", var->GetInt() );
+					output += str;
+				}
+				else if ( var->IsString() == true )
+				{
+					output += var->GetString();
+				}
+				else
 				{
 					Error::Error_1029_VariableForSubstitutionIsNotAString( startName, varName, var->GetType() );
-					return false; 
+					return false;
 				}
-				output += var->GetString();
 				break;
 			}
 			default:


### PR DESCRIPTION
ex:
````
.int = 42
Print( 'format int = $int$' )
=> 'format int = 43'
````
````
.bool = false
Print( 'format int = $bool$' )
=> 'format int = false'
````