### PR TITLE
- Fixed compilation errors(and assertions in debug) with DeoptimizeWritableFiles for precompiled header.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1350,6 +1350,8 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
     PROFILE_FUNCTION
 
     Array< AString > tokens( 1024, true );
+    if ( GetFlag( FLAG_CREATING_PCH ) )
+        useDeoptimization = false; // Deoptimization not supported for precompiled header.
 
     const bool useDedicatedPreprocessor = ( ( pass == PASS_PREPROCESSOR_ONLY ) && GetDedicatedPreprocessor() );
     if ( useDedicatedPreprocessor )


### PR DESCRIPTION
Hi Franta,

Trying to use merge requests to send you patches. Hopefully this will be much easier for you than our previous way of doing things.

The merge request is to fix build errors when making the pch input file writable when you have a .DeoptimizeWritableFiles setting.

The problem was that for the precomp.cpp, the m_CompilerOptionsDeoptimized was empty. This was then resulting in an invalid commandline passed to cl.exe. I don't know why but It seems that .PCHOptionsDeoptimized has been removed from fastbuild at some point(we are still generating it in sharpmake!).

Thus, this was resulting in the following command "cl /showincludes" which obviously is wrong.

I just ended up with a quick fix that disables deoptimization when compiling the precompiled header and this merge request is the result of this fix!

I've included below a truncated bff section extracted from our source tree.

I haven't added any new test case for this... Sorry about that.

Cheers
JS

ObjectList( 'Engine_FastBuild_Blob_Engine_Dll_Release_win64_objects' )
{
     Using( .win64Config )
    .Intermediate           = '..\..\tmp\win64\engine\engine_release_dll_vs2015_fastbuild\'

    .CompilerExtraOptions   = ''

    // Optimizations options
    // ---------------------
    .CompilerOptimizations = ''
            + ' /Ox'
            + ' /Ob2'
            + ' /Oi'
            + ' /Ot'
            + ' /Oy-'

    // Precompiled Headers options
    // ---------------------------
    .PCHInputFile           = '..\source\engine\precomp.cpp'
    .PCHOutputFile          = '..\..\tmp\win64\engine\engine_release_dll_vs2015_fastbuild\engine.pch'
    .PCHOptions             = '"%1" /Fp"%2" /Fo"%3" /c'
                            + ' /Yc"Engine\precomp.h"'
                            + ' $CompilerExtraOptions$'
                            + ' $CompilerOptimizations$'


    // Compiler options
    // ----------------
    .CompilerOptions        = '"%1" /Fo"%2" /c'
                            + ' /Yu"Engine\precomp.h" /Fp"$PCHOutputFile$"'
                            + ' $CompilerExtraOptions$'
                            + ' $CompilerOptimizations$'

    .CompilerInputUnity       = 'Engine_FastBuild_Blob_Engine_Dll_Release_win64_unity' 
    .CompilerOutputPath       = '$Intermediate$'
    .CompilerInputFiles       = { 'somefiles.cpp' }

    .PCHOptionsDeoptimized = .PCHOptions

    .CompilerOptionsDeoptimized = '"%1" /Fo"%2" /c'
                            + ' /Yu"Engine\precomp.h" /Fp"$PCHOutputFile$"'
                            + ' $CompilerExtraOptions$'
                            + ' /Od'

    .DeoptimizeWritableFiles = true
}


