### PR TITLE
VCXProjectNode uses full file path for deterministic GUID generation.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
@@ -74,11 +74,7 @@ VCXProjectNode::~VCXProjectNode() = default;
     VSProjectGenerator pg;
     pg.SetBasePaths( m_ProjectBasePaths );
 
-    // get project file name only
-    const char * p1 = m_Name.FindLast( NATIVE_SLASH );
-    p1 = p1 ? p1 : m_Name.Get();
-    AStackString<> projectName( p1 );
-    pg.SetProjectName( projectName );
+    pg.SetProjectName( m_Name );
 
     // Globals
     pg.SetRootNamespace( m_RootNamespace );

--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
@@ -154,9 +154,7 @@ void SLNGenerator::WriteProjectListings( const AString& solutionBasePath,
         AStackString<> projectGuid;
         if ( (*it)->GetProjectGuid().GetLength() == 0 )
         {
-            // For backward compatibility, keep the preceding slash and .vcxproj extension for GUID generation
-            AStackString<> projectNameForGuid( lastSlash ? lastSlash : projectPath.Get() );
-            VSProjectGenerator::FormatDeterministicProjectGUID( projectGuid, projectNameForGuid );
+            VSProjectGenerator::FormatDeterministicProjectGUID( projectGuid, projectPath );
         }
         else
         {
@@ -189,12 +187,8 @@ void SLNGenerator::WriteProjectListings( const AString& solutionBasePath,
                 // get all the projects this project depends on
                 for ( const AString & dependency : deps.m_Dependencies )
                 {
-                    // For backward compatibility, keep the preceding slash and .vcxproj extension for GUID generation
-                    const char * projNameFromSlash = dependency.FindLast( NATIVE_SLASH );
-                    AStackString<> projectNameForGuid( projNameFromSlash ? projNameFromSlash : dependency.Get() );
-
                     AStackString<> newGUID;
-                    VSProjectGenerator::FormatDeterministicProjectGUID( newGUID, projectNameForGuid );
+                    VSProjectGenerator::FormatDeterministicProjectGUID( newGUID, dependency );
                     dependencyGUIDs.Append( newGUID );
                 }
             }


### PR DESCRIPTION
Looked at the blame for VCXProjectNode and using the just the name (plus the slash right before it) seems to pre-date git. From the comment I'm guessing there's a reason for that, but I couldn't discern what.