### PR TITLE
Add -quiet option

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -100,6 +100,7 @@ int Main(int argc, char * argv[])
     bool cleanBuild = false;
     bool verbose = false;
     bool progressBar = true;
+    bool quiet = false;
     bool useCacheRead = false;
     bool useCacheWrite = false;
     bool allowDistributed = false;
@@ -232,6 +233,7 @@ int Main(int argc, char * argv[])
             else if ( thisArg == "-verbose" )
             {
                 verbose = true;
+                quiet = false;
                 continue;
             }
             else if ( thisArg == "-version" )
@@ -246,6 +248,12 @@ int Main(int argc, char * argv[])
                     fixupErrorPaths = true;
                     wrapperMode = WRAPPER_MODE_MAIN_PROCESS;
                 #endif
+                continue;
+            }
+            else if ((thisArg == "-quiet"))
+            {
+                quiet = true;
+                verbose = false;
                 continue;
             }
             else if ( thisArg == "-wait" )
@@ -404,6 +412,7 @@ int Main(int argc, char * argv[])
 
     options.m_ShowProgress = progressBar;
     options.m_ShowInfo = verbose;
+    options.m_ShowBuildCommands = !quiet;
     options.m_ShowCommandLines = showCommands;
     options.m_UseCacheRead = useCacheRead;
     options.m_UseCacheWrite = useCacheWrite;
@@ -503,6 +512,7 @@ void DisplayHelp()
             "                as possible.\n"
             " -report        Ouput a detailed report at the end of the build,\n"
             "                to report.html.  This will lengthen the total build\n"
+            " -quiet         Don't show build output.\n"
             "                time.\n"
             " -showcmds      Show command lines used to launch external processes.\n"
             " -showtargets   Display list of primary build targets.\n"

--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -495,12 +495,12 @@ void DisplayHelp()
             "Options:\n"
             " -cache[read|write] Control use of the build cache.\n"
             " -clean         Force a clean build.\n"
-            " -config [path] Explicitly specify the config file to use\n" );
+            " -config [path] Explicitly specify the config file to use.\n" );
 #ifdef DEBUG
     OUTPUT( " -debug         Break at startup, to attach debugger.\n" );
 #endif
     OUTPUT( " -dist          Allow distributed compilation.\n"
-            " -fixuperrorpaths Reformat error paths to be VisualStudio friendly.\n"
+            " -fixuperrorpaths Reformat error paths to be Visual Studio friendly.\n"
             " -help          Show this help.\n"
             " -ide           Enable multiple options when building from an IDE.\n"
             "                Enables: -noprogress, -fixuperrorpaths &\n"
@@ -508,11 +508,11 @@ void DisplayHelp()
             " -j[x]          Explicitly set LOCAL worker thread count X, instead of\n"
             "                default of hardware thread count.\n"
             " -noprogress    Don't show the progress bar while building.\n"
-            " -nostoponerror Don't stop building on first error. Try to build as much"
+            " -nostoponerror Don't stop building on first error. Try to build as much\n"
             "                as possible.\n"
-            " -report        Ouput a detailed report at the end of the build,\n"
-            "                to report.html.  This will lengthen the total build\n"
             " -quiet         Don't show build output.\n"
+            " -report        Ouput a detailed report at the end of the build.\n"
+            "                to report.html. This will lengthen the total build\n"
             "                time.\n"
             " -showcmds      Show command lines used to launch external processes.\n"
             " -showtargets   Display list of primary build targets.\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -92,6 +92,7 @@ FBuild::FBuild( const FBuildOptions & options )
 
     // poke options where required
     FLog::SetShowInfo( m_Options.m_ShowInfo );
+    FLog::SetShowBuildCommands( m_Options.m_ShowBuildCommands );
     FLog::SetShowErrors( m_Options.m_ShowErrors );
     FLog::SetShowProgress( m_Options.m_ShowProgress );
     FLog::SetMonitorEnabled( m_Options.m_EnableMonitor );

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -22,6 +22,7 @@ public:
     bool m_UseCacheWrite;
     bool m_ShowInfo;
     bool m_ShowCommandLines;
+    bool m_ShowBuildCommands;
     bool m_ShowErrors;
     bool m_ShowProgress;
     bool m_AllowDistributed;

--- a/Code/Tools/FBuild/FBuildCore/FLog.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FLog.cpp
@@ -37,6 +37,7 @@
 // Static Data
 //------------------------------------------------------------------------------
 /*static*/ bool FLog::s_ShowInfo = false;
+/*static*/ bool FLog::s_ShowBuildCommands = true;
 /*static*/ bool FLog::s_ShowErrors = true;
 /*static*/ bool FLog::s_ShowProgress = false;
 /*static*/ bool FLog::s_MonitorEnabled = false;

--- a/Code/Tools/FBuild/FBuildCore/FLog.h
+++ b/Code/Tools/FBuild/FBuildCore/FLog.h
@@ -21,14 +21,20 @@
 
 #define FLOG_BUILD( fmtString, ... )                \
     do {                                            \
-        FLog::Build( fmtString, ##__VA_ARGS__ );    \
+        if ( FLog::ShowBuildCommands() )            \
+        {                                           \
+          FLog::Build( fmtString, ##__VA_ARGS__ );  \
+        }                                           \
     PRAGMA_DISABLE_PUSH_MSVC(4127)                  \
     } while ( false );                              \
     PRAGMA_DISABLE_POP_MSVC
 
 #define FLOG_BUILD_DIRECT( message )                \
     do {                                            \
-        FLog::BuildDirect( message );               \
+        if ( FLog::ShowBuildCommands() )            \
+        {                                           \
+          FLog::BuildDirect( message );             \
+        }                                           \
     PRAGMA_DISABLE_PUSH_MSVC(4127)                  \
     } while ( false );                              \
     PRAGMA_DISABLE_POP_MSVC
@@ -70,6 +76,7 @@ class FLog
 {
 public:
     inline static bool ShowInfo() { return s_ShowInfo; }
+    inline static bool ShowBuildCommands() { return s_ShowBuildCommands; }
     inline static bool ShowErrors() { return s_ShowErrors; }
     inline static bool IsMonitorEnabled() { return s_MonitorEnabled; }
 
@@ -91,6 +98,7 @@ public:
 private:
     friend class FBuild;
     static inline void SetShowInfo( bool showInfo ) { s_ShowInfo = showInfo; }
+    static inline void SetShowBuildCommands( bool showBuildCommands ) { s_ShowBuildCommands = showBuildCommands;}
     static inline void SetShowErrors( bool showErrors ) { s_ShowErrors = showErrors; }
     static inline void SetShowProgress( bool showProgress ) { s_ShowProgress = showProgress; }
     static inline void SetMonitorEnabled( bool enabled ) { s_MonitorEnabled = enabled; }
@@ -100,6 +108,7 @@ private:
     static bool TracingOutputCallback( const char * message );
 
     static bool s_ShowInfo;
+    static bool s_ShowBuildCommands;
     static bool s_ShowErrors;
     static bool s_ShowProgress;
     static bool s_MonitorEnabled;


### PR DESCRIPTION
This option suppresses build command output, but will still show the progress bar, unless that is explicitly disabled with its respective option.

Also, I cleaned up a few typos in the `-help` text.