### PR TITLE
WIP : Appveyor + SonarQube

### DIFF
--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -4,8 +4,8 @@
 ;-------------------------------------------------------------------------------
 ; Windows Platform
 ;-------------------------------------------------------------------------------
-.VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 13.0'
-.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1'
+.VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0'
+.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0'
 .ClangBasePath		= 'C:\Program Files\LLVM\bin'
 
 ;-------------------------------------------------------------------------------

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -4,9 +4,9 @@
 ;-------------------------------------------------------------------------------
 ; Windows Platform
 ;-------------------------------------------------------------------------------
-.VSBasePath			= '../External/SDK/VS13.4'
-.WindowsSDKBasePath	= '../External/SDK/Windows8.1'
-.ClangBasePath		= '../External/SDK/ClangForWindows/3.7.1'
+.VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 13.0'
+.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1'
+.ClangBasePath		= 'C:\Program Files\LLVM\bin'
 
 ;-------------------------------------------------------------------------------
 ; Settings

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -5,7 +5,7 @@
 ; Windows Platform
 ;-------------------------------------------------------------------------------
 .VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0'
-.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0'
+.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A'
 .ClangBasePath		= 'C:\Program Files\LLVM\bin'
 
 ;-------------------------------------------------------------------------------

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -5,7 +5,7 @@
 ; Windows Platform
 ;-------------------------------------------------------------------------------
 .VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0'
-.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A'
+.WindowsSDKBasePath = 'C:\Program Files (x86)\Windows Kits\8.1'
 .ClangBasePath		= 'C:\Program Files\LLVM\bin'
 
 ;-------------------------------------------------------------------------------

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -5,7 +5,7 @@
 ; Windows Platform
 ;-------------------------------------------------------------------------------
 .VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0'
-.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A'
+.WindowsSDKBasePath = 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A'
 .ClangBasePath		= 'C:\Program Files\LLVM\bin'
 
 ;-------------------------------------------------------------------------------

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -6,7 +6,7 @@
 ;-------------------------------------------------------------------------------
 .VSBasePath         = 'C:\Program Files (x86)\Microsoft Visual Studio 12.0'
 .WindowsSDKBasePath = 'C:\Program Files (x86)\Windows Kits\8.1'
-.ClangBasePath		= 'C:\Program Files\LLVM\bin'
+.ClangBasePath		= 'C:\Program Files\LLVM'
 
 ;-------------------------------------------------------------------------------
 ; Settings

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #FASTBuild
 
