### PR TITLE
Remove clang static analyzer tokens from clang preprocessor pass

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1447,6 +1447,39 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                 }
             }
         }
+	
+	//remove static analyzer from clang preprocessor
+	if ( pass == PASS_PREPROCESSOR_ONLY )
+          {
+            if ( isClang )
+              {
+                if ( StripToken( "--analyze", token ) )
+                  {
+                    continue;
+                  }
+
+                if ( StripTokenWithArg( "-Xanalyzer", token, i ) )
+                  {
+                    continue;
+                  }
+
+                if ( StripTokenWithArg( "-analyzer-output", token, i ) )
+                  {
+                    continue;
+                  }
+
+                if ( StripTokenWithArg( "-analyzer-config", token, i ) )
+                  {
+                    continue;
+                  }
+
+                if ( StripTokenWithArg( "-analyzer-checker", token, i ) )
+                  {
+                    continue;
+                  }
+              }
+          }
+	
 
         // %1 -> InputFile
         const char * found = token.Find( "%1" );


### PR DESCRIPTION
https://github.com/fastbuild/fastbuild/issues/136

I added a pre-processor pass strip of analyzer tokens

now it seems to work ok
example of static analyzer report from fbuild
```
pavel@Core7 ~/Projects/TNG2 $ fbuild TNG2-Linux-ReleaseStaticAnalyzer  -nostoponerror
5> Obj: /home/pavel/Projects/TNG2/Build/tmp/MemoryArena.o      
1> Obj: /home/pavel/Projects/TNG2/Build/tmp/TNG2.o             
3> Obj: /home/pavel/Projects/TNG2/Build/tmp/Validations.o      
2> Obj: /home/pavel/Projects/TNG2/Build/tmp/JobSystem.o        
4> Obj: /home/pavel/Projects/TNG2/Build/tmp/main_linux.o       
6> Obj: /home/pavel/Projects/TNG2/Build/tmp/EntityManager.o    
6> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/EntityManager.o'
1> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/TNG2.o'
5> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/MemoryArena.o'
3> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/Validations.o'
4> WARNING: /home/pavel/Projects/TNG2/Build/tmp/main_linux.o   
/home/pavel/Projects/TNG2/src/platform/main_linux.c:104:13: warning: Value stored to 'width' is never read
            width = xce.width;
            ^       ~~~~~~~~~
/home/pavel/Projects/TNG2/src/platform/main_linux.c:104:13: note: Value stored to 'width' is never read
            width = xce.width;
            ^       ~~~~~~~~~
/home/pavel/Projects/TNG2/src/platform/main_linux.c:105:13: warning: Value stored to 'height' is never read
            height = xce.height;
            ^        ~~~~~~~~~~
/home/pavel/Projects/TNG2/src/platform/main_linux.c:105:13: note: Value stored to 'height' is never read
            height = xce.height;
            ^        ~~~~~~~~~~
2 warnings generated.
4> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/main_linux.o'
2> File missing despite success for '/home/pavel/Projects/TNG2/Build/tmp/JobSystem.o'
FBuild: Error: BUILD FAILED: TNG2-Linux-ReleaseStaticAnalyzer  
Time: 0.911s
```