### PR TITLE
Linux: Transfer file permissions on copy

### DIFF
--- a/Code/Core/CoreTest/Tests/TestFileIO.cpp
+++ b/Code/Core/CoreTest/Tests/TestFileIO.cpp
@@ -118,6 +118,13 @@ void TestFileIO::FileCopy() const
     TEST_ASSERT( FileIO::FileCopy( path.Get(), pathCopy.Get() ) );
     TEST_ASSERT( FileIO::FileExists( pathCopy.Get() ) == true );
 
+    // ensure attributes are transferred properly
+    FileIO::FileInfo sourceInfo;
+    TEST_ASSERT( FileIO::GetFileInfo(path, sourceInfo) == true );
+    FileIO::FileInfo destInfo;
+    TEST_ASSERT( FileIO::GetFileInfo(pathCopy, destInfo) == true );
+    TEST_ASSERT( destInfo.m_Attributes == sourceInfo.m_Attributes );
+
     // copy without overwrite allowed should fail
     const bool allowOverwrite = false;
     TEST_ASSERT( FileIO::FileCopy( path.Get(), pathCopy.Get(), allowOverwrite ) == false );

--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -177,15 +177,15 @@
         return false;
     }
 
-    int dest = open( dstFileName, O_WRONLY | O_CREAT | O_TRUNC, 0644 ); // TODO:LINUX Check args for FileCopy dst
+    struct stat stat_source;
+    VERIFY( fstat( source, &stat_source ) == 0 );
+
+    int dest = open( dstFileName, O_WRONLY | O_CREAT | O_TRUNC, stat_source.st_mode );
     if ( dest < 0 )
     {
         close( source );
         return false;
     }
-
-    struct stat stat_source;
-    VERIFY( fstat( source, &stat_source ) == 0 );
 
     ssize_t bytesCopied = sendfile( dest, source, 0, stat_source.st_size );
 


### PR DESCRIPTION
The `CopyFile` and `CopyDir` functions weren't properly setting file permissions on the destination files to be the same as the source files on Linux.