### PR TITLE
treat C1001 (internal compiler error) as system error

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2170,6 +2170,14 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
                 }
             }
 
+            // Internal compiler error is a system error; usually caused by
+            // hardware issues.
+            if ( stdOut && strstr( stdOut, "C1001" ) )
+            {
+                job->OnSystemError();
+                return;
+            }
+
             // Error messages above also contains this text
             // (We check for this message additionally to handle other error codes
             //  that may not have been observed yet)


### PR DESCRIPTION
Error C1001 may be caused by bugs in the compiler, but most of the time it
is a sign of faulty hardware. We do not want a single malfunctioning host
to cause all compilations to fail, so treat these as system errors.