### PR TITLE
Add custom Vim syntax/indent files

### DIFF
--- a/Code/Tools/FBuild/Integration/vim/indent/bff.vim
+++ b/Code/Tools/FBuild/Integration/vim/indent/bff.vim
@@ -1,0 +1,88 @@
+" Vim indent file
+" Language:     FASTBuild
+" Maintainer:   Arvid Gerstmann <ag AT arvid DOT io>
+" Created:      2016 Sep 14
+" Last Change:  2016 Sep 14
+" Revisions:
+"   - 1.0: Initial release
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=GetFASTBuildIndent()
+setlocal indentkeys=0{,0},!^F,o,O
+setlocal nosmartindent
+
+let b:undo_indent = "setl smartindent< indentkeys< indentexpr<"
+
+if exists("*GetFASTBuildIndent")
+  finish
+endif
+let s:keepcpo= &cpo
+set cpo&vim
+
+function s:prevnonblanknoncomment(lnum)
+  let lnum = a:lnum
+  while lnum > 1
+    let lnum = prevnonblank(lnum)
+    let line = getline(lnum)
+    if line =~ '\*/'
+      while lnum > 1 && line !~ '/\*'
+        let lnum -= 1
+      endwhile
+      if line =~ '^\s*/\*'
+        let lnum -= 1
+      else
+        break
+      endif
+    else
+      break
+    endif
+  endwhile
+  return lnum
+endfunction
+
+function s:count_braces(lnum, count_open)
+  let n_open = 0
+  let n_close = 0
+  let line = getline(a:lnum)
+  let pattern = '[{}]'
+  let i = match(line, pattern)
+  while i != -1
+    if synIDattr(synID(a:lnum, i + 1, 0), 'name') !~ 'bff\%(Comment\|StringQ\{1,2}\)'
+      if line[i] == '{'
+        let n_open += 1
+      elseif line[i] == '}'
+        if n_open > 0
+          let n_open -= 1
+        else
+          let n_close += 1
+        endif
+      endif
+    endif
+    let i = match(line, pattern, i + 1)
+  endwhile
+  return a:count_open ? n_open : n_close
+endfunction
+
+function GetFASTBuildIndent()
+  let line = getline(v:lnum)
+  if line =~ '^\s*\*'
+    return cindent(v:lnum)
+  endif
+
+  let pnum = s:prevnonblanknoncomment(v:lnum - 1)
+  if pnum == 0
+    return 0
+  endif
+
+  return indent(pnum) + s:count_braces(pnum, 1) * &sw
+        \ - s:count_braces(v:lnum, 0) * &sw
+endfunction
+
+let &cpo = s:keepcpo
+unlet s:keepcpo
+

--- a/Code/Tools/FBuild/Integration/vim/syntax/bff.vim
+++ b/Code/Tools/FBuild/Integration/vim/syntax/bff.vim
@@ -1,0 +1,66 @@
+" Vim syntax file
+" Language:     FASTBuild
+" Maintainer:   Arvid Gerstmann <ag AT arvid DOT io>
+" Created:      2016 Sep 12
+" Last Change:  2016 Sep 14
+" Revisions:
+"   - 1.0: Initial release
+
+" Quit when a syntax file is already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+" keywords
+syn keyword bffKeyword Alias Compiler Copy CopyDir CSAssembly DLL Exec
+syn keyword bffKeyword Executable ForEach Library ObjectList Print RemoveDir
+syn keyword bffKeyword Settings Test Unity Using VCXProject VSSSolution XCodeProject
+
+" preprocessor
+syn region bffPreproc start="^\s*#\s*\(if\|endif\)\>" skip="\\$" end="$" keepend
+syn region bffPreproc start="^\s*#\s*\(define\|undef\)\>" skip="\\$" end="$" keepend
+syn region bffPreproc start="^\s*#\s*\(import\|once\)\>" skip="\\$" end="$" keepend
+
+syn region bffIncluded contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match  bffIncluded contained "<[^>]*>"
+syn match  bffInclude "^\s*#\s*include\>\s*["<]" contains=bffIncluded
+
+" strings
+syn match  bffEscape display contained "\^.\|%[1-3]"
+syn region bffString start=+L\="+ skip=+\\\\\|\^"+ end=+"+ contains=bffEscape extend
+syn region bffString start=+L\='+ skip=+\\\\\|\^'+ end=+'+ contains=bffEscape extend
+
+" comments
+syn keyword bffTodo  TODO FIXME XXX contained
+syn match bffComment ";.*"  contains=bffTodo
+syn match bffComment "//.*" contains=bffTodo
+
+" variables / identifiers
+syn match bffIdentifier "\.[a-zA-Z_]\+\([a-zA-Z_]\|[0-9]\)*"
+
+" Actual highlighting
+if version >= 508 || !exists("bff_did_init")
+    if version < 508
+        let bff_did_init = 1
+        command -nargs=+ HiLink hi link <args>
+    else
+        command -nargs=+ HiLink hi def link <args>
+    endif
+
+    HiLink bffTodo          Todo
+    HiLink bffComment       Comment
+    HiLink bffKeyword       Statement
+    HiLink bffPreproc       PreProc
+    HiLink bffString        String
+    HiLink bffInclude       PreProc
+    HiLink bffIncluded      String
+    HiLink bffEscape        Special
+    HiLink bffIdentifier    Identifier
+
+    delcommand HiLink
+endif
+
+let b:current_syntax = "bff"
+


### PR DESCRIPTION
I've Added Vim syntax and indent for FASTBuild files. 
## Whats done?

Vim syntax and indent files have been added to `Code/Tools/FBuild/Integration/vim`.

Here is a small preview: 
<img width="454" alt="screen shot 2016-09-14 at 18 01 06" src="https://cloud.githubusercontent.com/assets/396475/18519730/3e602d54-7aa5-11e6-8117-24c524e1081c.png">
## What's still todo?

Integration inside the website is currently missing.
I believe it's better if it's done by you, since you have full access to the `downloads/` directory and can set it up to your liking.
