### PR TITLE
Checkout path independant cache

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionSettings.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionSettings.cpp
@@ -6,6 +6,8 @@
 #include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
 
 #include "FunctionSettings.h"
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+#include "Tools/FBuild/FBuildCore/FLog.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
 #include "Tools/FBuild/FBuildCore/Graph/SettingsNode.h"
 
@@ -40,6 +42,18 @@ FunctionSettings::FunctionSettings()
     {
         return false;
     }
+    // "RootPath"
+    AStackString<> rootPath;
+    if ( !GetString( funcStartIter, rootPath, ".RootPath" ) )
+    {
+        return false;
+    }
+    FBuild::Get().SetRootPath( rootPath );
+    if ( !rootPath.IsEmpty() )
+    {
+        FLOG_INFO( "RootPath: '%s'", rootPath.Get() );
+    }
+
 
     return settingsNode->Initialize( nodeGraph, funcStartIter, this );
 }

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -39,12 +39,15 @@
 #include "Core/Process/Process.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 
 //#define DEBUG_CRT_MEMORY_USAGE // Uncomment this for (very slow) detailed mem checks
 #ifdef DEBUG_CRT_MEMORY_USAGE
     #include <crtdbg.h>
 #endif
+
+#include <cctype>
 
 // Static
 //------------------------------------------------------------------------------
@@ -522,7 +525,7 @@ bool FBuild::ImportEnvironmentVar( const char * name, bool optional, AString & v
     else
     {
         // compute hash value for actual value
-        hash = xxHash::Calc32( value );
+        hash = FBuild::Hash32( value );
     }
 
     // check if the environment var was already imported
@@ -590,6 +593,108 @@ void FBuild::AbortBuild()
     {
         AbortBuild();
     }
+}
+
+// Hash functions
+//------------------------------------------------------------------------------
+
+PRAGMA_DISABLE_PUSH_MSVC(6308)
+char* TemporaryBlockForHash( size_t size )
+{
+    static THREAD_LOCAL void * s_Block = nullptr;
+    static THREAD_LOCAL size_t s_Size = 0;
+    if ( ( nullptr == s_Block ) || ( size > s_Size ) )
+    {
+        s_Size = ( ( size + 127 ) & ~127 ); // Round to next 128
+        s_Block = realloc( s_Block, s_Size );
+    }
+    return ( ( char * )s_Block );
+}
+PRAGMA_DISABLE_POP_MSVC
+
+static bool BufferForHashEqual( char lhs, char rhs )
+{
+    return ( ( lhs == rhs ) ||
+             ( lhs == '/' && rhs == '\\' ) ||
+             ( lhs == '\\' && rhs == '/' ) ||
+             ( std::tolower(lhs) == std::tolower(rhs) ) );
+}
+
+// Make hash functions path agnostic :
+static const void * PrepareBufferForHash( const char * inputBuffer, size_t inputLen, size_t& outputLen )
+{
+    const AString & rootPath = FBuild::Get().GetRootPath();
+    const uint32_t rootPathLen = rootPath.GetLength();
+    if ( rootPath.IsEmpty() || ( inputLen < rootPathLen ) )
+    {
+        outputLen = inputLen;
+        return inputBuffer;
+    }
+
+    const char rootPathAlias = char( 0x1A ); // SUB (substitute in ASCII)
+    char * preparedBuffer = TemporaryBlockForHash( inputLen/* cannot grow since alias in just one char */ );
+    if ( nullptr == preparedBuffer )
+    {
+        ASSERT( false );
+        return nullptr;
+    }
+
+    uint32_t match = 0, dst = 0;
+    for ( uint32_t src = 0 ; src < inputLen ; ++src )
+    {
+        ASSERT( dst < inputLen );
+
+        if ( BufferForHashEqual( inputBuffer[src], rootPath[match] ) && inputLen - src >= rootPathLen - match )
+        {
+            if ( ++match == rootPathLen )
+            {
+                match = 0;
+                preparedBuffer[dst++] = rootPathAlias;
+            }
+        }
+        else
+        {
+            ASSERT( src >= match );
+
+            if ( match )
+            {
+                for ( uint32_t i = 0 ; i < match ; ++i )
+                {
+                    preparedBuffer[dst++] = inputBuffer[src - match + i];
+                }
+                match = 0;
+            }
+
+            preparedBuffer[dst++] = inputBuffer[src];
+        }
+    }
+
+    outputLen = dst;
+    return preparedBuffer;
+}
+
+/*static*/ uint32_t FBuild::Hash32( const void * buffer, size_t len )
+{
+    size_t hashLen = 0;
+    const void * bufferForHash = PrepareBufferForHash( (const char *)buffer, len, hashLen );
+    const uint32_t h = xxHash::Calc32( bufferForHash, hashLen );
+    if ( bufferForHash == buffer )
+    {
+        ASSERT( hashLen == len );
+    }
+    return h;
+}
+
+/*static*/ uint64_t FBuild::Hash64( const void * buffer, size_t len )
+{
+    size_t hashLen = 0;
+    const void * bufferForHash = PrepareBufferForHash( (const char *)buffer, len, hashLen );
+    const uint64_t h = xxHash::Calc64( bufferForHash, hashLen );
+    if ( bufferForHash == buffer )
+    {
+        ASSERT( hashLen == len );
+    }
+    return h;
 }
 
 // UpdateBuildStatus

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -63,6 +63,9 @@ public:
     inline const char * GetEnvironmentString() const            { return m_EnvironmentString; }
     inline uint32_t     GetEnvironmentStringSize() const        { return m_EnvironmentStringSize; }
 
