### PR TITLE
Handle a DT_UNKNOWN value for the type field of the returned dirent

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -179,7 +179,7 @@
 
     struct stat stat_source;
     VERIFY( fstat( source, &stat_source ) == 0 );
-    
+
     // Ensure dest file will be writable if it exists
     FileIO::SetReadOnly( dstFileName, false );
 
@@ -798,8 +798,22 @@
                 break; // no more entries
             }
 
+            bool isDir = entry->d_type == DT_DIR;
+
+            // Not all filesystems have support for returning the file type in
+            // d_type and applications must properly handle a return of DT_UNKNOWN.
+            if (entry->d_type == DT_UNKNOWN)
+            {
+                pathCopy.SetLength( baseLength );
+                pathCopy += entry->d_name;
+
+                struct stat info;
+                VERIFY( stat( pathCopy.Get(), &info ) == 0 );
+                isDir = S_ISDIR(info.st_mode);
+            }
+
             // dir?
-            if ( ( entry->d_type & DT_DIR ) == DT_DIR )
+            if (isDir)
             {
                 // ignore . and ..
                 if ( entry->d_name[ 0 ] == '.' )
@@ -885,8 +899,22 @@
                 break; // no more entries
             }
 
+            bool isDir = entry->d_type == DT_DIR;
+
+            // Not all filesystems have support for returning the file type in
+            // d_type and applications must properly handle a return of DT_UNKNOWN.
+            if (entry->d_type == DT_UNKNOWN)
+            {
+                pathCopy.SetLength( baseLength );
+                pathCopy += entry->d_name;
+
+                struct stat info;
+                VERIFY( stat( pathCopy.Get(), &info ) == 0 );
+                isDir = S_ISDIR(info.st_mode);
+            }
+
             // dir?
-            if ( ( entry->d_type & DT_DIR ) == DT_DIR )
+            if (isDir)
             {
                 // ignore dirs
                 continue;
@@ -998,8 +1026,22 @@
                 break; // no more entries
             }
 
+            bool isDir = entry->d_type == DT_DIR;
+
+            // Not all filesystems have support for returning the file type in
+            // d_type and applications must properly handle a return of DT_UNKNOWN.
+            if (entry->d_type == DT_UNKNOWN)
+            {
+                pathCopy.SetLength( baseLength );
+                pathCopy += entry->d_name;
+
+                struct stat info;
+                VERIFY( stat( pathCopy.Get(), &info ) == 0 );
+                isDir = S_ISDIR(info.st_mode);
+            }
+
             // dir?
-            if ( ( entry->d_type & DT_DIR ) == DT_DIR )
+            if (isDir)
             {
                 // ignore . and ..
                 if ( entry->d_name[ 0 ] == '.' )
@@ -1113,8 +1155,22 @@
                 break; // no more entries
             }
 
+            bool isDir = entry->d_type == DT_DIR;
+
+            // Not all filesystems have support for returning the file type in
+            // d_type and applications must properly handle a return of DT_UNKNOWN.
+            if (entry->d_type == DT_UNKNOWN)
+            {
+                pathCopy.SetLength( baseLength );
+                pathCopy += entry->d_name;
+
+                struct stat info;
+                VERIFY( stat( pathCopy.Get(), &info ) == 0 );
+                isDir = S_ISDIR(info.st_mode);
+            }
+
             // dir?
-            if ( ( entry->d_type & DT_DIR ) == DT_DIR )
+            if (isDir)
             {
                 // ingnore dirs
                 continue;


### PR DESCRIPTION
The d_type field of dirent (returned by readdir()) is not valid for all filesystems. Applications need to handle a value of DT_UNKNOWN and instead do a stat() on the file to determine type. 