### PR TITLE
Include optimization options into .CompilerOptionsC

### DIFF
--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -328,6 +328,7 @@ Compiler( 'Compiler-x64-OSX' )
     .Config                 = 'Debug'
     .CompilerOptions        + ' -DDEBUG -DPROFILING_ENABLED'
                             + .CompilerDebugOptimizations
+    .CompilerOptionsC       + .CompilerDebugOptimizations
     .PCHOptions             + ' -DDEBUG -DPROFILING_ENABLED'
                             + .CompilerDebugOptimizations
     .LibrarianOptions       + .LibrarianDebugOptimizations
@@ -345,6 +346,7 @@ Compiler( 'Compiler-x64-OSX' )
     .CompilerOptionsDeoptimized     = '$CompilerOptions$ /Od'
 
     .CompilerOptions        + .CompilerReleaseOptimizations
+    .CompilerOptionsC       + .CompilerReleaseOptimizations
     .PCHOptions             + .CompilerReleaseOptimizations
     .LibrarianOptions       + .LibrarianReleaseOptimizations
     .LinkerOptions          + .LinkerReleaseOptimizations
@@ -409,6 +411,7 @@ Compiler( 'Compiler-x64-OSX' )
     .Config                 = 'Debug'
     .CompilerOptions        + ' -DDEBUG -DPROFILING_ENABLED'
                             + .CompilerDebugOptimizations
+    .CompilerOptionsC       + .CompilerDebugOptimizations
     .LibrarianOptions       + .LibrarianDebugOptimizations
     .LinkerOptions          + .LinkerDebugOptimizations
 ]
@@ -418,6 +421,7 @@ Compiler( 'Compiler-x64-OSX' )
     .Config                 = 'Release'
     .CompilerOptions        + ' -DRELEASE'
                             + .CompilerReleaseOptimizations
+    .CompilerOptionsC       + .CompilerReleaseOptimizations
     .LibrarianOptions       + .LibrarianReleaseOptimizations
     .LinkerOptions          + .LinkerReleaseOptimizations
 ]


### PR DESCRIPTION
LZ4 uses `.CompilerOptionsC` instead of `.CompilerOptions` in X86Clang and x64Linux configurations. But optimization options were only added to `.CompilerOptions` and not to `.CompilerOptionsC`.
This resulted in LZ4 compiled without `-O3` in Release configuration, which on machine lead to 10-12 times lower throughput of xxHash in CompareHashTimes_Large test.