### PR TITLE
This change adds support for generating usable Visual Studio 2015 .androidproj projects via the FastBuild VCXProject Function…

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionVCXProject.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionVCXProject.cpp
@@ -155,7 +155,10 @@ FunctionVCXProject::FunctionVCXProject()
     if ( !GetString( funcStartIter, baseConfig.m_BuildCommand,  ".ProjectBuildCommand", false ) ||
          !GetString( funcStartIter, baseConfig.m_RebuildCommand,".ProjectRebuildCommand", false ) ||
          !GetString( funcStartIter, baseConfig.m_CleanCommand,  ".ProjectCleanCommand", false ) ||
+         !GetString( funcStartIter, baseConfig.m_TargetName,    ".TargetName", false ) ||
+         !GetString( funcStartIter, baseConfig.m_TargetExt,     ".TargetExtension", false ) ||
          !GetString( funcStartIter, baseConfig.m_Output,        ".Output", false ) ||
+         !GetString( funcStartIter, baseConfig.m_AdditionalIncludePaths,    ".AdditionalIncludeDirectories", false ) ||
          !GetString( funcStartIter, baseConfig.m_PreprocessorDefinitions,   ".PreprocessorDefinitions", false ) ||
          !GetString( funcStartIter, baseConfig.m_IncludeSearchPath,     ".IncludeSearchPath", false ) ||
          !GetString( funcStartIter, baseConfig.m_ForcedIncludes,        ".ForcedIncludes", false ) ||
@@ -172,10 +175,17 @@ FunctionVCXProject::FunctionVCXProject()
          !GetString( funcStartIter, baseConfig.m_PlatformToolset,       ".PlatformToolset", false ) ||
          !GetString( funcStartIter, baseConfig.m_DeploymentType,        ".DeploymentType", false ) ||
          !GetString( funcStartIter, baseConfig.m_DeploymentFiles,       ".DeploymentFiles", false ) ||
+         !GetString( funcStartIter, baseConfig.m_PackagePath,           ".PackagePath", false ) ||
+         !GetString( funcStartIter, baseConfig.m_LaunchActivity,        ".LaunchActivity", false ) ||
+         !GetString( funcStartIter, baseConfig.m_PlatformIncludePattern,        ".PlatformIncludePattern", false ) ||
+         !GetString( funcStartIter, baseConfig.m_TargetArchitectureAlias,       ".TargetArchitectureAlias", false ) ||
+         !GetString( funcStartIter, baseConfig.m_AdditionalSymbolSearchPaths,   ".AdditionalSymbolSearchPaths", false ) ||
          !GetString( funcStartIter, baseConfig.m_LocalDebuggerCommandArguments, ".LocalDebuggerCommandArguments", false ) ||
          !GetString( funcStartIter, baseConfig.m_LocalDebuggerWorkingDirectory, ".LocalDebuggerWorkingDirectory", false ) ||
          !GetString( funcStartIter, baseConfig.m_LocalDebuggerCommand,          ".LocalDebuggerCommand", false ) ||
-         !GetString( funcStartIter, baseConfig.m_LocalDebuggerEnvironment,      ".LocalDebuggerEnvironment", false ) )
+         !GetString( funcStartIter, baseConfig.m_LocalDebuggerEnvironment,      ".LocalDebuggerEnvironment", false ) ||
+         !GetString( funcStartIter, baseConfig.m_WebBrowserDebuggerHttpUrl,     ".WebBrowserDebuggerHttpUrl", false ) ||
+         !GetString( funcStartIter, baseConfig.m_ProjectBuildType,      ".ProjectBuildType", false ) )
     {
         return false;
     }
@@ -217,6 +227,9 @@ FunctionVCXProject::FunctionVCXProject()
                 return false;
             }
 
+            GetStringFromStruct( s, ".TargetName",      newConfig.m_TargetName );
+            GetStringFromStruct( s, ".TargetExtension", newConfig.m_TargetExt );
+
             // .Target is optional
             AStackString<> target;
             if ( GetStringFromStruct( s, ".Target", target ) )
@@ -236,6 +249,7 @@ FunctionVCXProject::FunctionVCXProject()
             GetStringFromStruct( s, ".ProjectRebuildCommand",   newConfig.m_RebuildCommand );
             GetStringFromStruct( s, ".ProjectCleanCommand",     newConfig.m_CleanCommand );
             GetStringFromStruct( s, ".Output",                  newConfig.m_Output );
