### PR TITLE
Change boolean IdleDetection to continuous.

### DIFF
--- a/Code/Tools/FBuild/FBuildWorker/Worker/IdleDetection.h
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/IdleDetection.h
@@ -24,17 +24,18 @@ public:
     void Update();
 
     // query status
-    inline bool IsIdle() const { return m_IsIdle; }
+    inline float IsIdle() const { return m_IsIdle; }
 
 private:
-    bool IsIdleInternal();
+    float IsIdleInternal();
 
     Timer   m_Timer;
     #if defined( __WINDOWS__ )
         float   m_CPUUsageFASTBuild;
         float   m_CPUUsageTotal;
     #endif
-    bool    m_IsIdle;
+    float    m_IsIdle;
+    float    m_IsIdleReal;
     int32_t m_IdleSmoother;
 
     // struct to track processes with

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
@@ -213,7 +213,11 @@ void Worker::UpdateAvailability()
     {
         case WorkerSettings::WHEN_IDLE:
         {
-            if ( m_IdleDetection.IsIdle() == false )
+            if ( m_IdleDetection.IsIdle() >= 0.0f && m_IdleDetection.IsIdle() <= 1.0f )
+            {
+                numCPUsToUse = uint32_t(numCPUsToUse * m_IdleDetection.IsIdle());
+            }
+            else
             {
                 numCPUsToUse = 0;
             }


### PR DESCRIPTION
I'm not fan of boolean (on/off) idle detection on workers, because I don't have dedicated machines as compilation helpers.

So I tried to create something continuous so if user/machine is using 30% cputime there would be for example 5 of 8 idle.
I was trying to keep IdleSmoother behavior so it doesn't change too much.