+    const AString& GetRootPath() const { return m_RootPath; }
+    void SetRootPath( const AString& rootPath ) { m_RootPath = rootPath; }
+
     void DisplayTargetList() const;
     bool DisplayDependencyDB( const Array< AString > & targets ) const;
 
@@ -105,6 +108,13 @@ public:
     bool CacheOutputInfo() const;
     bool CacheTrim() const;
 
+    // root path agnostic hash functions
+    static uint32_t Hash32( const void * buffer, size_t len );
+    static uint64_t Hash64( const void * buffer, size_t len );
+
+    inline static uint32_t Hash32( const AString & string ) { return Hash32( string.Get(), string.GetLength() ); }
+    inline static uint64_t Hash64( const AString & string ) { return Hash64( string.Get(), string.GetLength() ); }
+
 private:
     bool GetTargets( const Array< AString > & targets, Dependencies & outDeps ) const;
 
@@ -121,6 +131,8 @@ private:
 
     AString m_DependencyGraphFile;
     ICache * m_Cache;
+
+    AString m_RootPath;
 
     SettingsNode * m_Settings;
 

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -6,6 +6,7 @@
 #include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
 
 // FBuildCore
+#include "FBuild.h"
 #include "FBuildOptions.h"
 #include "Tools/FBuild/FBuildCore/FBuildVersion.h"
 #include "Tools/FBuild/FBuildCore/FLog.h"

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -171,7 +171,7 @@ bool NodeGraph::ParseFromRoot( const char * bffFile )
         FLOG_ERROR( "Error reading BFF '%s'", bffFile );
         return false;
     }
-    const uint64_t rootBFFDataHash = xxHash::Calc64( data.Get(), size );
+    const uint64_t rootBFFDataHash = FBuild::Hash64( data.Get(), size );
 
     // re-parse the BFF from scratch, clean build will result
     BFFParser bffParser( *this );
@@ -245,7 +245,7 @@ NodeGraph::LoadResult NodeGraph::Load( IOStream & stream, const char * nodeGraph
             return LoadResult::LOAD_ERROR; // error reading
         }
 
