### PR TITLE
allow FASTBUILD_TEMP_PATH env var to override system temp dir

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -375,10 +375,22 @@
 {
     #if defined( __WINDOWS__ )
         char buffer[ MAX_PATH ];
-        DWORD len = GetTempPath( MAX_PATH, buffer );
-        if ( len != 0 )
+        DWORD res = GetEnvironmentVariable("FASTBUILD_TEMP_PATH",
+                buffer,MAX_PATH);
+        if ( res == 0 )
+        {
+            DWORD len = GetTempPath( MAX_PATH, buffer );
+            if ( len != 0 )
+            {
+                output = buffer;
+                output += '\\';
+                return true;
+            }
+        }
+        else
         {
             output = buffer;
+            output += '\\';
             return true;
         }
     #elif defined( __LINUX__ ) || defined( __APPLE__ )

--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -30,17 +30,21 @@
 //------------------------------------------------------------------------------
 /*static*/ bool PathUtils::IsFullPath( const AString & path )
 {
-    #if defined( __WINDOWS__ )
-        // full paths on Windows are in X: format
-        if ( path.GetLength() >= 2 )
-        {
-            return ( path[ 1 ] == ':' );
-        }
-        return false;
-    #elif defined( __LINUX__ ) || defined( __APPLE__ )
+
+    #if defined( __LINUX__ ) || defined( __APPLE__ )
         // full paths on Linux/OSX/IOS begin with a slash
-        return path.BeginsWith( NATIVE_SLASH );
+        if (path.BeginsWith( NATIVE_SLASH ))
+        {
+            return true;
+        }
     #endif
+     // full paths on Windows are in X: format
+     // we may testing windows full path filename on linux
+     if ( path.GetLength() >= 2 )
+     {
+         return ( path[ 1 ] == ':' );
+     }
+     return false;
 }
 
 // ArePathsEqual

--- a/Code/Core/Process/Semaphore.cpp
+++ b/Code/Core/Process/Semaphore.cpp
@@ -111,7 +111,7 @@ void Semaphore::Wait( uint32_t timeoutMS )
             ts.tv_nsec = totalNS % 1000000000;
             if ( sem_timedwait( &m_Semaphore, &ts ) != 0 )
             {
-                ASSERT( errno == ETIMEDOUT ); // anything else is a usage error?
+                ASSERT( ( errno == ETIMEDOUT ) || (errno == EINTR ) ); // anything else is a usage error?
             }
         #endif
     }

--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #if defined( __WINDOWS__ )
     #include <windows.h>
+#elif defined( __LINUX__ )
+    #include <signal.h>
 #endif
 
 // Return Codes
@@ -44,9 +46,10 @@ void DisplayHelp();
 void DisplayVersion();
 #if defined( __WINDOWS__ )
     BOOL CtrlHandler( DWORD fdwCtrlType ); // Handle Ctrl+C etc
+#elif defined( __LINUX__ )
+    void CtrlHandler( int dummy );
 #else
     // TODO:MAC Implement CtrlHandler
-    // TODO:LINUX Implement CtrlHandler
 #endif
 int WrapperMainProcess( const AString & args, const FBuildOptions & options, SystemMutex & finalProcess );
 int WrapperIntermediateProcess( const AString & args, const FBuildOptions & options );
@@ -93,6 +96,8 @@ int Main(int argc, char * argv[])
 
     #if defined( __WINDOWS__ )
         VERIFY( SetConsoleCtrlHandler( (PHANDLER_ROUTINE)CtrlHandler, TRUE ) ); // Register
+    #elif defined( __LINUX__ )
+        signal(SIGINT,CtrlHandler);
     #endif
 
     // handle cmd line args
@@ -560,6 +565,19 @@ void DisplayVersion()
         }
 
         return TRUE; // tell Windows we've "handled" it
+    }
+#elif defined (__LINUX__)
+
+void CtrlHandler( int UNUSED( dummy ) )
+    {
+        // tell FBuild we want to stop the build cleanly
+        FBuild::AbortBuild();
+        static bool received = false;
+        if ( received == false )
+        {
+            received = true;
+            OUTPUT( "<<<< ABORT SIGNAL RECEIVED >>>>\n" );
+        }
     }
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExec.cpp
@@ -36,12 +36,14 @@ FunctionExec::FunctionExec()
     const BFFVariable * workingDirV;
     int32_t expectedReturnCode;
     bool useStdOutAsOutput;
