### PR TITLE
Fix solution compatibility with Visual Studio 2010

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/SLNGenerator.cpp
@@ -116,7 +116,6 @@ void SLNGenerator::WriteHeader( const AString & solutionVisualStudioVersion,
     AStackString<> shortVersion( shortVersionStart, shortVersionEnd );
 
     // header
-    Write( "\r\n" ); // Deliberate blank line
     Write( "Microsoft Visual Studio Solution File, Format Version 12.00\r\n" );
     Write( "# Visual Studio %s\r\n", shortVersion.Get() );
     Write( "VisualStudioVersion = %s\r\n", version );


### PR DESCRIPTION
Microsoft Visual Studio Selector from Visual Studio 2010 doesn't understand
how to open solution generated with fastbuild even when specifying

	.SolutionVisualStudioVersion = '10.0.40219.1'
	.SolutionMinimumVisualStudioVersion = '10.0.40219.1'

This is caused by blank line inserted at the beginning of .sln file.

Unfortunately, code comment just says that adding this empty line is deliberate,
without explaining what purpose it is supposed to serve, so I am not sure what can break.