### PR TITLE
Add /Zo to MS compiler command line to enable enhanced optimized debugging.

### DIFF
--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -118,7 +118,7 @@ Compiler( 'Compiler-x64-OSX' )
 
     // Optimizations
     .CompilerDebugOptimizations     = ' /MTd /Od /RTC1 /GS /Oy- /GR- /analyze'
-    .CompilerReleaseOptimizations   = ' /MT /Ox /Oy /Oi /GS- /GF /GL /Gy /Gw /GR- /analyze'
+    .CompilerReleaseOptimizations   = ' /MT /Ox /Oy /Oi /GS- /GF /GL /Gy /Gw /GR- /analyze /Zo'
     .LibrarianDebugOptimizations    = ''
     .LibrarianReleaseOptimizations  = ' /LTCG'
     .LinkerDebugOptimizations       = ''


### PR DESCRIPTION
Heya,
This helps debugging FastBuild in release (the flag /Zo used to be called /d2Zi+, and was renamed in vs2013 update4).