+            GetStringFromStruct( s, ".AdditionalIncludeDirectories",	newConfig.m_AdditionalIncludePaths );
             GetStringFromStruct( s, ".PreprocessorDefinitions", newConfig.m_PreprocessorDefinitions );
             GetStringFromStruct( s, ".IncludeSearchPath",       newConfig.m_IncludeSearchPath );
             GetStringFromStruct( s, ".ForcedIncludes",          newConfig.m_ForcedIncludes );
@@ -252,10 +266,17 @@ FunctionVCXProject::FunctionVCXProject()
             GetStringFromStruct( s, ".PlatformToolset",         newConfig.m_PlatformToolset );
             GetStringFromStruct( s, ".DeploymentType",          newConfig.m_DeploymentType );
             GetStringFromStruct( s, ".DeploymentFiles",         newConfig.m_DeploymentFiles );
+            GetStringFromStruct( s, ".PackagePath",             newConfig.m_PackagePath );
+            GetStringFromStruct( s, ".LaunchActivity",          newConfig.m_LaunchActivity );
+            GetStringFromStruct( s, ".PlatformIncludePattern",  newConfig.m_PlatformIncludePattern );
+            GetStringFromStruct( s, ".TargetArchitectureAlias", newConfig.m_TargetArchitectureAlias );
+            GetStringFromStruct( s, ".AdditionalSymbolSearchPaths",     newConfig.m_AdditionalSymbolSearchPaths );
             GetStringFromStruct( s, ".LocalDebuggerCommandArguments",   newConfig.m_LocalDebuggerCommandArguments );
             GetStringFromStruct( s, ".LocalDebuggerWorkingDirectory",   newConfig.m_LocalDebuggerWorkingDirectory );
             GetStringFromStruct( s, ".LocalDebuggerCommand",            newConfig.m_LocalDebuggerCommand );
             GetStringFromStruct( s, ".LocalDebuggerEnvironment",        newConfig.m_LocalDebuggerEnvironment );
+            GetStringFromStruct( s, ".WebBrowserDebuggerHttpUrl",       newConfig.m_WebBrowserDebuggerHttpUrl );
+            GetStringFromStruct( s, ".ProjectBuildType",        newConfig.m_ProjectBuildType );
 
             configs.Append( newConfig );
         }

--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
@@ -27,7 +27,7 @@ SLNGenerator::SLNGenerator() = default;
 //------------------------------------------------------------------------------
 SLNGenerator::~SLNGenerator() = default;
 
-// GenerateVCXProj
+// GenerateSLN
 //------------------------------------------------------------------------------
 const AString & SLNGenerator::GenerateSLN( const AString & solutionFile,
                                            const AString & solutionBuildProject,
@@ -175,8 +175,19 @@ void SLNGenerator::WriteProjectListings( const AString& solutionBasePath,
             solutionBuildProjectGuid = projectGuid;
         }
 
-        Write( "Project(\"{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}\") = \"%s\", \"%s\", \"%s\"\r\n",
-               projectName.Get(), projectPath.Get(), projectGuid.Get() );
+        const bool writeAndroidProj = projectPath.EndsWithI( ".androidproj" );
+        if ( writeAndroidProj )
+        {
+            // This is a GUID which works for .androidprojs (found this out the hard way by hand)
+            Write( "Project(\"{39E2626F-3545-4960-A6E8-258AD8476CE5}\") = \"%s\", \"%s\", \"%s\"\r\n",
+                   projectName.Get(), projectPath.Get(), projectGuid.Get() );
+        }
+        else
+        {
+            // Use the default fastbuild C++ .vcxproj GUID
+            Write( "Project(\"{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}\") = \"%s\", \"%s\", \"%s\"\r\n",
+                   projectName.Get(), projectPath.Get(), projectGuid.Get() );
+        }
 
         // Manage dependencies
         Array< AString > dependencyGUIDs( 64, true );

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
@@ -8,7 +8,9 @@
 #include "VSProjectGenerator.h"
 
 // FBuildCore
+#include "Tools/FBuild/FBuildCore/FBuild.h" // for GetEnvironmentString
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+#include "Tools/FBuild/FBuildCore/Graph/CompilerNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/ObjectListNode.h"
 #include "Tools/FBuild/FBuildCore/Helpers/ProjectGeneratorBase.h" // TODO:C Remove when VSProjectGenerator derives from ProjectGeneratorBase
 
@@ -86,6 +88,48 @@ void VSProjectGenerator::AddFiles( const Array< AString > & files )
     guid.Format( "{%08x-6c94-4f93-bc2a-7f5284b7d434}", CRC32::Calc( projectNameNormalized ) );
 }
 
