### PR TITLE
PreprocessorGenericDependencies

### DIFF
--- a/Code/Core/Mem/MemDebug.cpp
+++ b/Code/Core/Mem/MemDebug.cpp
@@ -12,6 +12,9 @@
 // Core
 #include "Core/Env/Assert.h"
 
+// System
+#include <stdint.h>
+
 // FillMem
 //------------------------------------------------------------------------------
 void MemDebug::FillMem( void * ptr, const size_t size, const uint32_t pattern )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -51,7 +51,7 @@ protected:
 
     // internal helpers
     bool CreateDynamicObjectNode( NodeGraph & nodeGraph, Node * inputFile, const AString & baseDir, bool isUnityNode = false, bool isIsolatedFromUnityNode = false );
-    ObjectNode * CreateObjectNode( NodeGraph & nodeGraph, const BFFIterator & iter, const Function * function, const uint32_t flags, const AString & compilerOptions, const AString & compilerOptionsDeoptimized, const AString & objectName, const AString & objectInput, const AString & pchObjectName = AString::GetEmpty() );
+    ObjectNode * CreateObjectNode( NodeGraph & nodeGraph, const BFFIterator & iter, const Function * function, const uint32_t flags, const AString & compilerOptions, const AString & compilerOptionsDeoptimized, const uint32_t preprocessorFlags, const AString & objectName, const AString & objectInput, const AString & pchObjectName = AString::GetEmpty() );
 
     // Exposed Properties
     AString             m_Compiler;
@@ -79,6 +79,7 @@ protected:
     AString             m_PCHOptions;
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
+    bool                m_PreprocessorGenericDependencies   = false;
     Array< AString >    m_PreBuildDependencyNames;
 
     // Internal State

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -57,7 +57,10 @@ public:
         FLAG_INCLUDES_IN_STDERR =   0x20000,
         FLAG_QT_RCC             =   0x40000,
         FLAG_WARNINGS_AS_ERRORS_MSVC    = 0x80000,
+        FLAG_GENERIC_DEPENDENCIES =  0x100000,
     };
+
+    static uint32_t DetermineCompilerType( const Node * compilerNode );
     static uint32_t DetermineFlags( const Node * compilerNode,
                                     const AString & args,
                                     bool creatingPCH,


### PR DESCRIPTION
Experimental change, open to suggestions for other ways to do this.

Added support for PreprocessorGenericDependencies option to the
ObjectList node. When enabled the custom preprocessor will be used one
to generate dependency information. The preprocessor must write out the
list of dependencies to stdout.

This flag makes it possible to add support for additional compilers and
tools that introduce dynamic dependencies. For instance, the QT resource
compiler could use this method rather than needing to be handled as a
special case in the code.