### PR TITLE
Linux: Fix transfer of permissions on file copy for CIFS shares

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -180,10 +180,19 @@
     struct stat stat_source;
     VERIFY( fstat( source, &stat_source ) == 0 );
 
-    int dest = open( dstFileName, O_WRONLY | O_CREAT | O_TRUNC, stat_source.st_mode );
+    int dest = open( dstFileName, O_WRONLY | O_CREAT | O_TRUNC, 0644 );
     if ( dest < 0 )
     {
         close( source );
+        return false;
+    }
+
+    // set permissions to match the source file's
+    // we can't do this during open because in some filesystems (e.g. CIFS) that can fail
+    if ( fchmod(dest, stat_source.st_mode) < 0 )
+    {
+        close( source );
+        close( dest );
         return false;
     }
 


### PR DESCRIPTION
This change fixes a problem with #278 where destination files would not be created due to access denied errors when the destination is a CIFS share. It looks like Samba fails when setting the file mode (for some file modes only, e.g. `0555`) during an `open` call but it "succeeds" (see below) if done during a `chmod` call, so we use that now instead.

Note that in either case, if the SMB server is a Windows box then the actual file permissions are ignored (see FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS [here](https://www.samba.org/samba/docs/man/manpages-3/mount.cifs.8.html)).