### PR TITLE
Isolate files list for UnityNode

### DIFF
--- a/Code/Core/FileIO/IOStream.cpp
+++ b/Code/Core/FileIO/IOStream.cpp
@@ -58,4 +58,70 @@ void IOStream::AlignWrite( size_t alignment )
     ASSERT( ( Tell() % alignment ) == 0 );
 }
 
+// AlignWrite
+//------------------------------------------------------------------------------
+bool IOStream::ReadLines( Array< AString > & lines )
+{
+    const uint64_t size = GetFileSize();
+
+    const int bufferSize = 2048;
+    char buffer[2048];
+
+    uint64_t start = Tell();
+    uint64_t i = start;
+    for ( ; i<size ; ++i )
+    {
+        int8_t ch;
+        Read( ch );
+
+        uint64_t stop = start;
+
+        if ( ch  == '\n' || ch == '\r' )
+        {
+            stop = i;
+
+            if ( ch == '\r' )
+            {
+                Read( ch );
+                if ( ch != '\n' )
+                {
+                    Seek( i );
+                }
+                else
+                {
+                    i++;
+                }
+            }
+        }
+
+        ASSERT( start<=stop );
+
+        if ( start < stop )
+        {
+            const int b = int( stop - start );
+            lines.Append( AString( &buffer[0], &buffer[b] ) );
+            start = i+1;
+        }
+        else
+        {
+            const int b = int( i - start );
+            if ( b >= bufferSize )
+            {
+                ASSERT( false );
+                return false;
+            }
+
+            buffer[b] = char(ch);
+        }
+    }
+
+    if (start < i)
+    {
+        const int b = int( i - start );
+        lines.Append( AString( &buffer[0], &buffer[b] ) );
+    }
+
+    return true;
+}
+
 //------------------------------------------------------------------------------

--- a/Code/Core/FileIO/IOStream.h
+++ b/Code/Core/FileIO/IOStream.h
@@ -60,6 +60,8 @@ public:
     // manage memory-mapped aligned data
     void AlignRead( size_t alignment );
     void AlignWrite( size_t alignment );
+
+    bool ReadLines( Array< AString > & lines );
 };
 
 // Read ( Array< T > )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1487,6 +1487,10 @@ void ObjectNode::EmitCompilationMessage( const Args & fullArgs, bool useDeoptimi
         {
             output += "**Deoptimized** ";
         }
+		if ( GetFlag( FLAG_ISOLATED_FROM_UNITY ) )
+	    {
+        	output += "**Isolated** ";
+    	}
         output += GetName();
         if ( racingRemoteJob )
         {

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -233,7 +233,7 @@ UnityNode::~UnityNode()
                 numIsolated++;
                 filesInThisUnity.Top().SetIsolated( true );
 
-                FLOG_INFO( "Isolate file '%s' from unity", files[ index ].GetName().Get() );
+                FLOG_OUTPUT( "Isolate file '%s' from unity\n", files[ index ].GetName().Get() );
             }
 
             // count the file, whether we wrote it or not, to keep unity files stable
@@ -590,7 +590,7 @@ bool UnityNode::GetIsolatedFilesFromList( Array< AString > & files ) const
             }
             else
             {
-                FLOG_INFO( "Imported %u isolated files from list '%s'", (uint32_t)files.GetSize(), m_IsolateListFile.Get() );
+                FLOG_OUTPUT( "Imported %u isolated files from list '%s'\n", (uint32_t)files.GetSize(), m_IsolateListFile.Get() );
 
                 for ( AString& filename : files )
                 {

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -37,20 +37,27 @@ public:
         FileAndOrigin()
             : m_Info( nullptr )
             , m_DirListOrigin( nullptr )
+            , m_Isolated( false )
         {}
 
         FileAndOrigin( FileIO::FileInfo * info, DirectoryListNode * dirListOrigin )
             : m_Info( info )
             , m_DirListOrigin( dirListOrigin )
+            , m_Isolated( false )
         {}
 
         inline const AString &              GetName() const             { return m_Info->m_Name; }
         inline bool                         IsReadOnly() const          { return m_Info->IsReadOnly(); }
         inline const DirectoryListNode *    GetDirListOrigin() const    { return m_DirListOrigin; }
 
+        inline bool                         IsIsolated() const          { return m_Isolated; }
+        inline void                         SetIsolated( bool value )   { m_Isolated = value; }
+
+
     protected:
         FileIO::FileInfo *      m_Info;
         DirectoryListNode *     m_DirListOrigin;
+        bool                    m_Isolated;
     };
     inline const Array< FileAndOrigin > & GetIsolatedFileNames() const { return m_IsolatedFiles; }
 
@@ -62,6 +69,7 @@ private:
     virtual bool IsAFile() const override { return false; }
 
     bool GetFiles( Array< FileAndOrigin > & files );
+    bool GetIsolatedFilesFromList( Array< AString > & files ) const;
     void FilterForceIsolated( Array< FileAndOrigin > & files, Array< FileAndOrigin > & isolatedFiles );
 
     // Exposed properties
@@ -79,6 +87,7 @@ private:
     Array< AString > m_FilesToIsolate;
     bool m_IsolateWritableFiles;
     uint32_t m_MaxIsolatedFiles;
+    AString m_IsolateListFile;
     Array< AString > m_ExcludePatterns;
     Array< FileAndOrigin > m_IsolatedFiles;
     Array< AString > m_PreBuildDependencyNames;


### PR DESCRIPTION
Hi,

This PR adds an optional field "UnityInputIsolateListFile" to Unity() functon.
It should point to a file containing a list of files which will be isolated from the unity builds, following the same behavior than writable files when "UnityInputIsolateWritableFiles" is true.
The list must contain absolute paths, and will be read at each execution of FastBuild, allowing it's content to change without unnecessarily invalidating the fdb.

Using this new option a developer can feed fastbuild with an external tool to drive unity builds, like git :)
By filling the specified files with modified files (for instance with a simple wrapper around fbuild.exe), git users can use this feature reserved to this day to Perforce users without putting the burden of handling every SCM on FastBuild.

This PR is not complete yet as it lacks documentation, and maybe a cache to avoid reading the external file every time when using several unity nodes with the same list.
