### PR TITLE
Supports PreBuildDependencies in Exe Node

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExecutable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionExecutable.cpp
@@ -199,6 +199,12 @@ FunctionExecutable::FunctionExecutable()
     }
     else
     {
+
+        Dependencies preBuildDependencies;
+        if ( !GetNodeList( nodeGraph, funcStartIter, ".PreBuildDependencies", preBuildDependencies, false ) )
+        {
+            return false; // GetNodeList will have emitted an error
+        }
         n = nodeGraph.CreateExeNode( linkerOutput,
                               libraryNodes,
                               otherLibraryNodes,
@@ -209,7 +215,8 @@ FunctionExecutable::FunctionExecutable()
                               assemblyResources,
                               importLibName,
                               linkerStampExe,
-                              linkerStampExeArgs );
+                              linkerStampExeArgs,
+                              preBuildDependencies);
     }
 
     return ProcessAlias( nodeGraph, funcStartIter, n );

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.cpp
@@ -25,10 +25,14 @@ ExeNode::ExeNode( const AString & linkerOutputName,
                   const Dependencies & assemblyResources,
                   const AString & importLibName,
                   Node * linkerStampExe,
-                  const AString & linkerStampExeArgs )
+                  const AString & linkerStampExeArgs,
+                  const Dependencies & preBuildDependencies
+        )
 : LinkerNode( linkerOutputName, inputLibraries, otherLibraries, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs )
 {
     m_Type = EXE_NODE;
+
+    m_PreBuildDependencies = preBuildDependencies;
 }
 
 // DESTRUCTOR
@@ -51,9 +55,16 @@ ExeNode::~ExeNode() = default;
     NODE_LOAD( AStackString<>,  importLibName );
     NODE_LOAD_NODE_LINK( Node,  linkerStampExe );
     NODE_LOAD( AStackString<>,  linkerStampExeArgs );
+    NODE_LOAD_DEPS( 0,  preBuildDependencies);
 
-    ExeNode * en = nodeGraph.CreateExeNode( name, inputLibs, otherLibs, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs );
+    ExeNode * en = nodeGraph.CreateExeNode( name, inputLibs, otherLibs, linkerType, linker, linkerArgs, flags, assemblyResources, importLibName, linkerStampExe, linkerStampExeArgs, preBuildDependencies );
     return en;
 }
 
+    
+void ExeNode::Save( IOStream & stream ) const
+{
+    LinkerNode::Save(stream);
+    NODE_SAVE_DEPS( m_PreBuildDependencies);
+}
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExeNode.h
@@ -24,8 +24,12 @@ public:
                       const Dependencies & assemblyResources,
                       const AString & importLibName,
                       Node * linkerStampExe,
-                      const AString & linkerStampExeArgs );
+                      const AString & linkerStampExeArgs,
+                      const Dependencies & preBuildDependencies
+                      );
     virtual ~ExeNode();
+
+    virtual void Save( IOStream & stream ) const;
 
     static inline Node::Type GetTypeS() { return Node::EXE_NODE; }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -798,7 +798,8 @@ ExeNode * NodeGraph::CreateExeNode( const AString & linkerOutputName,
                                     const Dependencies & assemblyResources,
                                     const AString & importLibName,
                                     Node * linkerStampExe,
-                                    const AString & linkerStampExeArgs )
+                                    const AString & linkerStampExeArgs,
+                                    const Dependencies & preBuildDependencies )
 {
     ASSERT( Thread::IsMainThread() );
 
@@ -815,7 +816,8 @@ ExeNode * NodeGraph::CreateExeNode( const AString & linkerOutputName,
                                   assemblyResources,
                                   importLibName,
                                   linkerStampExe,
-                                  linkerStampExeArgs ) );
+                                  linkerStampExeArgs,
+                                  preBuildDependencies ) );
     AddNode( node );
     return node;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -140,7 +140,8 @@ public:
                                    const Dependencies & assemblyResources,
                                    const AString & importLibName,
                                    Node * linkerStampExe,
-                                   const AString & linkerStampExeArgs );
+                                   const AString & linkerStampExeArgs ,
+                                   const Dependencies & preBuildDependencies );
     UnityNode * CreateUnityNode( const AString & unityName );
     CSNode * CreateCSNode( const AString & csAssemblyName );
     TestNode * CreateTestNode( const AString & testOutput );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
@@ -54,7 +54,8 @@ void TestExe::CreateNode() const
                                             Dependencies(),
                                             AStackString<>(),
                                             nullptr,
-                                            AString::GetEmpty() ); // assembly resources
+                                            AString::GetEmpty(),
+                                            Dependencies() ); // assembly resources
 
     TEST_ASSERT( exeNode->GetType() == Node::EXE_NODE );
     TEST_ASSERT( ExeNode::GetTypeS() == Node::EXE_NODE );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -176,7 +176,7 @@ void TestGraph::TestNodeTypes() const
     {
         Dependencies libraries( 1, false );
         libraries.Append( Dependency( fn ) );
-        Node * n = ng.CreateExeNode( AStackString<>( "zz.exe" ), libraries, Dependencies(), AString::GetEmpty(), AString::GetEmpty(), AString::GetEmpty(), 0, Dependencies(), AStackString<>(),nullptr, AString::GetEmpty() );
+        Node * n = ng.CreateExeNode( AStackString<>( "zz.exe" ), libraries, Dependencies(), AString::GetEmpty(), AString::GetEmpty(), AString::GetEmpty(), 0, Dependencies(), AStackString<>(),nullptr, AString::GetEmpty(), Dependencies() );
         TEST_ASSERT( n->GetType() == Node::EXE_NODE );
         TEST_ASSERT( ExeNode::GetTypeS() == Node::EXE_NODE );
         TEST_ASSERT( AStackString<>( "Exe" ) == n->GetTypeName() );


### PR DESCRIPTION
link libraries may be embedded in link options, not easy to extract them
out as Libraries variable, it's better to support PreBuildDependencies