+    bool isGenerator;
     if ( !GetString( funcStartIter, outputV,        ".ExecOutput", true ) ||
          !GetString( funcStartIter, executableV,    ".ExecExecutable", true ) ||
          !GetString( funcStartIter, argsV,          ".ExecArguments" ) ||
          !GetString( funcStartIter, workingDirV,    ".ExecWorkingDir" ) ||
          !GetInt( funcStartIter, expectedReturnCode, ".ExecReturnCode", 0, false ) ||
-         !GetBool( funcStartIter, useStdOutAsOutput, ".ExecUseStdOutAsOutput", false, false))
+         !GetBool( funcStartIter, useStdOutAsOutput, ".ExecUseStdOutAsOutput", false, false) ||
+         !GetBool( funcStartIter, isGenerator,       ".ExecIsGenerator", false, false))
     {
         return false;
     }
@@ -108,7 +110,8 @@ FunctionExec::FunctionExec()
                                            workingDir,
                                            expectedReturnCode,
                                            preBuildDependencies,
-                                           useStdOutAsOutput);
+                                           useStdOutAsOutput,
+                                           isGenerator);
 
     return ProcessAlias( nodeGraph, funcStartIter, outputNode );
 }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExecutable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExecutable.cpp
@@ -199,6 +199,9 @@ FunctionExecutable::FunctionExecutable()
     }
     else
     {
+
+        Dependencies preBuildDependencies;
+        GetNodeList(nodeGraph,funcStartIter,".PreBuildDependencies",preBuildDependencies);
         n = nodeGraph.CreateExeNode( linkerOutput,
                               libraryNodes,
                               otherLibraryNodes,
@@ -209,7 +212,8 @@ FunctionExecutable::FunctionExecutable()
                               assemblyResources,
                               importLibName,
                               linkerStampExe,
-                              linkerStampExeArgs );
+                              linkerStampExeArgs,
+                              preBuildDependencies);
     }
 
     return ProcessAlias( nodeGraph, funcStartIter, n );

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -304,6 +304,10 @@ struct SaveTrigger
 {
     FBuild *instance;
 
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable: 6011)
+#endif
     ~SaveTrigger()
     {
         ASSERT(instance);
@@ -313,6 +317,9 @@ struct SaveTrigger
             instance->SaveDependencyGraph( instance->m_DependencyGraphFile.Get() );
         }
     }
+#ifdef _MSVC_VER
+#pragma warning( pop )
+#endif
 };
 
 // Build

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -25,6 +25,7 @@ class JobQueue;
 class Node;
 class NodeGraph;
 
+struct SaveTrigger;
 // FBuild
 //------------------------------------------------------------------------------
 class FBuild : public Singleton< FBuild >
@@ -40,7 +41,7 @@ public:
     // build a target
     bool Build( const AString & target );
     bool Build( const Array< AString > & targets );
-    bool Build( Node * nodeToBuild );
+    bool Build( Node * nodeToBuild ,bool saveLater = false );
 
     // after a build we can store progress/parsed rules for next time
     bool SaveDependencyGraph( const char * nodeGraphDBFile ) const;
@@ -105,6 +106,10 @@ public:
 
 private:
     void UpdateBuildStatus( const Node * node );
+    bool ReloadBff();
+    bool CheckGenerator();
+    bool BuildByProxy(const Array<AString>& targets, Dependencies& nodes);
+    friend struct SaveTrigger;
 
     static bool s_StopBuild;
 
@@ -114,6 +119,7 @@ private:
     JobQueue * m_JobQueue;
     Client * m_Client; // manage connections to worker servers
 
+    AString m_BffFile;
     AString m_DependencyGraphFile;
     AString m_CachePluginDLL;
     AString m_CachePath;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.cpp
@@ -25,10 +25,14 @@ ExeNode::ExeNode( const AString & linkerOutputName,
                   const Dependencies & assemblyResources,
                   const AString & importLibName,
                   Node * linkerStampExe,
-                  const AString & linkerStampExeArgs )
+                  const AString & linkerStampExeArgs,
+                  const Dependencies & preBuildDependencies
+        )
 : LinkerNode( linkerOutputName, inputLibraries, otherLibraries, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs )
 {
     m_Type = EXE_NODE;
+
+    m_PreBuildDependencies = preBuildDependencies;
 }
 
 // DESTRUCTOR
