### PR TITLE
always use absolute dir path of config file as working directory

### DIFF
--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -194,4 +194,28 @@
     }
 }
 
+// SplitDirFileName
 //------------------------------------------------------------------------------
+/*static*/ bool PathUtils::SplitDirFileName( const char * fileName, AString & dirName ,AString & baseName)
+{
+
+    AStackString<> fileNameStr( fileName );
+    if (IsFolderPath(fileNameStr)) {
+       return false; 
+    }
+
+    PathUtils::FixupFilePath( fileNameStr );
+    const char * last_slash = fileNameStr.FindLast(NATIVE_SLASH);
+
+    if (!last_slash) {
+        dirName.SetLength(0);
+        baseName=fileNameStr;
+        return true;
+    }
+
+    dirName = fileNameStr;
+    dirName.SetLength(last_slash-fileNameStr.Get());
+    baseName.Assign(last_slash+1, fileNameStr.Get()+fileNameStr.GetLength());
+    return true;
+}
+

--- a/Code/Core/FileIO/PathUtils.h
+++ b/Code/Core/FileIO/PathUtils.h
@@ -48,6 +48,7 @@ public:
     // Misc
     //----------------
     static void StripFileExtension( AString & filePath );
+    static bool SplitDirFileName(const char* fileName,AString & dirname ,AString & baseName);
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
it brings two benefits: 1.we can ensure relative path in bff always
resolved to same file , no matter which current folder we run fbuild.
2.always create same global process lock when different instance build
same bff,even they run from different dirs. without this, second instance will
report 'open file error' instead of 'another instance already running'

this implementation didn't handle relative path with '.' or '..', which I think should be part of 
FixupFilePath or maybe a new path normalize function. 