### PR TITLE
Handle invalid EOL markers

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
@@ -248,12 +248,17 @@ bool CIncludeParser::ParseGCC_Preprocessed( const char * compilerOutput,
 
     for (;;)
     {
-        pos = strstr( pos, "\n#" );
+        pos = strpbrk( pos, "\n\r" );
         if ( !pos )
         {
             break;
         }
-        pos += 2;
+        ++pos;
+        if ( *pos != '#' )
+        {
+            continue;
+        }
+        ++pos;
     possibleInclude:
         if ( *pos == ' ' )
         {


### PR DESCRIPTION
When dealing with mixed-format files clang/gcc will sometimes add the line directives after '\r' rather than a '\n'