### PR TITLE
Extend sleep workaround in BFFDrifted test to Linux

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -595,6 +595,8 @@ void TestGraph::BFFDirtied() const
 
     #if defined( __OSX__ )
         Thread::Sleep( 1000 ); // Work around low time resolution of HFS+
+    #elif defined( __LINUX__ )
+        Thread::Sleep( 1000 ); // Work around low time resolution of ext2/ext3/reiserfs and time caching used by used by others
     #endif
 
     // Modity BFF (make it empty)


### PR DESCRIPTION
Some file systems used on Linux (ext2, ext3, reiserfs) have only a second resolution for timestamps. And even file systems with a higher timestamp resolution can in practice be limited to a millisecond resolution because of time caching in the kernel (see `current_fs_time()` in the kernel and this answer from stackoverflow: https://stackoverflow.com/questions/14392975/timestamp-accuracy-on-ext4-sub-millsecond#answer-14393315).
Thus to avoid spurious failures we should sleep for 1s before clearing fbuild.bff file in the BFFDrifted test.

I have decided to duplicate call to `Sleep` in both `#if` blocks to better separate reasons for doing so on each platform.