### PR TITLE
allow FASTBUILD_TEMP_PATH environment variable to override system tem…

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -375,10 +375,22 @@
 {
     #if defined( __WINDOWS__ )
         char buffer[ MAX_PATH ];
-        DWORD len = GetTempPath( MAX_PATH, buffer );
-        if ( len != 0 )
+        DWORD res = GetEnvironmentVariable("FASTBUILD_TEMP_PATH",
+                buffer,MAX_PATH);
+        if ( res == 0 )
+        {
+            DWORD len = GetTempPath( MAX_PATH, buffer );
+            if ( len != 0 )
+            {
+                output = buffer;
+                output += '\\';
+                return true;
+            }
+        }
+        else
         {
             output = buffer;
+            output += '\\';
             return true;
         }
     #elif defined( __LINUX__ ) || defined( __APPLE__ )


### PR DESCRIPTION
…p dir

some antivirus (such as McAfee) prevent executable run from system temp dir.

it apply to windows only , as I know most linux/osx user didn't use antivirus. if they are, we may extend this to all platforms.

this didn't check trailing backslash, because win32 api accept path with extra backslash, and if we really want to clean path , must reverse checking every char from trailing to ensure no extra backslash , I think leave a(or maybe some) extra backslash is a little easier. 