+// IsFilenameAHeaderFile
+//------------------------------------------------------------------------------
+static inline const bool IsFilenameAHeaderFile( const AString & fileName )
+{
+    // TODO: Add support for other header types?
+    return ( fileName.EndsWith( 'h' ) || fileName.EndsWith( ".hpp" ) || fileName.EndsWith( ".hxx" ) || fileName.EndsWith( ".inl" ) );
+}
+
+static inline const bool ShouldWeSkipThisPlatform( const AString & platformIncludePattern, const AString & platform )
+{
+    // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, return true [So we can skip emitting this platform to the .vcxproj]
+    const char *thisPlatformIncludePattern = platformIncludePattern.Get();
+    ASSERT( (thisPlatformIncludePattern != nullptr) && (platformIncludePattern != "") );
+    return ( (!platformIncludePattern.IsEmpty()) && (!platform.Find( thisPlatformIncludePattern )) );
+}
+
+static inline const char* GetPossiblyAliasedPlatformStringInUppercase( const AString & targetArchitectureAlias, const AString & platform )
+{
+    // Handle Platform Aliases - these define new platforms and alias existing platforms to them
+    if( !targetArchitectureAlias.IsEmpty() )
+    {
+        const char *thisPlatformAlias = targetArchitectureAlias.Get();
+        ASSERT( (thisPlatformAlias != nullptr) && (targetArchitectureAlias != "") );
+        AStackString<>							thisPlatformAliasString( thisPlatformAlias );
+                                                thisPlatformAliasString.ToUpper();
+        const char *thisPlatformAliasUpper =	thisPlatformAliasString.Get();
+        return thisPlatformAliasUpper;
+    }
+    return platform.Get();
+}
+
+static inline const char* GetPossiblyAliasedPlatformString( const AString & targetArchitectureAlias, const AString & platform )
+{
+    // Handle Platform Aliases - these define new platforms and alias existing platforms to them
+    if( !targetArchitectureAlias.IsEmpty() )
+    {
+        ASSERT( (targetArchitectureAlias.Get() != nullptr) && (targetArchitectureAlias != "") );
+        return targetArchitectureAlias.Get();
+    }
+    return platform.Get();
+}
+
 // GenerateVCXProj
 //------------------------------------------------------------------------------
 const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile,
@@ -102,9 +146,16 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
     const char * lastSlash = projectFile.FindLast( NATIVE_SLASH );
     AStackString<> projectBasePath( projectFile.Get(), lastSlash ? lastSlash + 1 : projectFile.Get() );
 
+    const bool writeCSProj		= projectFile.EndsWithI( ".csproj" );
+    const bool writeAndroidProj = projectFile.EndsWithI( ".androidproj" );
+
+    // Don't write a custom build command by default, because as of Visual Studio 2015 R3, Makefile projects can't currently utilize this functionality
+    // However, if we have a Utility project, then we can execute per-file custom build steps
+    bool writeCustomBuildCommands = false;
+
     // header
     Write( "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" );