-        const uint64_t dataHash = xxHash::Calc64( mem.Get(), size );
+        const uint64_t dataHash = FBuild::Hash64( mem.Get(), size );
         if ( dataHash == usedFiles[ i ].m_DataHash )
         {
             // file didn't change, update stored timestamp to save time on the next run
@@ -331,7 +331,7 @@ NodeGraph::LoadResult NodeGraph::Load( IOStream & stream, const char * nodeGraph
     else
     {
         // If the Environment will be overriden, make sure we use the LIB from that
-        const uint32_t libEnvVarHash = ( envStringSize > 0 ) ? xxHash::Calc32( libEnvVar ) : GetLibEnvVarHash();
+        const uint32_t libEnvVarHash = ( envStringSize > 0 ) ? FBuild::Hash32( libEnvVar ) : GetLibEnvVarHash();
         if ( libEnvVarHashInDB != libEnvVarHash )
         {
             // make sure the user knows why some things might re-build
@@ -1666,7 +1666,7 @@ uint32_t NodeGraph::GetLibEnvVarHash() const
     // ok for LIB var to be missing, we'll hash the empty string
     AStackString<> libVar;
     FBuild::Get().GetLibEnvVar( libVar );
-    return xxHash::Calc32( libVar );
+    return FBuild::Hash32( libVar );
 }
 
 // IsCleanPath

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1035,7 +1035,7 @@ const AString & ObjectNode::GetCacheName( Job * job ) const
 
     // hash the pre-processed intput data
     ASSERT( job->GetData() );
-    uint64_t a = xxHash::Calc64( job->GetData(), job->GetDataSize() );
+    uint64_t a = FBuild::Hash64( job->GetData(), job->GetDataSize() );
 
     // hash the build "environment"
     // TODO:B Exclude preprocessor control defines (the preprocessed input has considered those already)
@@ -1046,7 +1046,7 @@ const AString & ObjectNode::GetCacheName( Job * job ) const
         const bool showIncludes = false;
         const bool finalize = false; // Don't write args to reponse file
         BuildArgs( job, args, PASS_COMPILE_PREPROCESSED, useDeoptimization, showIncludes, finalize );
-        b = xxHash::Calc32( args.GetRawArgs().Get(), args.GetRawArgs().GetLength() );
+        b = FBuild::Hash32( args.GetRawArgs().Get(), args.GetRawArgs().GetLength() );
     }
 
     // ToolChain hash
@@ -1094,7 +1094,7 @@ bool ObjectNode::RetrieveFromCache( Job * job )
             uint64_t pchKey = 0;
             if ( GetFlag( FLAG_CREATING_PCH ) && GetFlag( FLAG_MSVC ) )
             {
-                pchKey = xxHash::Calc64( cacheData, cacheDataSize );
+                pchKey = FBuild::Hash64( cacheData, cacheDataSize );
             }
 
             // do decompression
@@ -1231,7 +1231,7 @@ void ObjectNode::WriteToCache( Job * job )
                 // Dependent objects need to know the PCH key to be able to pull from the cache
                 if ( GetFlag( FLAG_CREATING_PCH ) && GetFlag( FLAG_MSVC ) )
                 {
-                    m_PCHCacheKey = xxHash::Calc64( data, dataSize );
+                    m_PCHCacheKey = FBuild::Hash64( data, dataSize );
                 }
 
                 // Output
@@ -2010,7 +2010,7 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
     ASSERT( job->GetData() && job->GetDataSize() );
 
     Node * sourceFile = GetSourceFile();
-    uint32_t sourceNameHash = xxHash::Calc32( sourceFile->GetName().Get(), sourceFile->GetName().GetLength() );
+    uint32_t sourceNameHash = FBuild::Hash32( sourceFile->GetName().Get(), sourceFile->GetName().GetLength() );
 
     FileStream tmpFile;
     AStackString<> fileName( sourceFile->GetName().FindLast( NATIVE_SLASH ) + 1 );

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
@@ -7,6 +7,7 @@
 
 #include "CIncludeParser.h"
 
+#include "Tools/FBuild/FBuildCore/FBuild.h"
 #include "Tools/FBuild/FBuildCore/FLog.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
 
@@ -364,7 +365,7 @@ void CIncludeParser::AddInclude( const char * begin, const char * end )
     #endif
 
     // quick check
-    uint32_t crc1 = xxHash::Calc32( begin, end - begin );
+    uint32_t crc1 = FBuild::Hash32( begin, end - begin );
     if ( crc1 == m_LastCRC1 )
     {
         return;
@@ -384,10 +385,10 @@ void CIncludeParser::AddInclude( const char * begin, const char * end )
         // Windows and OSX are case-insensitive
         AStackString<> lowerCopy( cleanInclude );
         lowerCopy.ToLower();
-        uint32_t crc2 = xxHash::Calc32( lowerCopy );
+        uint32_t crc2 = FBuild::Hash32( lowerCopy );
     #else
         // Linux is case-sensitive
-        uint32_t crc2 = xxHash::Calc32( cleanInclude );
+        uint32_t crc2 = FBuild::Hash32( cleanInclude );
     #endif
     if ( crc2 == m_LastCRC2 )
     {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
@@ -6,6 +6,7 @@
 #include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
 
 #include "ToolManifest.h"
+#include "Tools/FBuild/FBuildCore/FBuild.h"
 
 // Core
 #include "Core/Containers/AutoPtr.h"
@@ -117,10 +118,10 @@ bool ToolManifest::Generate( const Node * mainExecutable, const AString& mainExe
         // file name & sub-path (relative to remote folder)
         AStackString<> relativePath;
         GetRemoteFilePath( (uint32_t)i, relativePath, false ); // false = don't use full path
-        *pos = xxHash::Calc32( relativePath );
+        *pos = FBuild::Hash32( relativePath );
         ++pos;
     }
-    m_ToolId = xxHash::Calc64( mem, memSize );
+    m_ToolId = FBuild::Hash64( mem, memSize );
     FREE( mem );
 
     // update time stamp (most recent file in manifest)
@@ -228,7 +229,7 @@ void ToolManifest::Deserialize( IOStream & ms, bool remote )
         {
             continue; // problem reading file
         }
-        if( xxHash::Calc32( mem.Get(), (size_t)f.GetFileSize() ) != m_Files[ i ].m_Hash )
+        if( FBuild::Hash32( mem.Get(), (size_t)f.GetFileSize() ) != m_Files[ i ].m_Hash )
         {
             continue; // file contents unexpected
         }
@@ -536,7 +537,7 @@ bool ToolManifest::AddFile( const Node * node )
     // create the file entry
     const AString & name = node->GetName();
     const uint64_t timeStamp = node->GetStamp();
-    const uint32_t hash = xxHash::Calc32( content, contentSize );
+    const uint32_t hash = FBuild::Hash32( content, contentSize );
     m_Files.Append( File(name, timeStamp, hash, node, contentSize ) );
 
     // store file content (take ownership of file data)


### PR DESCRIPTION
Hi,

This PR adds a .RootPath argument to Settings() function, which should point to current checkout directory. RootPath will be automagically replaced by a special char in hash input, making cache keys path agnostic : ie we can share cache between 2 different paths.

The PR is at prototype stage (no doc no tests) and this is  a brute force approach, but I was able to share the cache with just that and I would like to get your feedback.

Thanks!