### PR TITLE
Fix readlink usage in GetExePath

### DIFF
--- a/Code/Core/Env/Env.cpp
+++ b/Code/Core/Env/Env.cpp
@@ -221,8 +221,10 @@ void Env::GetExePath( AString & output )
         output = argv[0];
     #else
         char path[ PATH_MAX ];
-        VERIFY( readlink( "/proc/self/exe", path, PATH_MAX ) != -1 );
-        output = path;
+        const ssize_t length = readlink( "/proc/self/exe", path, PATH_MAX );
+        VERIFY( length != -1 );
+        VERIFY( length <= PATH_MAX );
+        output.Assign( path, path + length );
     #endif
 }
 


### PR DESCRIPTION
`readlink` doesn't add terminating null character to the supplied buffer [1]. Therefore we shouldn't treat `path` as a null-terminated string in `GetExePath`.

[1] https://linux.die.net/man/3/readlink Section "Application Usage".