### PR TITLE
Add Exclude Patterns to ObjectList-Based Functions

### DIFF
--- a/Code/TestFramework/UnitTestManager.cpp
+++ b/Code/TestFramework/UnitTestManager.cpp
@@ -130,6 +130,7 @@ bool UnitTestManager::RunTests( const char * testGroup )
 		catch (...)
 		{
 			OUTPUT( " - Test '%s' *** FAILED ***\n", s_TestInfos[ s_NumTests - 1 ].m_TestName );
+			s_TestInfos[ s_NumTests - 1 ].m_TestGroup->PostTest();
 		}
 		test = test->m_NextTestGroup;
 	}

--- a/Code/Tools/FBuild/Documentation/docs/functions/csassembly.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/csassembly.html
@@ -27,6 +27,7 @@ Builds one or more files (typically .cs files) into an assembly (a dll or execut
   .CompilerInputPattern         ; (optional) Pattern(s) of input files (default *.cs)
   .CompilerInputExcludePath     ; (optional) Path(s) to exclude from compilation
   .CompilerInputExcludedFiles   ; (optional) File(s) to exclude from compilation (partial, root-relative of full path)
+  .CompilerInputExcludePattern  ; (optional) Pattern(s) to exclude from compilation
   .CompilerReferences           ; (optional) References for the assembly
 
   ; Additional options

--- a/Code/Tools/FBuild/Documentation/docs/functions/library.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/library.html
@@ -34,14 +34,15 @@ Builds a statically linked library.
   .LibrarianAdditionalInputs; (optional) Additional inputs to merge into library
 
   ; Specify inputs for compilation
-  .CompilerInputPath        ; (optional) Path to find files in
-  .CompilerInputPattern     ; (optional) Pattern(s) to use when finding files (default *.cpp)
-  .CompilerInputPathRecurse ; (optional) Recurse into dirs when finding files (default true)
-  .CompilerInputExcludePath ; (optional) Path(s) to exclude from compilation
-  .CompilerInputExcludedFiles;(optional) File(s) to exclude from compilation (partial, root-relative of full path)
-  .CompilerInputFiles       ; (optional) Explicit array of files to build
-  .CompilerInputFilesRoot   ; (optional) Root path to use for .obj path generation for explicitly listed files  
-  .CompilerInputUnity       ; (optional) Unity to build (or Unities)
+  .CompilerInputPath           ; (optional) Path to find files in
+  .CompilerInputPattern        ; (optional) Pattern(s) to use when finding files (default *.cpp)
+  .CompilerInputPathRecurse    ; (optional) Recurse into dirs when finding files (default true)
+  .CompilerInputExcludePath    ; (optional) Path(s) to exclude from compilation
+  .CompilerInputExcludedFiles  ; (optional) File(s) to exclude from compilation (partial, root-relative of full path)
+  .CompilerInputExcludePattern ; (optional) Pattern(s) to exclude from compilation
+  .CompilerInputFiles          ; (optional) Explicit array of files to build
+  .CompilerInputFilesRoot      ; (optional) Root path to use for .obj path generation for explicitly listed files
+  .CompilerInputUnity          ; (optional) Unity to build (or Unities)
 
   ; Cache & Distributed compilation control
   .AllowCaching             ; (optional) Allow caching of compiled objects if available (default true)

--- a/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
@@ -28,14 +28,15 @@ Builds a list of objects, typically for later input into a Library, Executable o
   .CompilerOutputPrefix     ; (optional) Specify a prefix for generated objects (default none)
 
   ; Specify inputs for compilation
-  .CompilerInputPath        ; (optional) Path to find files in
-  .CompilerInputPattern     ; (optional) Pattern(s) to use when finding files (default *.cpp)
-  .CompilerInputPathRecurse ; (optional) Recurse into dirs when finding files (default true)
-  .CompilerInputExcludePath ; (optional) Path(s) to exclude from compilation
-  .CompilerInputExcludedFiles;(optional) File(s) to exclude from compilation (partial, root-relative of full path)
-  .CompilerInputFiles       ; (optional) Explicit array of files to build
-  .CompilerInputFilesRoot   ; (optional) Root path to use for .obj path generation for explicitly listed files
-  .CompilerInputUnity       ; (optional) Unity to build (or Unities)
+  .CompilerInputPath           ; (optional) Path to find files in
+  .CompilerInputPattern        ; (optional) Pattern(s) to use when finding files (default *.cpp)
+  .CompilerInputPathRecurse    ; (optional) Recurse into dirs when finding files (default true)
+  .CompilerInputExcludePath    ; (optional) Path(s) to exclude from compilation
+  .CompilerInputExcludedFiles  ; (optional) File(s) to exclude from compilation (partial, root-relative of full path)
+  .CompilerInputExcludePattern ; (optional) Pattern(s) to exclude from compilation
+  .CompilerInputFiles          ; (optional) Explicit array of files to build
+  .CompilerInputFilesRoot      ; (optional) Root path to use for .obj path generation for explicitly listed files
+  .CompilerInputUnity          ; (optional) Unity to build (or Unities)
   
   ; Cache & Distributed compilation control
   .AllowCaching             ; (optional) Allow caching of compiled objects if available (default true)

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -461,6 +461,7 @@ bool Function::GetDirectoryListNodeList( NodeGraph & nodeGraph,
 										 const Array< AString > & paths,
 										 const Array< AString > & excludePaths,
 										 const Array< AString > & filesToExclude,
+										 const Array< AString > & excludePatterns,
 										 bool recurse,
 										 const Array< AString > * patterns,
 										 const char * inputVarName,
@@ -492,7 +493,7 @@ bool Function::GetDirectoryListNodeList( NodeGraph & nodeGraph,
 
 		// get node for the dir we depend on
 		AStackString<> name;
-		DirectoryListNode::FormatName( path, patterns, recurse, excludePaths, filesToExcludeCleaned, name );
+		DirectoryListNode::FormatName( path, patterns, recurse, excludePaths, filesToExcludeCleaned, excludePatterns, name );
 		Node * node = nodeGraph.FindNode( name );
 		if ( node == nullptr )
 		{
@@ -501,7 +502,8 @@ bool Function::GetDirectoryListNodeList( NodeGraph & nodeGraph,
 											   patterns,
 											   recurse,
 											   excludePaths, 
-                                               filesToExcludeCleaned );
+											   filesToExcludeCleaned,
+											   excludePatterns );
 		}
 		else if ( node->GetType() != Node::DIRECTORY_LIST_NODE )
 		{

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
@@ -69,6 +69,7 @@ public:
 								   const Array< AString > & paths,
 								   const Array< AString > & excludePaths,
 								   const Array< AString > & filesToExclude,
+								   const Array< AString > & excludePatterns,
 								   bool recurse,
 								   const Array< AString > * patterns,
 								   const char * inputVarName,

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCSAssembly.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCSAssembly.cpp
@@ -76,12 +76,18 @@ FunctionCSAssembly::FunctionCSAssembly()
 			return false; // GetFolderPaths will have emitted an error
 		}
 
-        Array< AString > filesToExclude(0, true);
-        if ( !GetStrings( funcStartIter, filesToExclude, ".CompilerInputExcludedFiles", false ) ) // not required
-        {
-            return false; // GetStrings will have emitted an error
-        }
-	    CleanFileNames( filesToExclude );
+		Array< AString > filesToExclude(0, true);
+		if ( !GetStrings( funcStartIter, filesToExclude, ".CompilerInputExcludedFiles", false ) ) // not required
+		{
+			return false; // GetStrings will have emitted an error
+		}
+		CleanFileNames( filesToExclude );
+
+		Array< AString > excludePatterns;
+		if ( !GetStrings( funcStartIter, excludePatterns, ".CompilerInputExcludePattern", false ) ) // not required
+		{
+			return false; // GetStrings will have emitted an error
+		}
 
 		// Input paths
 		Array< AString > inputPaths;
@@ -91,7 +97,7 @@ FunctionCSAssembly::FunctionCSAssembly()
 		}
 
 		Dependencies dirNodes( inputPaths.GetSize() );
-		if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, filesToExclude, recurse, &patterns, "CompilerInputPath", dirNodes ) )
+		if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, filesToExclude, excludePatterns, recurse, &patterns, "CompilerInputPath", dirNodes ) )
 		{
 			return false; // GetDirectoryListNodeList will have emitted an error
 		}

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
@@ -52,7 +52,7 @@ FunctionCopyDir::FunctionCopyDir()
 
 	// convert input paths to DirectoryListNodes
 	Dependencies staticDeps( inputPaths.GetSize() );
