### PR TITLE
Fix CopyDir failing when trying to copy files that had been deleted.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
@@ -86,6 +86,8 @@ CopyDirNode::~CopyDirNode() = default;
 {
     (void)forceClean; // dynamic deps are always re-added here, so this is meaningless
 
+    m_DynamicDependencies.Clear();
+
     ASSERT( !m_StaticDependencies.IsEmpty() );
 
     Array< AString > preBuildDependencyNames( m_PreBuildDependencies.GetSize(), false );

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCopy/copy.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCopy/copy.bff
@@ -76,6 +76,16 @@ CopyDir( 'CopyDir' )
 }
 
 //
+// CopyDirDeleteSrc
+//
+CopyDir( 'CopyDirDeleteSrc' )
+{
+    .SourcePaths        = '$Out$/Test/Copy/CopyDir/'
+    .SourcePathsPattern = '*.txt'
+    .Dest               = '$Out$/Test/Copy/CopyDirDeleteSrc/'
+}
+
+//
 // CopyEmpty
 //
 Copy( 'CopyEmpty' )


### PR DESCRIPTION
DynamicDependencies was never cleared so it would still list files that had been previously copied but since deleted.

Add test case to catch this regression in the future.