### PR TITLE
Drop the requirement that Exec node inputs must be files.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
@@ -78,22 +78,6 @@ FunctionExec::FunctionExec()
     {
         return false; // GetNodeList will have emitted an error
     }
-    else
-    {
-        // Make sure all nodes are files
-        const Dependency * const end = inputNodes.End();
-        for (const Dependency * it = inputNodes.Begin();
-            it != end;
-            ++it)
-        {
-            Node * node = it->GetNode();
-            if (node->IsAFile() == false)
-            {
-                Error::Error_1103_NotAFile(funcStartIter, this, "ExecInput", node->GetName(), node->GetType());
-                return false;
-            }
-        }
-    }
 
     // optional args
     const AString & arguments(  argsV ?         argsV->GetString()      : AString::GetEmpty() );


### PR DESCRIPTION
There is no particular reason to require Exec inputs to be files only. There
are situations where one would want to operate on object files, for instance,
or on Executable nodes for symbol stripping. Potentially, any rule output may
be used as input for an Exec node.