@@ -51,9 +55,16 @@ ExeNode::~ExeNode() = default;
     NODE_LOAD( AStackString<>,  importLibName );
     NODE_LOAD_NODE_LINK( Node,  linkerStampExe );
     NODE_LOAD( AStackString<>,  linkerStampExeArgs );
+    NODE_LOAD_DEPS( 0,  preBuildDependencies);
 
-    ExeNode * en = nodeGraph.CreateExeNode( name, inputLibs, otherLibs, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs );
+    ExeNode * en = nodeGraph.CreateExeNode( name, inputLibs, otherLibs, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs, preBuildDependencies );
     return en;
 }
 
+    
+void ExeNode::Save( IOStream & stream ) const
+{
+    LinkerNode::Save(stream);
+    NODE_SAVE_DEPS( m_PreBuildDependencies);
+}
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.h
@@ -24,8 +24,12 @@ public:
                       const Dependencies & assemblyResources,
                       const AString & importLibName,
                       Node * linkerStampExe,
-                      const AString & linkerStampExeArgs );
+                      const AString & linkerStampExeArgs,
+                      const Dependencies & preBuildDependencies
+                      );
     virtual ~ExeNode();
+
+    virtual void Save( IOStream & stream ) const;
 
     static inline Node::Type GetTypeS() { return Node::EXE_NODE; }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -22,13 +22,15 @@ public:
                         const AString & workingDir,
                         int32_t expectedReturnCode,
                         const Dependencies & preBuildDependencies,
-                        bool useStdOutAsOutput );
+                        bool useStdOutAsOutput,
+                        bool isGenerator = false );
     virtual ~ExecNode();
 
     static inline Node::Type GetTypeS() { return Node::EXEC_NODE; }
 
     static Node * Load( NodeGraph & nodeGraph, IOStream & stream );
     virtual void Save( IOStream & stream ) const override;
+    virtual bool IsGenerator() const override;
 private:
     virtual BuildResult DoBuild( Job * job ) override;
 
@@ -43,6 +45,7 @@ private:
     AString     m_WorkingDir;
     int32_t     m_ExpectedReturnCode;
     bool        m_UseStdOutAsOutput;
+    bool        m_IsGenerator;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -1006,3 +1006,8 @@ bool Node::InitializePreBuildDependencies( NodeGraph & nodeGraph, const BFFItera
 }
 
 //------------------------------------------------------------------------------
+    
+bool Node::IsGenerator() const
+{
+    return false;
+}

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -142,6 +142,9 @@ public:
     // each node must specify if it outputs a file
     virtual bool IsAFile() const = 0;
 
+    //if this node is used to generate bff file 
+    virtual bool IsGenerator() const;
+
     inline State GetState() const { return m_State; }
 
     inline bool GetStatFlag( StatsFlag flag ) const { return ( ( m_StatsFlags & flag ) != 0 ); }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -62,6 +62,7 @@
 //------------------------------------------------------------------------------
 NodeGraph::NodeGraph()
 : m_AllNodes( 1024, true )
+, m_GeneratorNodes( 1, true )
 , m_NextNodeIndex( 0 )
 , m_UsedFiles( 16, true )
 {
@@ -611,6 +612,11 @@ size_t NodeGraph::GetNodeCount() const
     return m_AllNodes.GetSize();
 }
 
+Array< Node* >& NodeGraph::GetGeneratorNodes()
+{
+    return m_GeneratorNodes;
+}
+
 // CreateCopyFileNode
 //------------------------------------------------------------------------------
 CopyFileNode * NodeGraph::CreateCopyFileNode( const AString & dstFileName )