-	if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, Array< AString >(), recurse, patterns.IsEmpty() ? nullptr : &patterns, ".SourcePaths", staticDeps ) )
+	if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, Array< AString >(), Array< AString >(), recurse, patterns.IsEmpty() ? nullptr : &patterns, ".SourcePaths", staticDeps ) )
 	{
 		return false; // GetDirectoryListNodeList will have emitted an error
 	}

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionObjectList.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionObjectList.cpp
@@ -482,6 +482,12 @@ bool FunctionObjectList::GetInputs( NodeGraph & nodeGraph, const BFFIterator & i
         }
 	    CleanFileNames( filesToExclude );
 
+        Array< AString > excludePatterns;
+        if ( !GetStrings( iter, excludePatterns, ".CompilerInputExcludePattern", false ) ) // not required
+        {
+            return false; // GetStrings will have emitted an error
+        }
+
 		// Input paths
 		Array< AString > inputPaths;
 		if ( !GetFolderPaths( iter, inputPaths, ".CompilerInputPath", false ) )
@@ -490,7 +496,7 @@ bool FunctionObjectList::GetInputs( NodeGraph & nodeGraph, const BFFIterator & i
 		}
 
 		Dependencies dirNodes( inputPaths.GetSize() );
-		if ( !GetDirectoryListNodeList( nodeGraph, iter, inputPaths, excludePaths, filesToExclude, recurse, &patterns, "CompilerInputPath", dirNodes ) )
+		if ( !GetDirectoryListNodeList( nodeGraph, iter, inputPaths, excludePaths, filesToExclude, excludePatterns, recurse, &patterns, "CompilerInputPath", dirNodes ) )
 		{
 			return false; // GetDirectoryListNodeList will have emitted an error
 		}

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
@@ -56,7 +56,7 @@ FunctionRemoveDir::FunctionRemoveDir()
 
     // convert input paths to DirectoryListNodes
     Dependencies staticDeps( inputPaths.GetSize() );
