### PR TITLE
Add bash completion script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Bash scripts have to have LF line endings, otherwise they work only on Windows
+*.bash-completion eol=lf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/Code/Tools/FBuild/Integration/fbuild.bash-completion
+++ b/Code/Tools/FBuild/Integration/fbuild.bash-completion
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+_fbuild() {
+	local cur="${COMP_WORDS[COMP_CWORD]}"
+	local prev="${COMP_WORDS[COMP_CWORD-1]}"
+	local opts="
+		-cache
+		-cacheread
+		-cachewrite
+		-clean
+		-config
+		-dist
+		-fixuperrorpaths
+		-help
+		-ide
+		-j
+		-monitor
+		-noprogress
+		-nostoponerror
+		-report
+		-showcmds
+		-showtargets
+		-summary
+		-verbose
+		-version
+		-vs
+		-wait
+		-wrapper
+	"
+
+	# Offer files after -config
+	case ${prev} in
+	-config)
+		COMPREPLY=( $(compgen -f -- "${cur}") )
+		[[ ${BASH_VERSINFO[0]} -ge 4 ]] && compopt -o filenames
+		return 0
+		;;
+	esac
+
+	# Offer number of cores on this machine after -j
+	case ${cur} in
+	-j*)
+		local ncpus=8
+		declare -f _ncpus >/dev/null && ncpus=$(_ncpus)
+		COMPREPLY=( $(compgen -W "-j{1..${ncpus}}" -- "$cur" ) )
+		return 0
+		;;
+	esac
+
+	# Search for -config option to pass to fbuild to get the list of targets
+	local args=()
+	for (( i=0; i < ${#COMP_WORDS[@]}; i++ )); do
+		if [[ "${COMP_WORDS[i]}" == -config ]]; then
+			args=( -config "${COMP_WORDS[i+1]}" )
+		fi
+	done
+
+	# Get available targets. Works only if config is valid, otherwise produces nothing.
+	local targets="$("${COMP_WORDS[0]}" "${args[@]}" -showtargets | sed -n -e '/List of available targets/,$ {/List of available targets/d; p}')"
+
+	COMPREPLY=( $( compgen -W "${opts} ${targets}" -- "${cur}" ) )
+}
+
+complete -o bashdefault -o default -F _fbuild fbuild
+complete -o bashdefault -o default -F _fbuild FBuild
+case "$(uname)" in
+MINGW32*|MSYS*|CYGWIN*)
+	complete -o bashdefault -o default -F _fbuild fbuild.exe
+	complete -o bashdefault -o default -F _fbuild FBuild.exe
+	;;
+esac


### PR DESCRIPTION
Offered completions:
   1. All fbuild options.
   2. Files after -config.
   3. Targets (parsed from -showtargets output), when config is valid.

Tested to work on Linux, in msysGit bash (old (<2.0.0) Git for Windows)
and in MSYS2 bash (new (>=2.0.0) Git for Windows).

To install fbuild.bash-completion, either:
   1. (locally) Source it from your ~/.bashrc
   2. (system-wide) Copy it to /etc/bash_completion.d/ (requires modern
       bash-completion).