@@ -668,6 +674,10 @@ ExecNode * NodeGraph::CreateExecNode( const AString & dstFileName,
 
     ExecNode * node = FNEW( ExecNode( fullPath, inputFiles, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies, useStdOutAsOutput, isGenerator ) );
     AddNode( node );
+    if (isGenerator)
+    {
+        m_GeneratorNodes.Append( node );
+    }
     return node;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -658,14 +658,15 @@ ExecNode * NodeGraph::CreateExecNode( const AString & dstFileName,
                                       const AString & workingDir,
                                       int32_t expectedReturnCode,
                                       const Dependencies & preBuildDependencies,
-                                      bool useStdOutAsOutput )
+                                      bool useStdOutAsOutput,
+                                      bool isGenerator )
 {
     ASSERT( Thread::IsMainThread() );
 
     AStackString< 512 > fullPath;
     CleanPath( dstFileName, fullPath );
 
-    ExecNode * node = FNEW( ExecNode( fullPath, inputFiles, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies, useStdOutAsOutput ) );
+    ExecNode * node = FNEW( ExecNode( fullPath, inputFiles, executable, arguments, workingDir, expectedReturnCode, preBuildDependencies, useStdOutAsOutput, isGenerator ) );
     AddNode( node );
     return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -798,7 +798,8 @@ ExeNode * NodeGraph::CreateExeNode( const AString & linkerOutputName,
                                     const Dependencies & assemblyResources,
                                     const AString & importLibName,
                                     Node * linkerStampExe,
-                                    const AString & linkerStampExeArgs )
+                                    const AString & linkerStampExeArgs,
+                                    const Dependencies & preBuildDependencies )
 {
     ASSERT( Thread::IsMainThread() );
 
@@ -815,7 +816,8 @@ ExeNode * NodeGraph::CreateExeNode( const AString & linkerOutputName,
                                   assemblyResources,
                                   importLibName,
                                   linkerStampExe,
-                                  linkerStampExeArgs ) );
+                                  linkerStampExeArgs,
+                                  preBuildDependencies ) );
     AddNode( node );
     return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -106,7 +106,8 @@ public:
                                const AString & workingDir,
                                int32_t expectedReturnCode,
                                const Dependencies & preBuildDependencies,
-                               bool useStdOutAsOutput );
+                               bool useStdOutAsOutput,
+                               bool isGenerator = false );
     FileNode * CreateFileNode( const AString & fileName, bool cleanPath = true );
     DirectoryListNode * CreateDirectoryListNode( const AString & name,
                                                  const AString & path,

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -140,7 +140,8 @@ public:
                                    const Dependencies & assemblyResources,
                                    const AString & importLibName,
                                    Node * linkerStampExe,
-                                   const AString & linkerStampExeArgs );
+                                   const AString & linkerStampExeArgs ,
+                                   const Dependencies & preBuildDependencies );
     UnityNode * CreateUnityNode( const AString & unityName );
     CSNode * CreateCSNode( const AString & csAssemblyName );
     TestNode * CreateTestNode( const AString & testOutput );

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -92,6 +92,7 @@ public:
     Node * FindNode( const AString & nodeName ) const;
     Node * GetNodeByIndex( size_t index ) const;
     size_t GetNodeCount() const;
+    Array< Node* >& GetGeneratorNodes() ;
 
     // create new nodes
     CopyFileNode * CreateCopyFileNode( const AString & dstFileName );
@@ -228,6 +229,7 @@ private:
     enum { NODEMAP_TABLE_SIZE = 65536 };
     Node **         m_NodeMap;
     Array< Node * > m_AllNodes;
+    Array< Node * > m_GeneratorNodes;
     uint32_t        m_NextNodeIndex;
 
     Timer m_Timer;

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
@@ -54,7 +54,8 @@ void TestExe::CreateNode() const
                                             Dependencies(),
                                             AStackString<>(),
                                             nullptr,
-                                            AString::GetEmpty() ); // assembly resources
+                                            AString::GetEmpty(),
+                                            Dependencies() ); // assembly resources
 
     TEST_ASSERT( exeNode->GetType() == Node::EXE_NODE );
     TEST_ASSERT( ExeNode::GetTypeS() == Node::EXE_NODE );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -176,7 +176,7 @@ void TestGraph::TestNodeTypes() const
     {
         Dependencies libraries( 1, false );
         libraries.Append( Dependency( fn ) );
-        Node * n = ng.CreateExeNode( AStackString<>( "zz.exe" ), libraries, Dependencies(), AString::GetEmpty(), AString::GetEmpty(), AString::GetEmpty(), 0, Dependencies(), AStackString<>(),nullptr, AString::GetEmpty() );
+        Node * n = ng.CreateExeNode( AStackString<>( "zz.exe" ), libraries, Dependencies(), AString::GetEmpty(), AString::GetEmpty(), AString::GetEmpty(), 0, Dependencies(), AStackString<>(),nullptr, AString::GetEmpty(), Dependencies() );
         TEST_ASSERT( n->GetType() == Node::EXE_NODE );
         TEST_ASSERT( ExeNode::GetTypeS() == Node::EXE_NODE );
         TEST_ASSERT( AStackString<>( "Exe" ) == n->GetTypeName() );


### PR DESCRIPTION
some antivirus (such as McAfee) prevent executable run from system temp dir. this patch add a env var to override this temp location. it may also fix #194