### PR TITLE
Monitor Log: Enrich START_JOB event

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FLog.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FLog.cpp
@@ -49,7 +49,7 @@ static FileStream * g_MonitorFileStream = nullptr;
 
 // Defines
 //------------------------------------------------------------------------------
-#define FBUILD_MONITOR_VERSION uint32_t( 1 )
+#define FBUILD_MONITOR_VERSION uint32_t( 2 )
 
 // Info
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -490,7 +490,7 @@ void Client::Process( const ConnectionInfo * connection, const Protocol::MsgRequ
 
     // output to signify remote start
     FLOG_BUILD( "-> Obj: %s <REMOTE: %s>\n", job->GetNode()->GetName().Get(), ss->m_RemoteName.Get() );
-    FLOG_MONITOR( "START_JOB %s \"%s\" \n", ss->m_RemoteName.Get(), job->GetNode()->GetName().Get() );
+    FLOG_MONITOR( "START_JOB %s \"%s\" Object\n", ss->m_RemoteName.Get(), job->GetNode()->GetName().Get() );
 
     {
         PROFILE_SECTION( "SendJob" )

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
@@ -622,7 +622,7 @@ void JobQueue::FinishedProcessingJob( Job * job, bool success, bool wasARemoteJo
          ( node->GetType() == Node::TEST_NODE ) )
     {
         nodeRelevantToMonitorLog = true;
-        FLOG_MONITOR( "START_JOB local \"%s\" \n", nodeName.Get() );
+        FLOG_MONITOR( "START_JOB local \"%s\" %s\n", nodeName.Get(), node->GetTypeName() );
     }
 
     // make sure the output path exists for files

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
@@ -281,7 +281,7 @@ void JobQueueRemote::FinishedProcessingJob( Job * job, bool success )
 
     if ( job->IsLocal() )
     {
-        FLOG_MONITOR( "START_JOB local \"%s\" \n", job->GetNode()->GetName().Get() );
+        FLOG_MONITOR( "START_JOB local \"%s\" %s %s\n", job->GetNode()->GetName().Get(), job->GetNode()->GetTypeName(), racingRemoteJob ? "RACE" : "" );
     }
 
     // remote tasks must output to a tmp file


### PR DESCRIPTION
- Output build stage (`Node::Type`)
- Mark local race jobs

Although I would prefer to place these additional tokens right after the event name, I ended up appending them to the end of each START_JOB events so existing visualizers (FASTBuild Monitor) won't break.

I also incremented the `FBUILD_MONITOR_VERSION` macro to 2, which should cover all the following changes to the log protocol until your next release (v0.94).