### PR TITLE
For large projects that distribute their builds, having an extremely …

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1498,10 +1498,16 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                     continue; // skip this token in both cases
                 }
             }
-            if ( isMSVC )
-            {
-                // NOTE: Leave /I includes for compatibility with Recode
-                // (unlike Clang, MSVC is ok with leaving the /I when compiling preprocessed code)
+			if (isMSVC)
+			{
+				// NOTE: Stripping off /I includes drastically shortens the command line for large projects.
+				// This may break support for Recode.
+				// (unlike Clang, MSVC is ok with leaving the /I when compiling preprocessed code)
+
+				if (StripTokenWithArg_MSVC("I", token, i))
+				{
+					continue;
+				}
 
                 // Strip "Force Includes" statements (as they are merged in now)
                 if ( StripTokenWithArg_MSVC( "FI", token, i ) )


### PR DESCRIPTION
…long path can cause error D8049 on MSVC. See https://github.com/fastbuild/fastbuild/issues/105

The error only presents itself on remote workers. Preprocessing only happens on the host machine. Removing all /I includes drastically reduces the command line length for the remote workers, and the includes are not required anyway (except for Recode? Not sure what that is).
This still feels like a workaround since it's unclear why the preprocessor doesn't choke on the long command line, and why the preprocessed code with the long command line does not fail on the host machine.