### PR TITLE
Limit debug check for ':' in FileNode to Windows

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
@@ -21,8 +21,10 @@ FileNode::FileNode( const AString & fileName, uint32_t controlFlags )
 : Node( fileName, Node::FILE_NODE, controlFlags )
 {
     ASSERT( fileName.EndsWith( "\\" ) == false );
+#if defined( __WINDOWS__ )
     ASSERT( ( fileName.FindLast( ':' ) == nullptr ) ||
             ( fileName.FindLast( ':' ) == ( fileName.Get() + 1 ) ) );
+#endif
 
     m_LastBuildTimeMs = 1; // very little work required
 }


### PR DESCRIPTION
Second `ASSERT` in the `FileNode` ctor verifies that `:` can only appear as the second character in the `fileName`. This check should only apply to Windows because Linux and Mac OS allow to use `:` anywhere in file path.

This fixes TestSerialization test in Linux debug build.