### PR TITLE
Add optional .CompilerFamily option to the Compiler node, so that we …

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -26,6 +26,7 @@ REFLECT_NODE_BEGIN( CompilerNode, Node, MetaName( "Executable" ) + MetaFile() )
     REFLECT( m_ClangRewriteIncludes, "ClangRewriteIncludes", MetaOptional() )
     REFLECT( m_ExecutableRootPath,  "ExecutableRootPath",   MetaOptional() + MetaPath() )
     REFLECT( m_SimpleDistributionMode,  "SimpleDistributionMode",   MetaOptional() )
+    REFLECT( m_CompilerFamily, "CompilerFamily", MetaOptional() )
 REFLECT_END( CompilerNode )
 
 // CONSTRUCTOR

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -35,6 +35,8 @@ public:
         inline bool IsVS2012EnumBugFixEnabled() const { return m_VS2012EnumBugFix; }
     #endif
     inline bool IsClangRewriteIncludesEnabled() const { return m_ClangRewriteIncludes; }
+    inline const AString &GetCompilerFamily() const { return m_CompilerFamily; }
+
 private:
     virtual bool DetermineNeedToBuild( bool forceClean ) const override;
     virtual BuildResult DoBuild( Job * job ) override;
@@ -47,6 +49,7 @@ private:
     bool            m_VS2012EnumBugFix;
     bool            m_ClangRewriteIncludes;
     AString         m_ExecutableRootPath;
+    AString         m_CompilerFamily;
     bool            m_SimpleDistributionMode;
     ToolManifest    m_Manifest;
 };

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -758,11 +758,70 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
     flags |= ( usingPCH     ? ObjectNode::FLAG_USING_PCH : 0 );
 
     const AString & compiler = compilerNode->GetName();
-    const bool isDistributableCompiler = ( compilerNode->GetType() == Node::COMPILER_NODE ) &&
+    const bool isCompilerNode = (compilerNode->GetType() == Node::COMPILER_NODE);
+    const bool isDistributableCompiler = isCompilerNode &&
                                          ( compilerNode->CastTo< CompilerNode >()->CanBeDistributed() );
 
+    bool compilerTypeSpecified = false;
+    if (isCompilerNode)
+    {
+        const AString &compilerFamily = compilerNode->CastTo< CompilerNode >()->GetCompilerFamily();
+        if (!compilerFamily.IsEmpty())
+        {
+            compilerTypeSpecified = true;
+            static AString strMSVC("msvc");
+            static AString strClang("clang");
+            static AString strGCC("gcc");
+            static AString strSNC("snc");
+            static AString strWii("codewarrior_wii");
+            static AString strWiiU("greenhills_wiiu");
+            static AString strNVCC("cuda_nvcc");
+            static AString strRCC("qt_rcc");
+
+            if (0 == compilerFamily.CompareI(strMSVC))
+            {
+                flags |= ObjectNode::FLAG_MSVC;
+            }
+            else if (0 == compilerFamily.CompareI(strClang))
+            {
+                flags |= ObjectNode::FLAG_CLANG;
+            }
+            else if (0 == compilerFamily.CompareI(strGCC))
+            {
+                flags |= ObjectNode::FLAG_GCC;
+            }
+            else if (0 == compilerFamily.CompareI(strSNC))
+            {
+                flags |= ObjectNode::FLAG_SNC;
+            }
+            else if (0 == compilerFamily.CompareI(strWii))
+            {
+                flags |= ObjectNode::CODEWARRIOR_WII;
+            }
+            else if (0 == compilerFamily.CompareI(strWiiU))
+            {
+                flags |= ObjectNode::GREENHILLS_WIIU;
+            }
+            else if (0 == compilerFamily.CompareI(strNVCC))
+            {
+                flags |= ObjectNode::FLAG_CUDA_NVCC;
+            }
+            else if (0 == compilerFamily.CompareI(strRCC))
+            {
+                flags |= ObjectNode::FLAG_QT_RCC;
+            }
+            else
+            {
+                compilerTypeSpecified = false;
+            }
+        }
+    }
+
     // Compiler Type
-    if ( compiler.EndsWithI( "\\cl.exe" ) ||
+    if (compilerTypeSpecified)
+    {
+    }
+    else if ( compiler.EndsWithI( "\\cl.exe" ) ||
          compiler.EndsWithI( "\\cl" ) ||
          compiler.EndsWithI( "\\icl.exe" ) ||
          compiler.EndsWithI( "\\icl" ) )


### PR DESCRIPTION
…can explicitly specify the compiler type (e.g. Clang) from within the .bff file.

This is useful for i.e. Android and Emscripten - both of these use Clang back-end but do not have the normal clang.exe binary name for the compiler (e.g. Emscripten is emcc).

Signed-off-by: Layla Mah <layla@insightfulvr.com>