### PR TITLE
Syntax highlighting for Sublime Text 3

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/download.html
+++ b/Code/Tools/FBuild/Documentation/docs/download.html
@@ -50,6 +50,7 @@ Syntax Highlighting
 	<li><a href='https://github.com/ClxS/FASTBuild-UE4'>FASTBuild-UE4</a> - Integration for Unreal Engine 4 by ClxS</li>    
 	<li><a href='https://github.com/liamkf/Unreal_FASTBuild'>Unreal_FASTBuild</a> - Integration for Unreal Engine 4 by liamkf</li>    
 	<li><a href='https://github.com/dummyunit/vim-fastbuild'>vim-fastbuild</a> - Syntax highlighting for vim by dummyunit</li>    
+	<li><a href="https://packagecontrol.io/packages/FASTBuild">FASTBuild-Sublime</a> - Syntax highlighting for Sublime Text 3 by Manuzor</li>
 </ul>
     </div>
 


### PR DESCRIPTION
I've created a syntax highlighting plugin for the Sublime Text 3 editor.

(This succeeds #204 and properly adheres to the `dev`-branch policy)