-    Write( "<Project DefaultTargets=\"Build\" ToolsVersion=\"4.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n" );
+    Write( "<Project DefaultTargets=\"Build\" ToolsVersion=\"14.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n" );
 
     // Project Configurations
     {
@@ -112,16 +163,52 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         const VSProjectConfig * const cEnd = configs.End();
         for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
         {
-            Write( "    <ProjectConfiguration Include=\"%s|%s\">\n", cIt->m_Config.Get(), cIt->m_Platform.Get() );
-            Write( "      <Configuration>%s</Configuration>\n", cIt->m_Config.Get() );
-            Write( "      <Platform>%s</Platform>\n", cIt->m_Platform.Get() );
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            const char *thisPlatform = GetPossiblyAliasedPlatformString( cIt->m_TargetArchitectureAlias, cIt->m_Platform );
+            const char *thisConfiguration = cIt->m_Config.Get();
+
+            // Handle Platform Aliases - these define new platforms and alias existing platforms to them
+            if( !cIt->m_TargetArchitectureAlias.IsEmpty() )
+            {
+                const char *thisPlatformAliasUpper	= GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform );
+                const char *thisPlatformAlias		= thisPlatform;
+
+                Write( "    <ProjectConfiguration Include=\"%s|%s\">\n", thisConfiguration, thisPlatformAliasUpper );
+                Write( "      <Configuration>%s</Configuration>\n", thisConfiguration );
+                Write( "      <Platform>%s</Platform>\n", thisPlatformAlias );
+                Write( "      <TargetArchitecture>%s</TargetArchitecture>\n", thisPlatformAlias );
+                Write( "    </ProjectConfiguration>\n" );
+            }
+
+            Write( "    <ProjectConfiguration Include=\"%s|%s\">\n", thisConfiguration, cIt->m_Platform.Get() );	// We're explicitly using cIt->m_Platform.Get() here. We do not want to use thisPlatform, because it may be == thisPlatformAlias.
+            Write( "      <Configuration>%s</Configuration>\n", thisConfiguration );
+            Write( "      <Platform>%s</Platform>\n", thisPlatform );												// We're explicitly using thisPlatform (which may be == thisPlatformAlias) here.
             Write( "    </ProjectConfiguration>\n" );
+
+            // Don't write a custom build command by default, because as of Visual Studio 2015 R3, Makefile projects can't currently utilize this functionality
+            if ( !cIt->m_ProjectBuildType.IsEmpty( ) )
+            {
+                if ( cIt->m_ProjectBuildType == "Utility" )
+                {
+                    // Visual Studio Utility Projects Can Execute Per-File Custom Build Steps
+                    writeCustomBuildCommands = true;
+                }
+            }
+
         }
+
         Write( "  </ItemGroup>\n" );
     }
 
     // files
+    if( !writeAndroidProj ) // We don't need files in .androidproj, because VS ignores them anyway
     {
+        const char * environment = FBuild::Get( ).GetEnvironmentString( );
         Write("  <ItemGroup>\n" );
         const AString * const fEnd = m_Files.End();
         for ( const AString * fIt = m_Files.Begin(); fIt!=fEnd; ++fIt )
@@ -137,17 +224,51 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
                     break;
                 }
             }
+
+            const bool   isHeader = IsFilenameAHeaderFile( *fIt );
+            const char * includeTypeString = isHeader ? "ClInclude" : "CustomBuild";
+            Write( "    <%s Include=\"%s\">\n", includeTypeString, fileName );
             if ( fileType )
             {
-                Write( "    <CustomBuild Include=\"%s\">\n", fileName );
                 Write( "        <FileType>%s</FileType>\n", fileType );
-                Write( "    </CustomBuild>\n" );
             }
-            else
+
+            if ( writeCustomBuildCommands && !isHeader )
             {
-                Write( "    <CustomBuild Include=\"%s\" />\n", fileName );
+                // Build Command [Conditional]
+                Write( "        <Message>Compiling %%(Identity)</Message>\n" );
+                const VSProjectConfig * const cEnd = configs.End( );
+                for ( const VSProjectConfig * cIt = configs.Begin( ); cIt != cEnd; ++cIt )
+                {
+                    // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+                    if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+                    {
+                        continue;
+                    }
+
+                    const ObjectListNode * oln = ProjectGeneratorBase::FindTargetForIntellisenseInfo( cIt->m_Target );
+                    if ( oln != nullptr )
+                    {
+                        AString my_compilerName( ( oln != nullptr ) ? oln->GetCompiler( )->GetName( ).Get( ) : "error: compiler unknown" );
+                        AString my_compilerOptions( ( oln != nullptr ) ? oln->GetCompilerOptions( ).Get( ) : "error: compiler options unknown" );
+
+                        my_compilerOptions.Replace( "%1", "%(FullPath)" );
+                        my_compilerOptions.Replace( "%2", "$(OutDir)%(Identity).obj" );
+
+                        Write( "        <Command Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">@echo on &amp; SET %s; &amp; %s %s</Command>\n", cIt->m_Config.Get( ), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ), environment, my_compilerName.Get( ), my_compilerOptions.Get( ) );
+                    }
+                    else
+                    {
+                        Write( "        <Command Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">echo FastBuild VSProjectGenerator.cpp Failed To Generate Command</Command>\n", cIt->m_Config.Get( ), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ) );
+                    }
+                }
+
+                Write( "        <Outputs>$(OutDir)%%(Identity).obj</Outputs>\n" );
             }
+
+            Write( "    </%s>\n", includeTypeString );
         }
+
         Write("  </ItemGroup>\n" );
     }
 
@@ -197,6 +318,63 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         guid = m_ProjectGuid;
     }
 
