### PR TITLE
Adding the prx compiler linker pass through argument for detecting a dll node

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -612,7 +612,7 @@ void LinkerNode::GetAssemblyResourceFiles( Args & fullArgs, const AString & pre,
         for ( const AString * it=tokens.Begin(); it!=end; ++it )
         {
             const AString & token = *it;
-            if ( ( token == "-shared" ) || ( token == "-dynamiclib" ) || ( token == "--oformat=prx" ) )
+            if ( ( token == "-shared" ) || ( token == "-dynamiclib" ) || ( token == "--oformat=prx" ) || ( token == "-Wl,--oformat=prx" ) )
             {
                 flags |= LinkerNode::LINK_FLAG_DLL;
                 continue;


### PR DESCRIPTION
The orbis-clang compiler allows users to use the same executable to call
the linker but linker options need to be prefixed "-Wl," so fastbuild
doesn't see that "--oformat=prx" is used because of the extra "-Wl,"
characters before it.