### PR TITLE
Fix AString::Replace taking extremly long time when "from" is an empty string

### DIFF
--- a/Code/Core/Strings/AString.cpp
+++ b/Code/Core/Strings/AString.cpp
@@ -571,14 +571,19 @@ void AString::Trim( uint32_t startCharsToTrim, uint32_t endCharsToTrim )
 //------------------------------------------------------------------------------
 uint32_t AString::Replace( const char * from, const char * to, uint32_t maxReplaces )
 {
-    AStackString< 2 * KILOBYTE > temp;
+    const size_t fromLength = StrLen( from );
+    if ( fromLength == 0 )
+    {
+        // string to replace can't be empty, otherwise replace operation doesn't make sense
+        return 0;
+    }
 
+    AStackString< 2 * KILOBYTE > temp;
     uint32_t replaceCount = 0;
 
     // loop until the last possible position for a potential match
     const char * pos = m_Contents;
     const char * end = m_Contents + m_Length;
-    const size_t fromLength = StrLen( from );
     while ( pos <= ( end - fromLength ) )
     {
         if ( StrNCmp( pos, from, fromLength ) == 0 )


### PR DESCRIPTION
When `AString::Replace` is called with empty `from` string, it never
advances `pos` pointer in the main loop and exits only when `maxReplaces`
reaches 0, which takes 2^32 iterations.
This problem can be observed with this input (parsing takes very long
time):

    .X = 'a'
    .X - ''

This patch adds early exit to catch this case.