-[![Build](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true)](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true) [![Quality Gate](https://sonarqube.com/api/badges/gate?key=fastbuild)](https://sonarqube.com/dashboard/index/fastbuild)
+[![Build](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true)](https://ci.appveyor.com/project/jairbubbles/fastbuild) [![Quality Gate](https://sonarqube.com/api/badges/gate?key=fastbuild)](https://sonarqube.com/dashboard/index/fastbuild)
 
 ##Branch policy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #FASTBuild
 
-[![Build](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true)](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true)
+[![Build](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true)](https://ci.appveyor.com/api/projects/status/f5vewk6oqi7i5pi9?svg=true) [![Quality Gate](https://sonarqube.com/api/badges/gate?key=fastbuild)](https://sonarqube.com/dashboard/index/fastbuild)
 
 ##Branch policy
 

--- a/SonarQubeAnalysis.ps1
+++ b/SonarQubeAnalysis.ps1
@@ -35,11 +35,11 @@ Add-Type -assembly system.io.compression.filesystem
 # Download and unzip sonnar scanner
 if(![System.IO.Directory]::Exists($PSScriptRoot + '\SonarScanner'))
 {
-	(new-object net.webclient).DownloadFile('http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/2.6/sonar-scanner-cli-2.6.zip', $PSScriptRoot +  '\SonarScanner.zip')
+	(new-object net.webclient).DownloadFile('http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/2.8/sonar-scanner-cli-2.8.zip', $PSScriptRoot +  '\SonarScanner.zip')
 	[io.compression.zipfile]::ExtractToDirectory($PSScriptRoot + '\SonarScanner.zip', $PSScriptRoot + '\SonarScanner')
 }
 
-$scannerCmdLine = ".\SonarScanner\sonar-scanner-2.6\bin\sonar-scanner.bat -D sonar.host.url='$hostUrl' -D sonar.login='$login' -D sonar.projectKey='$projectKey' -D sonar.projectName='$projectName' -D sonar.projectVersion='$projectVersion' -D sonar.sources='$sources'"
+$scannerCmdLine = ".\SonarScanner\sonar-scanner-2.8\bin\sonar-scanner.bat -D sonar.host.url='$hostUrl' -D sonar.login='$login' -D sonar.projectKey='$projectKey' -D sonar.projectName='$projectName' -D sonar.projectVersion='$projectVersion' -D sonar.sources='$sources'"
 
 #Download build wrapper (if needed)
 if($buildWrapperCommand)

--- a/SonarQubeAnalysis.ps1
+++ b/SonarQubeAnalysis.ps1
@@ -1,0 +1,55 @@
+Param(
+	[parameter(Mandatory=$true)]
+	[alias("h")]
+	[string]$hostUrl,
+	[parameter(Mandatory=$true)]
+	[alias("l")]
+	[string]$login,
+	[parameter(Mandatory=$true)]
+	[alias("n")]
+	[string]$projectName,
+	[parameter(Mandatory=$true)]
+	[alias("k")]
+	[string]$projectKey,
+	[parameter(Mandatory=$true)]
+	[alias("b")]
+	[string]$projectVersion,
+	[parameter(Mandatory=$true)]
+	[alias("s")]
+	[string]$sources,
+	[string]$buildWrapperCommand 
+)
+
+Add-Type -assembly system.io.compression.filesystem
+
+# Download and unzip sonnar scanner
+if(![System.IO.Directory]::Exists($PSScriptRoot + '\SonarScanner'))
+{
+	(new-object net.webclient).DownloadFile('http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/2.6/sonar-scanner-cli-2.6.zip', $PSScriptRoot +  '\SonarScanner.zip')
+	[io.compression.zipfile]::ExtractToDirectory($PSScriptRoot + '\SonarScanner.zip', $PSScriptRoot + '\SonarScanner')
+}
+
+$scannerCmdLine = ".\SonarScanner\sonar-scanner-2.6\bin\sonar-scanner.bat -D sonar.host.url='$hostUrl' -D sonar.login='$login' -D sonar.projectKey='$projectKey' -D sonar.projectName='$projectName' -D sonar.projectVersion='$projectVersion' -D sonar.sources='$sources'"
+
+#Download build wrapper (if needed)
+if($buildWrapperCommand)
+{
+	if(![System.IO.Directory]::Exists($PSScriptRoot +  '\BuildWrapper'))
+	{
+		[System.Net.ServicePointManager]::SecurityProtocol = @('Tls12','Tls11','Tls','Ssl3')
+		(new-object net.webclient).DownloadFile('http://sonarqube.com/static/cpp/build-wrapper-win-x86.zip', $PSScriptRoot + '\BuildWrapper.zip')
+		[io.compression.zipfile]::ExtractToDirectory($PSScriptRoot + '\BuildWrapper.zip', $PSScriptRoot + '\BuildWrapper')
+	}
+	
+	# Compile with BuildWrapper
+	
+    $builderCmdLine = ".\BuildWrapper\build-wrapper-win-x86\build-wrapper-win-x86-64.exe --out-dir 'Build' $buildWrapperCommand"
+	Write-Output $builderCmdLine
+	Invoke-Expression $builderCmdLine
+	
+	$scannerCmdLine += ' -D sonar.cfamily.build-wrapper-output=Build'
+}
+
+Write-Output $scannerCmdLine
+
+Invoke-Expression $scannerCmdLine

--- a/SonarQubeAnalysis.ps1
+++ b/SonarQubeAnalysis.ps1
@@ -1,23 +1,33 @@
+
 Param(
-	[parameter(Mandatory=$true)]
+	# Analysis parameters (see http://docs.sonarqube.org/display/SONAR/Analysis+Parameters)
+	[parameter(Mandatory=$true,HelpMessage="Server URL ")]
 	[alias("h")]
 	[string]$hostUrl,
-	[parameter(Mandatory=$true)]
+	[parameter(Mandatory=$true,HelpMessage="The authentication token of a SonarQube user with Execute Analysis permission.")]
 	[alias("l")]
 	[string]$login,
-	[parameter(Mandatory=$true)]
+	[parameter(Mandatory=$true,HelpMessage="Name of the project that will be displayed on the web interface.\nSet through <name> when using Maven.")]
 	[alias("n")]
-	[string]$projectName,
-	[parameter(Mandatory=$true)]
+	[string]$projectName, 
+	[parameter(Mandatory=$true,HelpMessage="The project key that is unique for each project.\nAllowed characters are: letters, numbers, '-', '_', '.' and ':', with at least one non-digit.\nWhen using Maven, it is automatically set to <groupId>:<artifactId>.")]
 	[alias("k")]
 	[string]$projectKey,
-	[parameter(Mandatory=$true)]
-	[alias("b")]
+	[parameter(Mandatory=$true,HelpMessage="The project version.\nSet through <version> when using Maven.")]
+	[alias("v")]
 	[string]$projectVersion,
-	[parameter(Mandatory=$true)]
+	[parameter(Mandatory=$true, HelpMessage="Comma-separated paths to directories containing source files.\nCompatible with Maven. If not set, the source code is retrieved from the default Maven source code location. ")]
 	[alias("s")]
 	[string]$sources,
-	[string]$buildWrapperCommand 
+	#Option build wrapper command (for C/C++/Objective-C builds)
+	[string]$buildWrapperCommand,
+	# Pull request specific arguments (see http://docs.sonarqube.org/display/PLUG/GitHub+Plugin)
+	[parameter(HelpMessage="Pull request number")]
+	[int]$gitHubPullRequest,
+	[parameter(HelpMessage="Personal access token generated in GitHub for the technical user ")]
+	[string]$gitHubOauth,	
+	[parameter(HelpMessage="Identification of the repository. Format is: <organisation/repo>. Exemple: SonarSource/sonarqube	")]
+	[string]$gitHubRepository
 )
 
 Add-Type -assembly system.io.compression.filesystem
@@ -48,6 +58,12 @@ if($buildWrapperCommand)
 	Invoke-Expression $builderCmdLine
 	
 	$scannerCmdLine += ' -D sonar.cfamily.build-wrapper-output=Build'
+}
+
+# Pull request ?
+if($gitHubPullRequest)
+{
+	$scannerCmdLine += " -D sonar.analysis.mode=preview -D sonar.github.oauth='$gitHubOauth' -D sonar.github.repository='$gitHubRepository' -D sonar.github.pullRequest='$gitHubPullRequest'"
 }
 
 Write-Output $scannerCmdLine

--- a/SonarQubeAnalysisForAppVeyor.ps1
+++ b/SonarQubeAnalysisForAppVeyor.ps1
@@ -13,7 +13,7 @@ Param(
 if(Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	Write-Output 'Pull Request Analysis'
 	Write-Output $env:APPVEYOR_PULL_REQUEST_NUMBER
-	.\SonarQubeAnalysis.ps1 -h $env:SONAR_HOST_URL -l $env:SONAR_TOKEN -s $sources -n $env:APPVEYOR_PROJECT_NAME -k $env:APPVEYOR_PROJECT_SLUG -v $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand $buildWrapperCommand -gitHubPullRequest $env:APPVEYOR_PULL_REQUEST_NUMBER -gitHubOauth $GITHUB_TOKEN -gitHubRepository $env:APPVEYOR_REPO_NAME
+	.\SonarQubeAnalysis.ps1 -h $env:SONAR_HOST_URL -l $env:SONAR_TOKEN -s $sources -n $env:APPVEYOR_PROJECT_NAME -k $env:APPVEYOR_PROJECT_SLUG -v $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand $buildWrapperCommand -gitHubPullRequest $env:APPVEYOR_PULL_REQUEST_NUMBER -gitHubOauth $env:GITHUB_TOKEN -gitHubRepository $env:APPVEYOR_REPO_NAME
 }
 # Full analysis for master branch only
 ElseIf($env:APPVEYOR_REPO_BRANCH -eq 'master') {

--- a/SonarQubeAnalysisForAppVeyor.ps1
+++ b/SonarQubeAnalysisForAppVeyor.ps1
@@ -1,0 +1,23 @@
+# This assumes that the 2 following variables are defined:
+# - SONAR_HOST_URL => should point to the public URL of the SQ server (e.g. : https://sonarqube.com)
+# - SONAR_TOKEN    => token of a user who has the "Execute Analysis" permission on the SQ server
+# - GITHUB_TOKEN    => token for commenting pull requests in GitHub
+
+Param(
+	[parameter(Mandatory=$true)]
+	[string]$sources,
+	[string]$buildWrapperCommand	
+)
+
+# Special behavior for pull requests
+if(Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) {
+	Write-Output 'Pull Request Analysis'
+	Write-Output $env:APPVEYOR_PULL_REQUEST_NUMBER
+	.\SonarQubeAnalysis.ps1 -h $env:SONAR_HOST_URL -l $env:SONAR_TOKEN -s $sources -n $env:APPVEYOR_PROJECT_NAME -k $env:APPVEYOR_PROJECT_SLUG -v $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand $buildWrapperCommand -gitHubPullRequest $env:APPVEYOR_PULL_REQUEST_NUMBER -gitHubOauth $GITHUB_TOKEN -gitHubRepository $env:APPVEYOR_REPO_NAME
+}
+# Full analysis for master branch only
+ElseIf($env:APPVEYOR_REPO_BRANCH -eq 'master') {
+	Write-Output 'Full Analysis'
+	.\SonarQubeAnalysis.ps1 -h $env:SONAR_HOST_URL -l $env:SONAR_TOKEN -s $sources -n $env:APPVEYOR_PROJECT_NAME -k $env:APPVEYOR_PROJECT_SLUG -v $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand $buildWrapperCommand
+}
+else {Write-Output 'Skipping Analysis'}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,10 @@ before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
-- ps: Write-Output $env:APPVEYOR_BUILD_FOLDER
-- ps: dir
  
 build_script:
-- ps: .\FastBuild\fbuild.exe -config Code\fbuild.bff
+- ps: .\FBuild.exe -config Code\fbuild.bff
   
 after_build:
-- ps: .\FastBuild\fbuild.exe -config Code\fbuild.bff solution
+- ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
-- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/')"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
  
 build_script:
-- ps: fbuild.exe -config Code\fbuild.bff
+- ps: FastBuild\fbuild.exe -config Code\fbuild.bff
   
 after_build:
-- ps: fbuild.exe -config Code\fbuild.bff solution
+- ps: FastBuild\fbuild.exe -config Code\fbuild.bff solution
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,7 @@ before_build:
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows'
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0'
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A'
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1'
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin'
  
 # Using FastBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ before_build:
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/FastBuild')"
  
-build:
+build_script:
 - ps: fbuild.exe -config Code\fbuild.bff
   
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,4 +24,5 @@ build_script:
   
 after_build:
 #Launch analysis
+- ps: cd ..
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '../tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ before_build:
 # Generate VS projects
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 # Add current location to path
-- ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
+- ps: "$env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER"
  
 # Using FastBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ before_build:
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
+- ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
  
 # We need to setup SDK to compile with fbuild
 #build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ before_build:
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A\bin'
  
 # Using FastBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ before_build:
 - ps: cd Code
 - ps: "[Environment]::CurrentDirectory = $PWD"
 # Download & Unzip FastBuild
-- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:\Tmp\FastBuild.zip')
+- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:/Tmp/FastBuild.zip')
 - ps: Add-Type -assembly "system.io.compression.filesystem"
-- ps: "[io.compression.zipfile]::ExtractToDirectory('C:\Tmp\FastBuild.zip', 'C:\FastBuild')"
+- ps: "[io.compression.zipfile]::ExtractToDirectory(C:/Tmp/FastBuild.zip, C:/FastBuild)"
 # Add FastBuild to path
 - ps: "$env:Path = $env:Path + ';C:\FastBuild'"
 # Generate VS projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,16 @@
 os: Visual Studio 2013
 
 before_build:
+# Download & Unzip FastBuild
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
+# Attempt to set working directory to current location
+- ps: [Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER
+# Generate VS projects
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
+# Add current location to path
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
-- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A\bin'
  
 # Using FastBuild
 build_script:
@@ -18,4 +22,5 @@ build_script:
 #  verbosity: minimal
   
 after_build:
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'C:\projects\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"
+#Launch analysis
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '.\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ before_build:
 # Download & Unzip FastBuild
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:/FastBuild.zip')
 - ps: Add-Type -assembly "system.io.compression.filesystem"
-- ps: "[io.compression.zipfile]::ExtractToDirectory(C:/FastBuild.zip, C:/FastBuild)"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('C:/FastBuild.zip', 'C:/FastBuild')"
 # Add FastBuild to path
 - ps: "$env:Path = $env:Path + ';C:/FastBuild'"
 # Generate VS projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ before_build:
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
 - ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1'
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A'
  
 # Using FastBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
 - ps: Add-Type -assembly "system.io.compression.filesystem"
 - ps: "[io.compression.zipfile]::ExtractToDirectory(C:/Tmp/FastBuild.zip, C:/FastBuild)"
 # Add FastBuild to path
-- ps: "$env:Path = $env:Path + ';C:\FastBuild'"
+- ps: "$env:Path = $env:Path + ';C:/FastBuild'"
 # Generate VS projects
 - ps: fbuild solution
  
@@ -24,4 +24,4 @@ build_script:
   
 after_build:
 #Launch analysis
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '..\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '../tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Visual Studio 2013
 
 before_build:
-# Change working directoty and current location
+# Change working directory and current location
 - ps: cd Code
 - ps: "[Environment]::CurrentDirectory = $PWD"
 # Download & Unzip FastBuild
@@ -11,11 +11,11 @@ before_build:
 # Add FastBuild to path
 - ps: "$env:Path = $env:Path + ';C:/FastBuild'"
 # Generate VS projects
-- ps: fbuild solution
+- ps: fbuild solution -noprogress
  
 # Using FastBuild
 build_script:
-- ps: fbuild All-x86 All-x64
+- ps: fbuild All-x86 All-x64 -noprogress
 
 # Using MSbuild
 #build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+before_build:
+ - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
+ - ps: Add-Type -assembly “system.io.compression.filesystem”
+ - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/FastBuild')"
+ 
+ build:
+ - ps: fbuild.exe -config Code\fbuild.bff
+  
+after_build:
+- ps: fbuild.exe -config Code\fbuild.bff solution
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ before_build:
 # We need to setup SDK to compile with fbuild
 #build_script:
 #- ps: .\FBuild.exe -config Code\fbuild.bff
+
+build:
+  project: C:\projects\tmp\VisualStudio\FASTBuild.sln
+  verbosity: minimal
   
 after_build:
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'C:\projects\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
  
 # Using FastBuild
 build_script:
-- ps: fbuild
+- ps: fbuild All-x86 All-x64
 
 # Using MSbuild
 #build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ build_script:
 after_build:
 #Launch analysis
 - ps: cd ..
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl $env:SONAR_HOST_URL -login $env:SONAR_TOKEN -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
-- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/FastBuild')"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/')"
  
 build_script:
 - ps: fbuild.exe -config Code\fbuild.bff

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ build_script:
 after_build:
 #Launch analysis
 - ps: cd ..
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '../tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,12 @@ before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
+- ps: Write-Output $env:APPVEYOR_BUILD_FOLDER
+- ps: dir
  
 build_script:
-- ps: FastBuild\fbuild.exe -config Code\fbuild.bff
+- ps: .\FastBuild\fbuild.exe -config Code\fbuild.bff
   
 after_build:
-- ps: FastBuild\fbuild.exe -config Code\fbuild.bff solution
+- ps: .\FastBuild\fbuild.exe -config Code\fbuild.bff solution
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ build_script:
 after_build:
 #Launch analysis
 - ps: cd ..
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl $env:SONAR_HOST_URL -login $env:SONAR_TOKEN -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"
+- ps:  ./SonarQubeAnalysisForAppVeyor.ps1 -sources Code/ -buildWrapperCommand "msbuild  'tmp/VisualStudio/FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,14 @@ before_build:
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
  
-# We need to setup SDK to compile with fbuild
-#build_script:
-#- ps: .\FBuild.exe -config Code\fbuild.bff
+# Using FastBuild
+build_script:
+- ps: .\FBuild.exe -config Code\fbuild.bff
 
-build:
-  project: C:\projects\tmp\VisualStudio\FASTBuild.sln
-  verbosity: minimal
+# Using MSbuild
+#build:
+#  project: C:\projects\tmp\VisualStudio\FASTBuild.sln
+#  verbosity: minimal
   
 after_build:
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  'C:\projects\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,21 @@
 os: Visual Studio 2013
 
 before_build:
+# Attempt to set working directory to current location
+- ps: cd Code
+- ps: "[Environment]::CurrentDirectory = $PWD"
+# Add current location to path
+- ps: "$env:Path = $env:Path + $PWD"
 # Download & Unzip FastBuild
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
-- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
-# Attempt to set working directory to current location
-- ps: "[Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER"
-- ps: $PWD
-- ps: Get-Location
-- ps: "[Environment]::CurrentDirectory"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $PWD)"
 # Generate VS projects
-- ps: .\FBuild.exe -config Code\fbuild.bff solution
-# Add current location to path
-- ps: "$env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER"
+- ps: .\FBuild.exe -config fbuild.bff solution
  
 # Using FastBuild
 build_script:
-- ps: .\FBuild.exe -config Code\fbuild.bff
+- ps: .\FBuild.exe -config fbuild.bff
 
 # Using MSbuild
 #build:
@@ -26,4 +24,4 @@ build_script:
   
 after_build:
 #Launch analysis
-- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '.\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"
+- ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  '..\tmp\VisualStudio\FASTBuild.sln'  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 before_build:
- - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
- - ps: Add-Type -assembly “system.io.compression.filesystem”
- - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/FastBuild')"
+- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
+- ps: Add-Type -assembly “system.io.compression.filesystem”
+- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER +'/FastBuild')"
  
- build:
- - ps: fbuild.exe -config Code\fbuild.bff
+build:
+- ps: fbuild.exe -config Code\fbuild.bff
   
 after_build:
 - ps: fbuild.exe -config Code\fbuild.bff solution

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,11 @@ before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
+- ps: .\FBuild.exe -config Code\fbuild.bff solution
  
-build_script:
-- ps: .\FBuild.exe -config Code\fbuild.bff
+# We need to setup SDK to compile with fbuild
+#build_script:
+#- ps: .\FBuild.exe -config Code\fbuild.bff
   
 after_build:
-- ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: .\SonarQubeAnalysis.ps1 -hostUrl 'https://sonarqube.com' -login  d5fcf62e7cba7c67b913e9edb4ecee2e9a697d52 -sources Code/ -projectName $env:APPVEYOR_PROJECT_NAME -projectKey $env:APPVEYOR_PROJECT_SLUG -projectVersion $env:APPVEYOR_BUILD_NUMBER -buildWrapperCommand "msbuild  tmp\VisualStudio\FASTBuild.sln  /t:rebuild"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ before_build:
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 # Attempt to set working directory to current location
 - ps: "[Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER"
+- ps: $PWD
+- ps: Get-Location
+- ps: "[Environment]::CurrentDirectory
 # Generate VS projects
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 # Add current location to path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ before_build:
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 - ps: $env:Path = $env:Path + $env:APPVEYOR_BUILD_FOLDER
+- ps: dir 'C:\Program Files (x86)\Microsoft SDKs\Windows'
  
 # Using FastBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+os: Visual Studio 2013
+
 before_build:
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ before_build:
 - ps: Add-Type -assembly “system.io.compression.filesystem”
 - ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $env:APPVEYOR_BUILD_FOLDER)"
 # Attempt to set working directory to current location
-- ps: [Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER
+- ps: "[Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER"
 # Generate VS projects
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 # Add current location to path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ before_build:
 - ps: "[Environment]::CurrentDirectory = $env:APPVEYOR_BUILD_FOLDER"
 - ps: $PWD
 - ps: Get-Location
-- ps: "[Environment]::CurrentDirectory
+- ps: "[Environment]::CurrentDirectory"
 # Generate VS projects
 - ps: .\FBuild.exe -config Code\fbuild.bff solution
 # Add current location to path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ before_build:
 - ps: cd Code
 - ps: "[Environment]::CurrentDirectory = $PWD"
 # Download & Unzip FastBuild
-- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:/Tmp/FastBuild.zip')
+- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:/FastBuild.zip')
 - ps: Add-Type -assembly "system.io.compression.filesystem"
 - ps: "[io.compression.zipfile]::ExtractToDirectory(C:/Tmp/FastBuild.zip, C:/FastBuild)"
 # Add FastBuild to path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ before_build:
 # Download & Unzip FastBuild
 - ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:/FastBuild.zip')
 - ps: Add-Type -assembly "system.io.compression.filesystem"
-- ps: "[io.compression.zipfile]::ExtractToDirectory(C:/Tmp/FastBuild.zip, C:/FastBuild)"
+- ps: "[io.compression.zipfile]::ExtractToDirectory(C:/FastBuild.zip, C:/FastBuild)"
 # Add FastBuild to path
 - ps: "$env:Path = $env:Path + ';C:/FastBuild'"
 # Generate VS projects

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,17 +5,17 @@ before_build:
 - ps: cd Code
 - ps: "[Environment]::CurrentDirectory = $PWD"
 # Download & Unzip FastBuild
-- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:\FastBuild.zip')
-- ps: Add-Type -assembly “system.io.compression.filesystem”
-- ps: "[io.compression.zipfile]::ExtractToDirectory('C:\FastBuild.zip', 'C:\FastBuild')"
+- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:\Tmp\FastBuild.zip')
+- ps: Add-Type -assembly "system.io.compression.filesystem"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('C:\Tmp\FastBuild.zip', 'C:\FastBuild')"
 # Add FastBuild to path
 - ps: "$env:Path = $env:Path + ';C:\FastBuild'"
 # Generate VS projects
-- ps: FBuild.exe -config fbuild.bff solution
+- ps: fbuild solution
  
 # Using FastBuild
 build_script:
-- ps: FBuild.exe -config fbuild.bff
+- ps: fbuild
 
 # Using MSbuild
 #build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,21 @@
 os: Visual Studio 2013
 
 before_build:
-# Attempt to set working directory to current location
+# Change working directoty and current location
 - ps: cd Code
 - ps: "[Environment]::CurrentDirectory = $PWD"
-# Add current location to path
-- ps: "$env:Path = $env:Path + $PWD"
 # Download & Unzip FastBuild
-- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'FastBuild.zip')
+- ps: (new-object net.webclient).DownloadFile('http://fastbuild.org/downloads/v0.91/FASTBuild-Windows-x64-v0.91.zip', 'C:\FastBuild.zip')
 - ps: Add-Type -assembly “system.io.compression.filesystem”
-- ps: "[io.compression.zipfile]::ExtractToDirectory('FastBuild.zip', $PWD)"
+- ps: "[io.compression.zipfile]::ExtractToDirectory('C:\FastBuild.zip', 'C:\FastBuild')"
+# Add FastBuild to path
+- ps: "$env:Path = $env:Path + ';C:\FastBuild'"
 # Generate VS projects
-- ps: .\FBuild.exe -config fbuild.bff solution
+- ps: FBuild.exe -config fbuild.bff solution
  
 # Using FastBuild
 build_script:
-- ps: .\FBuild.exe -config fbuild.bff
+- ps: FBuild.exe -config fbuild.bff
 
 # Using MSbuild
 #build:


### PR DESCRIPTION
I finally managed to get compilation (https://ci.appveyor.com/project/jairbubbles/fastbuild) and analysis (https://sonarqube.com/overview?id=fastbuild) working.

I also put badges on the readme to look modern and cool ;-)

A few notes:
- Clang was failing and I didn't spend time to investigate. It's only x86 / x64 for now.
- Pull request with fast analysis should be working now.  See here for more infos http://docs.sonarqube.org/display/PLUG/GitHub+Plugin
- Switching SDKs is not convenient and I had to update main bff. On a different project I had the issue too and I ended up creating a fbuild_vs2012.bff which was not very pretty. What would be great is to be able to switch between sub scripts that only change SDK, includes, libs and compiler files. These sub scripts could be shared between projects for people who are starting with FB.
- PowerShell is a pain in the ass. There are a lot of weird things and I didn't find a simple tutorial so it was a lot of back and forth.
- AppVeyor is really great. You have a full windows image so you can do everything you want.

You need to setup some en var in the AppVeyor settings :
```
# This assumes that the 2 following variables are defined:
# - SONAR_HOST_URL => should point to the public URL of the SQ server (e.g. : https://sonarqube.com)
# - SONAR_TOKEN    => token of a user who has the "Execute Analysis" permission on the SQ server
# - GITHUB_TOKEN    => token for commenting pull requests in GitHub
```

Closes #150 