### PR TITLE
Fix FBuild -dist stopped or not distributed on macOS 

### DIFF
--- a/Code/Core/Mem/MemDebug.cpp
+++ b/Code/Core/Mem/MemDebug.cpp
@@ -12,6 +12,8 @@
 // Core
 #include "Core/Env/Assert.h"
 
+#include <stdint.h>
+
 // FillMem
 //------------------------------------------------------------------------------
 void MemDebug::FillMem( void * ptr, const size_t size, const uint32_t pattern )

--- a/Code/Core/Network/TCPConnectionPool.cpp
+++ b/Code/Core/Network/TCPConnectionPool.cpp
@@ -224,7 +224,7 @@ const ConnectionInfo * TCPConnectionPool::Connect( uint32_t hostIP, uint16_t por
 
     // set send/recv timeout
     #if defined( __APPLE__ )
-        uint32_t bufferSize = ( 7 * 1024 * 1024 ); // larger values fail on OS X
+        uint32_t bufferSize = ( 5 * 1024 * 1024 ); // larger values fail on OS X
     #else
         uint32_t bufferSize = ( 10 * 1024 * 1024 );
     #endif
@@ -833,7 +833,7 @@ void TCPConnectionPool::ListenThreadFunction( ConnectionInfo * ci )
 
         // set send/recv timeout
         #if defined( __APPLE__ )
-            uint32_t bufferSize = ( 7 * 1024 * 1024 ); // larger values fail on OS X
+            uint32_t bufferSize = ( 5 * 1024 * 1024 ); // larger values fail on OS X
         #else
             uint32_t bufferSize = ( 10 * 1024 * 1024 );
         #endif


### PR DESCRIPTION
 FBuild with Distribution is not working on macOS Sierra.

I found that FBuildWorker can't change socket buffer size from FBuild and it make FBuild stop with SIGPIPE. 

I think current socket buffer size(7MB) is still large on macOS.
It is working well with 5MB : )   
