### PR TITLE
Fix nasty and rare bug that could delete source files when using fastcancel

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
@@ -627,7 +627,8 @@ void JobQueue::FinishedProcessingJob( Job * job, bool success, bool wasARemoteJo
 
     // make sure the output path exists for files
     // (but don't bother for input files)
-    if ( node->IsAFile() && ( node->GetType() != Node::FILE_NODE ) && ( node->GetType() != Node::COMPILER_NODE ) )
+    const bool isOutputFile = node->IsAFile() && ( node->GetType() != Node::FILE_NODE ) && ( node->GetType() != Node::COMPILER_NODE );
+    if ( isOutputFile )
     {
         if ( Node::EnsurePathExistsForFile( node->GetName() ) == false )
         {
@@ -680,7 +681,7 @@ void JobQueue::FinishedProcessingJob( Job * job, bool success, bool wasARemoteJo
     {
         if ( result == Node::NODE_RESULT_FAILED )
         {
-            if ( node->GetControlFlags() & Node::FLAG_NO_DELETE_ON_FAIL )
+            if ( !isOutputFile || ( node->GetControlFlags() & Node::FLAG_NO_DELETE_ON_FAIL ) )
             {
                 // node failed, but builder wants result left on disc
             }


### PR DESCRIPTION
Heya,

This fixes a bug I've been chasing for a while. In case of cancellation of build with fastcancel, the node result is forced to NODE_RESULT_FAILED.
But, with that status, we delete the old stale files from disk.

Most of the time everything went fine, because the "input" nodes where up to date, and in that case we weren't entering that loop.

The fix is just to add a test for the type of file node, ie, we only allow deletion of output file nodes.