-    if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, Array< AString >(), recurse, patterns.IsEmpty() ? nullptr : &patterns, ".RemovePaths", staticDeps ) )
+    if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, excludePaths, Array< AString >(), Array< AString >(), recurse, patterns.IsEmpty() ? nullptr : &patterns, ".RemovePaths", staticDeps ) )
     {
         return false; // GetDirectoryListNodeList will have emitted an error
     }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionVCXProject.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionVCXProject.cpp
@@ -281,7 +281,7 @@ FunctionVCXProject::FunctionVCXProject()
 
 	// create all of the DirectoryListNodes we need
 	Dependencies dirNodes( inputPaths.GetSize() );
-	if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, Array< AString >(), Array< AString >(), true, &allowedFileExtensions, "ProjectInputPaths", dirNodes ) )
+	if ( !GetDirectoryListNodeList( nodeGraph, funcStartIter, inputPaths, Array< AString >(), Array< AString >(), Array< AString >(), true, &allowedFileExtensions, "ProjectInputPaths", dirNodes ) )
 	{
 		return false; // GetDirectoryListNodeList will have emitted an error
 	}

--- a/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h
@@ -21,7 +21,8 @@ public:
 								const Array< AString > * patterns,
 								bool recursive,
 								const Array< AString > & excludePaths,
-                                const Array< AString > & filesToExclude );
+                                const Array< AString > & filesToExclude,
+                                const Array< AString > & excludePatterns );
 	virtual ~DirectoryListNode();
 
 	const AString & GetPath() const { return m_Path; }
@@ -36,6 +37,7 @@ public:
 							bool recursive,
 							const Array< AString > & excludePaths,
                             const Array< AString > & excludeFiles,
+                            const Array< AString > & excludePatterns,
 							AString & result );
 
 	static Node * Load( NodeGraph & nodeGraph, IOStream & stream );
@@ -48,6 +50,7 @@ private:
 	Array< AString > m_Patterns;
 	Array< AString > m_ExcludePaths;
     Array< AString > m_FilesToExclude;