+    if ( writeAndroidProj )
+    {
+        // Globals
+        Write( "  <PropertyGroup Label=\"Globals\">\n" );
+        Write( "    <DisableReferencesFolder>true</DisableReferencesFolder>\n" );
+        Write( "    <UseDefaultPropertyPageSchemas>false</UseDefaultPropertyPageSchemas>\n" );
+        Write( "    <RootNamespace>Android11</RootNamespace>\n" );
+        Write( "    <ProjectVersion>1.0</ProjectVersion>\n" );
+        WritePGItem( "ProjectGuid", guid );
+        Write( "    <ApkDebuggingProject>true</ApkDebuggingProject>\n" );
+        Write( "    <DebuggerFlavor>AndroidDebugger</DebuggerFlavor>\n" );
+
+        const VSProjectConfig * const cEnd = configs.End();
+        for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
+        {
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            const char *thisConfig = cIt->m_Config.Get();
+            const char *thisPlatform = GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform );
+
+            Write( "    <PackagePath Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">%s</PackagePath>\n", thisConfig, thisPlatform, cIt->m_PackagePath.Get() );
+            Write( "    <LaunchActivity Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">%s</LaunchActivity>\n", thisConfig, thisPlatform, cIt->m_LaunchActivity.Get() );
+            Write( "    <AdditionalSymbolSearchPaths Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">%s</AdditionalSymbolSearchPaths>\n", thisConfig, thisPlatform, cIt->m_AdditionalSymbolSearchPaths.Get() );
+            Write( "    <AdditionalSourceSearchPaths Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">%s</AdditionalSourceSearchPaths>\n", thisConfig, thisPlatform, cIt->m_AdditionalIncludePaths.Get() );
+        }
+
+        Write( "  </PropertyGroup>\n" );
+
+        Write( "  <Import Project=\"$(AndroidTargetsPath)\\Android.Default.props\" />\n" );
+        Write( "  <Import Project=\"$(AndroidTargetsPath)\\Android.props\" />\n" );
+        Write( "  <Import Project=\"$(AndroidTargetsPath)\\Android.targets\" />\n" );
+
+        Write( "  <Target Name=\"Build\" />\n" );
+        Write( "  <Target Name=\"Clean\" />\n" );
+        Write( "  <Target Name=\"Rebuild\" />\n" );
+
+        Write( "  <ItemGroup>\n" );
+        Write( "    <PropertyPageSchema Include=\"$(XamlDirectory)\\ProjectItemsSchema.xaml\" />\n" );
+        Write( "    <PropertyPageSchema Include=\"$(XamlDirectory)\\AndroidDebugger.xaml\">\n" );
+        Write( "      <Context>Project</Context>\n" );
+        Write( "    </PropertyPageSchema>\n" );
+        Write( "    <PropertyPageSchema Include=\"$(XamlDirectory)\\folder.xaml\">\n" );
+        Write( "      <Context>File;BrowseObject</Context>\n" );
+        Write( "    </PropertyPageSchema>\n" );
+        Write( "    <PropertyPageSchema Include=\"$(XamlDirectory)\\DebuggerGeneral.xaml\" />\n" );
+        Write( "  </ItemGroup>\n" );
+
+        Write( "</Project>" ); // carriage return at end
+
+        m_OutputVCXProj = m_Tmp;
+        return m_OutputVCXProj;
+    }
+
     // Globals
     Write( "  <PropertyGroup Label=\"Globals\">\n" );
     WritePGItem( "RootNamespace", m_RootNamespace );
@@ -214,14 +392,30 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         const VSProjectConfig * const cEnd = configs.End();
         for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
         {
-            Write( "  <PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\" Label=\"Configuration\">\n", cIt->m_Config.Get(), cIt->m_Platform.Get() );
-            Write( "    <ConfigurationType>Makefile</ConfigurationType>\n" );
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            Write( "  <PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\" Label=\"Configuration\">\n", cIt->m_Config.Get(), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ) );
+
+            if( !cIt->m_ProjectBuildType.IsEmpty( ) )
+            {
+                WritePGItem( "ConfigurationType", cIt->m_ProjectBuildType );
+            }
+            else
+            {
+                Write( "    <ConfigurationType>Makefile</ConfigurationType>\n" );
+            }
+
             Write( "    <UseDebugLibraries>false</UseDebugLibraries>\n" );
 
             WritePGItem( "PlatformToolset",                 cIt->m_PlatformToolset );
             WritePGItem( "LocalDebuggerCommandArguments",   cIt->m_LocalDebuggerCommandArguments );
             WritePGItem( "LocalDebuggerCommand",            cIt->m_LocalDebuggerCommand );
             WritePGItem( "LocalDebuggerEnvironment",        cIt->m_LocalDebuggerEnvironment );
+            WritePGItem( "WebBrowserDebuggerHttpUrl",		cIt->m_WebBrowserDebuggerHttpUrl );
 
             Write( "  </PropertyGroup>\n" );
         }
@@ -239,7 +433,13 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         const VSProjectConfig * const cEnd = configs.End();
         for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
         {
-            Write( "  <ImportGroup Label=\"PropertySheets\" Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), cIt->m_Platform.Get() );
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            Write( "  <ImportGroup Label=\"PropertySheets\" Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ) );
             Write( "    <Import Project=\"$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props\" Condition=\"exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')\" Label=\"LocalAppDataPlatform\" />\n" );
             Write( "  </ImportGroup>\n" );
         }
@@ -253,12 +453,28 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         const VSProjectConfig * const cEnd = configs.End();
         for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
         {
-            Write( "  <PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), cIt->m_Platform.Get() );
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            Write( "  <PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ) );
 
             WritePGItem( "NMakeBuildCommandLine",           cIt->m_BuildCommand );
             WritePGItem( "NMakeReBuildCommandLine",         cIt->m_RebuildCommand );
             WritePGItem( "NMakeCleanCommandLine",           cIt->m_CleanCommand );
             WritePGItem( "NMakeOutput",                     cIt->m_Output );
+            WritePGItem( "TargetName",                      cIt->m_TargetName );
+            WritePGItem( "TargetExt",                       cIt->m_TargetExt );
+
+            AStackString<> vsIncludeSearchPath;
+            if ( !cIt->m_AdditionalIncludePaths.IsEmpty( ) )
+            {
+                vsIncludeSearchPath = cIt->m_AdditionalIncludePaths;
+                vsIncludeSearchPath += "$(IncludePath);";
+                WritePGItem( "IncludePath", vsIncludeSearchPath );
+            }
 
             const ObjectListNode * oln = nullptr;
             if ( cIt->m_PreprocessorDefinitions.IsEmpty() || cIt->m_IncludeSearchPath.IsEmpty() )
@@ -323,7 +539,13 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         const VSProjectConfig * const cEnd = configs.End();
         for ( const VSProjectConfig * cIt = configs.Begin(); cIt!=cEnd; ++cIt )
         {
-            Write( "  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), cIt->m_Platform.Get() );
+            // If we have a .PlatformIncludePattern filter defined, and this platform doesn't match it, then skip emitting this platform to the .vcxproj
+            if( ShouldWeSkipThisPlatform( cIt->m_PlatformIncludePattern, cIt->m_Platform ) )
+            {
+                continue;
+            }
+
+            Write( "  <ItemDefinitionGroup Condition=\"'$(Configuration)|$(Platform)'=='%s|%s'\">\n", cIt->m_Config.Get(), GetPossiblyAliasedPlatformStringInUppercase( cIt->m_TargetArchitectureAlias, cIt->m_Platform ) );
             Write( "    <BuildLog>\n" );
             Write( "      <Path />\n" );
             Write( "    </BuildLog>\n" );
@@ -378,12 +600,14 @@ const AString & VSProjectGenerator::GenerateVCXProjFilters( const AString & proj
             AStackString<> folder;
             GetFolderPath( *fIt, folder );
             const char * fileName = fIt->BeginsWithI( projectBasePath ) ? fIt->Get() + projectBasePath.GetLength() : fIt->Get();
-            Write( "    <CustomBuild Include=\"%s\">\n", fileName );
+            const char * includeTypeString = IsFilenameAHeaderFile( *fIt ) ? "ClInclude" : "CustomBuild";
+
+            Write( "    <%s Include=\"%s\">\n", includeTypeString, fileName );
             if ( !folder.IsEmpty() )
             {
                 Write( "      <Filter>%s</Filter>\n", folder.Get() );
             }
-            Write( "    </CustomBuild>\n" );
+            Write( "    </%s>\n", includeTypeString );
 
             // add new folders
             if ( !folder.IsEmpty() )
@@ -517,7 +741,11 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
         stream.Write( cfg.m_RebuildCommand );
         stream.Write( cfg.m_CleanCommand );
 
+        stream.Write( cfg.m_TargetName );
+        stream.Write( cfg.m_TargetExt );
+
         stream.Write( cfg.m_Output );
+        stream.Write( cfg.m_AdditionalIncludePaths );
         stream.Write( cfg.m_PreprocessorDefinitions );
         stream.Write( cfg.m_IncludeSearchPath );
         stream.Write( cfg.m_ForcedIncludes );
@@ -534,11 +762,19 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
         stream.Write( cfg.m_PlatformToolset );
         stream.Write( cfg.m_DeploymentType );
         stream.Write( cfg.m_DeploymentFiles );
+        stream.Write( cfg.m_PackagePath );
+        stream.Write( cfg.m_LaunchActivity );
+        stream.Write( cfg.m_PlatformIncludePattern );
+        stream.Write( cfg.m_TargetArchitectureAlias );
+        stream.Write( cfg.m_AdditionalSymbolSearchPaths );
 
         stream.Write( cfg.m_LocalDebuggerCommandArguments );
         stream.Write( cfg.m_LocalDebuggerWorkingDirectory );
         stream.Write( cfg.m_LocalDebuggerCommand );
         stream.Write( cfg.m_LocalDebuggerEnvironment );
+        stream.Write( cfg.m_WebBrowserDebuggerHttpUrl );
+        stream.Write( cfg.m_ProjectBuildType );
+
     }
 }
 
@@ -570,7 +806,11 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
         if ( stream.Read( cfg.m_RebuildCommand ) == false ) { return false; }
         if ( stream.Read( cfg.m_CleanCommand ) == false ) { return false; }
 
+        if ( stream.Read( cfg.m_TargetName ) == false ) { return false; }
+        if ( stream.Read( cfg.m_TargetExt ) == false ) { return false; }
+
         if ( stream.Read( cfg.m_Output ) == false ) { return false; }
+        if ( stream.Read( cfg.m_AdditionalIncludePaths ) == false ) { return false; }
         if ( stream.Read( cfg.m_PreprocessorDefinitions ) == false ) { return false; }
         if ( stream.Read( cfg.m_IncludeSearchPath ) == false ) { return false; }
         if ( stream.Read( cfg.m_ForcedIncludes ) == false ) { return false; }
@@ -587,11 +827,20 @@ void VSProjectGenerator::GetFolderPath( const AString & fileName, AString & fold
         if ( stream.Read( cfg.m_PlatformToolset ) == false ) { return false; }
         if ( stream.Read( cfg.m_DeploymentType ) == false ) { return false; }
         if ( stream.Read( cfg.m_DeploymentFiles ) == false ) { return false; }
+        if ( stream.Read( cfg.m_PackagePath ) == false ) { return false; }
+        if ( stream.Read( cfg.m_LaunchActivity ) == false ) { return false; }
+        if ( stream.Read( cfg.m_PlatformIncludePattern) == false ) { return false; }
+        if ( stream.Read( cfg.m_TargetArchitectureAlias ) == false ) { return false; }
+        if ( stream.Read( cfg.m_AdditionalSymbolSearchPaths ) == false ) { return false; }
 
         if ( stream.Read( cfg.m_LocalDebuggerCommandArguments ) == false ) { return false; }
         if ( stream.Read( cfg.m_LocalDebuggerWorkingDirectory ) == false ) { return false; }
         if ( stream.Read( cfg.m_LocalDebuggerCommand ) == false ) { return false; }
         if ( stream.Read( cfg.m_LocalDebuggerEnvironment ) == false ) { return false; }
+        if ( stream.Read( cfg.m_WebBrowserDebuggerHttpUrl ) == false ) { return false; }
+
+        if ( stream.Read( cfg.m_ProjectBuildType ) == false ) { return false; }
+
     }
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.h
@@ -31,7 +31,10 @@ public:
     AString m_BuildCommand;
     AString m_RebuildCommand;
     AString m_CleanCommand;
+    AString m_TargetName;
+    AString m_TargetExt;
     AString m_Output;
+    AString m_AdditionalIncludePaths;
     AString m_PreprocessorDefinitions;
     AString m_IncludeSearchPath;
     AString m_ForcedIncludes;
@@ -48,11 +51,18 @@ public:
     AString m_PlatformToolset;
     AString m_DeploymentType;
     AString m_DeploymentFiles;
+    AString m_PackagePath;
+    AString m_LaunchActivity;
+    AString m_PlatformIncludePattern;
+    AString m_TargetArchitectureAlias;
+    AString m_AdditionalSymbolSearchPaths;
 
     AString m_LocalDebuggerCommandArguments;
     AString m_LocalDebuggerWorkingDirectory;
     AString m_LocalDebuggerCommand;
     AString m_LocalDebuggerEnvironment;
+    AString m_WebBrowserDebuggerHttpUrl;
+    AString m_ProjectBuildType;
 
     static bool Load( NodeGraph & nodeGraph, IOStream & stream, Array< VSProjectConfig > & configs );
     static void Save( IOStream & stream, const Array< VSProjectConfig > & configs );
@@ -74,6 +84,7 @@ public:
 //------------------------------------------------------------------------------
 class VSProjectGenerator
 {
+
 public:
     VSProjectGenerator();
     ~VSProjectGenerator();

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -80,11 +80,19 @@ void TestProjectGeneration::Test() const
     cfg.m_BuildCommand = "fbuild -cache $(Project)-$(Config)-$(Platform)";
     cfg.m_RebuildCommand = "fbuild -cache -clean $(Project)-$(Config)-$(Platform)";
 
+//  cfg.m_TargetName = "^$(ProjectName)";
+//  cfg.m_TargetExt = ".exe";
+
+    cfg.m_ProjectBuildType = "Makefile";
+
     // debugger
     cfg.m_LocalDebuggerCommand = "$(SolutionDir)..\\..\\..\\tmp\\$(Platform)\\$(Config)\\Tools\\FBuild\\FBuildTest\\FBuildTest.exe";
     cfg.m_LocalDebuggerWorkingDirectory = "$(ProjectDir)";
     cfg.m_LocalDebuggerCommandArguments = "-verbose";
     cfg.m_LocalDebuggerEnvironment = "_NO_DEBUG_HEAP=1";
+
+    // web debugger
+    // cfg.m_WebBrowserDebuggerHttpUrl
 
     cfg.m_Platform = "Win32";
     cfg.m_Config = "Debug";


### PR DESCRIPTION
…. These generated .androidproj projects enable native C++ code debugging on attached Android devices from within Visual Studio 2015.

NOTE: This change is a superset of #238.

To generate a `.androidproj` via `VCXProject`, simply use the `.androidproj` extension instead of the `.vcxproj extension` inside your .bff code.

This change also adds a couple of new and needed features to VCXProj to support functional .androidproj generation:
1. "`.PackagePath`" - This is the location of your APK file on disk [e.g. `Output/ARM/ProjectName/APK/bin/ProjectName-debug.apk`]
2. "`.LaunchActivity`" - This is the activity name to launch when the APK is deployed. [e.g. `com.android.NativeActivity`]
3. "`.PlatformIncludePattern`" - This is a string which can be used to specify which matching platforms should be included in the `.vcxproj` [e.g. `ARM` - would match `ARM` and `ARM64`]
4. "`.TargetArchitectureAlias`" - This is a string which can be used to add an alias between a user-defined target platform (e.g. `Android-ARM`) and another MSBuild target platform (e.g. `ARM`)
5. "`.AdditionalSymbolSearchPaths`" - This is a semi-colon delimited string fed to Visual Studio which is used to tell the `.androidproj` where to find debugging symbols for the code deployed inside the APK.
6. "`.AdditionalIncludePaths`" - This was defined in #238 and is re-used here to give the android debugger access to paths where it can find source files for debugging.

This change also adds code to the solution generation (`SLNGenerator.cpp`) to use a different GUID `{39E2626F-3545-4960-A6E8-258AD8476CE5}` for referencing .androidproj(s).
I found this out the difficult way, by trial and error, using VS to make things work, and then looking what it did differently in its generated XML.

There is also the preliminary mention of .csproj here. This change could be extended to cover Visual Studio .csproj and .iosproj projects eventually.

Signed-off-by: Layla <layla@insightfulvr.com>

---------------------------------------------------------------------------

For reference, here is the commit message for #238:

Add support for new optional parameters: `.TargetName`, `.TargetExt`, `.AdditionalIncludeDirectories`, `.WebBrowserDebuggerHttpUrl` and `.ProjectBuildType` to `VCXProject`, and support `CustomBuild` steps on `Utility` projects for fast iteration.

This is an updated PR which cherry picks just the changes to these files, without the history that they had in the other PR. I will close out the other PR next.

Signed-off-by: Layla Mah layla@insightfulvr.com

---------------------------------------------------------------------------