### PR TITLE
Deduplicate alias generation, provide useful per-configuration aliases on Linux and OSX

### DIFF
--- a/Code/Core/Core.bff
+++ b/Code/Core/Core.bff
@@ -120,23 +120,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -177,23 +177,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-x64OSX-Debug', '$ProjectName$-x64OSX-Release', '$ProjectName$-x64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/OSUI/OSUI.bff
+++ b/Code/OSUI/OSUI.bff
@@ -119,23 +119,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/TestFramework/TestFramework.bff
+++ b/Code/TestFramework/TestFramework.bff
@@ -121,23 +121,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-x64OSX-Debug', '$ProjectName$-x64OSX-Release', '$ProjectName$-x64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
+++ b/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
@@ -149,23 +149,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug',  '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug',    '$ProjectName$-X64OSX-Release',   '$ProjectName$-X64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../../../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -139,23 +139,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../../../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -182,23 +182,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-x64OSX-Debug', '$ProjectName$-x64OSX-Release', '$ProjectName$-x64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../../../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
@@ -168,23 +168,7 @@
 
     // Aliases
     //--------------------------------------------------------------------------
-    // Per-Config
-    Alias( '$ProjectName$-Debug' )      { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-Profile' )    { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-Release' )    { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-    // Per-Platform
-    Alias( '$ProjectName$-X86' )        { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
-    Alias( '$ProjectName$-X64' )        { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-    Alias( '$ProjectName$-X86Clang' )   { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
-
-    // All
-    Alias( '$ProjectName$' )
-    {
-        .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-    }
+    #include "../../../gen_default_aliases.bff"
 
     // Visual Studio Project Generation
     //--------------------------------------------------------------------------

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -1,0 +1,19 @@
+// Generates Alias targets for .ProjectName
+
+// Per-Config
+Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
+Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
+Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
+
+// Per-Platform
+Alias( '$ProjectName$-X86' )             { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X86-Profile' } }
+Alias( '$ProjectName$-X64' )             { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
+Alias( '$ProjectName$-X86Clang' )        { .Targets = { '$ProjectName$-X86Clang-Debug' } }
+Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
+Alias( '$ProjectName$-X64OSX' )          { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
+
+// All
+Alias( '$ProjectName$' )
+{
+    .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
+}

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -1,9 +1,21 @@
 // Generates Alias targets for .ProjectName
 
 // Per-Config
+#if __WINDOWS__
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
 Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
 Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
+#endif
+#if __LINUX__
+Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64Linux-Debug' } }
+Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-Profile' } }
+Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release' } }
+#endif
+#if __OSX__
+Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64OSX-Debug' } }
+Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64OSX-Profile' } }
+Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64OSX-Release' } }
+#endif
 
 // Per-Platform
 Alias( '$ProjectName$-X86' )             { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X86-Profile' } }

--- a/External/LZ4/LZ4.bff
+++ b/External/LZ4/LZ4.bff
@@ -121,23 +121,7 @@
 
 	// Aliases
 	//--------------------------------------------------------------------------
-	// Per-Config
-	Alias( '$ProjectName$-Debug' )		{ .Targets = { '$ProjectName$-X86-Debug',   '$ProjectName$-X64-Debug', '$ProjectName$-X86Clang-Debug' } }
-	Alias( '$ProjectName$-Profile' )	{ .Targets = { '$ProjectName$-X86-Profile', '$ProjectName$-X64-Profile' } }
-	Alias( '$ProjectName$-Release' )	{ .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
-
-	// Per-Platform
-	Alias( '$ProjectName$-X86' )		{ .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X86-Profile' } }
-	Alias( '$ProjectName$-X64' )		{ .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
-	Alias( '$ProjectName$-X86Clang' )	{ .Targets = { '$ProjectName$-X86Clang-Debug' } }
-    Alias( '$ProjectName$-x64Linux' )   { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-    Alias( '$ProjectName$-x64OSX' )     { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
-
-	// All
-	Alias( '$ProjectName$' )
-	{
-		.Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
-	}
+    #include "../../Code/gen_default_aliases.bff"
 
 	// Visual Studio Project Generation
 	//--------------------------------------------------------------------------


### PR DESCRIPTION
All identical code for generating per-platform, per-configuration and `All` aliases is moved to separate file. Main reason is to simplify second commit and further PRs (building with Clang on Linux, building with sanitizers).

Second commit changes per-configuration aliases to use `.Targets` useful on each platform.