+	Array< AString > m_ExcludePatterns;
 	bool m_Recursive;
 
 	Array< FileIO::FileInfo > m_Files;

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -700,14 +700,15 @@ DirectoryListNode * NodeGraph::CreateDirectoryListNode( const AString & name,
 													    const Array< AString > * patterns,
 													    bool recursive,
 													    const Array< AString > & excludePaths,
-                                                        const Array< AString > & filesToExclude )
+                                                        const Array< AString > & filesToExclude,
+                                                        const Array< AString > & excludePatterns )
 {
 	ASSERT( Thread::IsMainThread() );
 
 	// NOTE: DirectoryListNode assumes valid values from here
 	// and will assert as such (so we don't check here)
 
-	DirectoryListNode * node = FNEW( DirectoryListNode( name, path, patterns, recursive, excludePaths, filesToExclude ) );
+	DirectoryListNode * node = FNEW( DirectoryListNode( name, path, patterns, recursive, excludePaths, filesToExclude, excludePatterns ) );
 	AddNode( node );
 	return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -54,7 +54,7 @@ public:
 	}
 	inline ~NodeGraphHeader() {}
 
-	enum { NODE_GRAPH_CURRENT_VERSION = 87 };
+	enum { NODE_GRAPH_CURRENT_VERSION = 88 };
 
 	bool IsValid() const
 	{
@@ -118,7 +118,8 @@ public:
 												 const Array< AString > * patterns,
 												 bool recursive,
                                                  const Array< AString > & excludePaths,
-                                                 const Array< AString > & filesToExclude
+                                                 const Array< AString > & filesToExclude,
+                                                 const Array< AString > & excludePatterns
                                                  );
 	LibraryNode *	CreateLibraryNode( const AString & libraryName,
 									   const Dependencies & inputNodes,

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -394,18 +394,6 @@ bool UnityNode::GetFiles( Array< FileAndOrigin > & files )
 		    {
 			    bool keep = true;
 
-			    // filter patterns
-			    const AString * pit = m_ExcludePatterns.Begin();
-			    const AString * const pend = m_ExcludePatterns.End();
-			    for ( ; pit != pend; ++pit )
-			    {
-				    if ( PathUtils::IsWildcardMatch( pit->Get(), filesIt->m_Name.Get() ) )
-				    {
-					    keep = false;
-					    break;
-				    }
-			    }
-
 				if ( keep && ( pchCPP.IsEmpty() == false ) )
 				{
 					if ( PathUtils::PathEndsWithFile( filesIt->m_Name, pchCPP ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -83,7 +83,7 @@ bool UnityNode::Initialize( NodeGraph & nodeGraph, const BFFIterator & iter, con
 	}
 
 	Dependencies dirNodes( m_InputPaths.GetSize() );
-	if ( !function->GetDirectoryListNodeList( nodeGraph, iter, m_InputPaths, m_PathsToExclude, m_FilesToExclude, m_InputPathRecurse, &m_InputPattern, "UnityInputPath", dirNodes ) )
+	if ( !function->GetDirectoryListNodeList( nodeGraph, iter, m_InputPaths, m_PathsToExclude, m_FilesToExclude, m_ExcludePatterns, m_InputPathRecurse, &m_InputPattern, "UnityInputPath", dirNodes ) )
 	{
 		return false; // GetDirectoryListNodeList will have emitted an error
 	}

--- a/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
@@ -62,7 +62,7 @@ bool XCodeProjectNode::Initialize( NodeGraph & nodeGraph, const BFFIterator & it
 	ProjectGeneratorBase::FixupAllowedFileExtensions( m_ProjectAllowedFileExtensions );
 
 	Dependencies dirNodes( m_ProjectInputPaths.GetSize() );
-	if ( !function->GetDirectoryListNodeList( nodeGraph, iter, m_ProjectInputPaths, m_ProjectInputPathsExclude, m_ProjectFilesToExclude, true, &m_ProjectAllowedFileExtensions, "ProjectInputPaths", dirNodes ) )
+	if ( !function->GetDirectoryListNodeList( nodeGraph, iter, m_ProjectInputPaths, m_ProjectInputPathsExclude, m_ProjectFilesToExclude, m_PatternToExclude, true, &m_ProjectAllowedFileExtensions, "ProjectInputPaths", dirNodes ) )
 	{
 		return false; // GetDirectoryListNodeList will have emitted an error
 	}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObjectList/Exclusions/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObjectList/Exclusions/fbuild.bff
@@ -42,3 +42,12 @@ ObjectList( 'ExcludeFilePathRelative' )
 	.CompilerInputExcludedFiles	= "../FBuildTest/Data/TestObjectList/Exclusions/ignore.cpp"
 	.CompilerOutputPath			+ 'ExcludeFilePathRelative/'
 }
+
+//
+// Exclude by file pattern
+//------------------------------------------------------------------------------
+ObjectList( 'ExcludeFilePattern' )
+{
+	.CompilerInputExcludePattern	= "*nore.cpp"
+	.CompilerOutputPath				+ 'ExcludeFilePattern/'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestUnity/Exclusions/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestUnity/Exclusions/fbuild.bff
@@ -51,3 +51,17 @@ ObjectList( 'ExcludeFilePathRelative' )
 	.CompilerInputUnity			= 'ExcludeFilePathRelative-Unity'
 	.CompilerOutputPath			+ 'ExcludeFilePathRelative/'
 }
+
+//
+// Exclude by file pattern
+//------------------------------------------------------------------------------
+Unity( 'ExcludeFilePattern-Unity' )
+{
+	.UnityInputExcludePattern	= "*nore.cpp"
+	.UnityOutputPath			+ 'ExcludeFilePattern/'
+}
+ObjectList( 'ExcludeFilePattern' )
+{
+	.CompilerInputUnity			= 'ExcludeFilePattern-Unity'
+	.CompilerOutputPath			+ 'ExcludeFilePattern/'
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -125,6 +125,7 @@ void TestGraph::TestNodeTypes() const
                                                             &patterns,
                                                             false,
                                                             Array< AString >(),
+                                                            Array< AString >(),
                                                             Array< AString >() );
 	TEST_ASSERT( dn->GetType() == Node::DIRECTORY_LIST_NODE );
 	TEST_ASSERT( DirectoryListNode::GetTypeS() == Node::DIRECTORY_LIST_NODE );
@@ -273,6 +274,7 @@ void TestGraph::TestDirectoryListNode() const
 														   testFolder,
 														   &patterns,
 														   true,
+														   Array< AString >(),
 														   Array< AString >(),
 														   Array< AString >() );
 	TEST_ASSERT( ng.FindNode( name ) == node );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestObjectList.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestObjectList.cpp
@@ -59,6 +59,13 @@ void TestObjectList::TestExcludedFiles() const
 
 		TEST_ASSERT( fBuild.Build( AStackString<>( "ExcludeFilePathRelative" ) ) );
 	}
+
+	{
+		FBuild fBuild( options );
+		TEST_ASSERT( fBuild.Initialize() );
+
+		TEST_ASSERT( fBuild.Build( AStackString<>( "ExcludeFilePattern" ) ) );
+	}
 }
 
 // ExtraOutputFolders

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
@@ -236,6 +236,13 @@ void TestUnity::TestExcludedFiles() const
 
 		TEST_ASSERT( fBuild.Build( AStackString<>( "ExcludeFilePathRelative" ) ) );
 	}
+
+	{
+		FBuild fBuild( options );
+		TEST_ASSERT( fBuild.Initialize() );
+
+		TEST_ASSERT( fBuild.Build( AStackString<>( "ExcludeFilePattern" ) ) );
+	}
 }
 
 // IsolateFromUnity_Regression

--- a/Code/Tools/FBuild/Integration/usertype.dat
+++ b/Code/Tools/FBuild/Integration/usertype.dat
@@ -39,6 +39,7 @@ Compiler
 CompilerForceUsing
 CompilerInputExcludedFiles
 CompilerInputExcludePath
+CompilerInputExcludePattern
 CompilerInputFiles
 CompilerInputPath
 CompilerInputPathRecurse


### PR DESCRIPTION
This change adds ".CompilerExcludePattern" to ObjectList-based Functions like Library, Exe, ObjectList, etc.  It includes:
- A DB version bump
- Tests for ObjectList and Unity exclusion patterns
- Whitespace (spaces->tabs) fixes around the adjacent file exclusion list properties
- A forced call to `PostTest()` after a test failure so callback outputs clean up and `Tracing::AddCallbackOutput` doesn't hit an assert on the following test

Also I am barely functional with GitHub, so let me know if I need to change anything about this process or pull request.  Thanks!