### PR TITLE
Use native slash in cache paths

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/Cache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/Cache.cpp
@@ -143,11 +143,13 @@
 void Cache::GetCacheFileName( const AString & cacheId, AString & path ) const
 {
     // format example: N:\\fbuild.cache\\23\\77\\2377DE32_FED872A1_AB62FEAA23498AAC.3
-    path.Format( "%s%c%c\\%c%c\\%s", m_CachePath.Get(),
+    path.Format( "%s%c%c%c%c%c%c%s", m_CachePath.Get(),
                                        cacheId[ 0 ],
                                        cacheId[ 1 ],
+                                       NATIVE_SLASH,
                                        cacheId[ 2 ],
                                        cacheId[ 3 ],
+                                       NATIVE_SLASH,
                                        cacheId.Get() );
 }
 


### PR DESCRIPTION
This re-enables grouping of cache files into separate directories on
Linux and OS X.
This also allows storage of cache files on filesystems that don't allow
\ as part of a file name. For example, I encountered this issue while trying to set up mounted VirtualBox shared folder (guest=Linux, host=Windows7) as FASTBUILD_CACHE_PATH (files weren't getting created).

Also, a slightly unrelated question: On Linux I am getting cache files with names like `EB65EB0AD97484EC_824A3E5A_30FBF3C59D93AF21-0000000000000000.7`, what `-0000000000000000` is supposed to encode? That part is always all zeroes, which doesn't look correct, also cache files on Windows doesn't have it.