### PR TITLE
Use AString::Copy overload with length when assigning/appending AString to AString

### DIFF
--- a/Code/Core/Strings/AString.cpp
+++ b/Code/Core/Strings/AString.cpp
@@ -53,7 +53,7 @@ AString::AString( const AString & string )
     uint32_t reserved = Math::RoundUp( len, (uint32_t)2 );
     m_Contents = (char *)ALLOC( reserved + 1 );
     SetReserved( reserved, true );
-    Copy( string.Get(), m_Contents ); // copy handles terminator
+    Copy( string.Get(), m_Contents, len ); // copy handles terminator
 }
 
 // CONSTRUCTOR (const char *)
@@ -355,7 +355,7 @@ void AString::Assign( const AString & string )
         // didn't resize then the passed in string is empty too
         return;
     }
-    Copy( string.Get(), m_Contents ); // handles terminator
+    Copy( string.Get(), m_Contents, len ); // handles terminator
     m_Length = len;
 }
 
@@ -456,7 +456,7 @@ AString & AString::operator += ( const AString & string )
             Grow( newLen );
         }
 
-        Copy( string.Get(), m_Contents + m_Length ); // handles terminator
+        Copy( string.Get(), m_Contents + m_Length, suffixLen ); // handles terminator
         m_Length += suffixLen;
     }
     return *this;


### PR DESCRIPTION
There are two reasons to prefer Copy that accepts length:
   1. That version is much faster that the other, especially on long strings.
   2. This avoids incomplete string copies when source string contains an embedded null-terminator. In that case data is copied only up to the null-terminator but `m_Length` is set to the same value as in       the source string. Such incomplete copies can later lead to uninitialized memory reads.

Issue described in (2) was found in practice with MemorySanitizer:
   * In `Cache:Publish` last slash in `cacheFileName` is replaced with `'\0'`.
   * `FileIO::EnsurePathExists` is called, it makes (incomplete) copy of its argument.
   * `AString::Replace` is called (via `PathUtils::FixupFolderPath`) on that copy, it checks all characters in range `[m_Contents, m_Contents + m_Length)` including ones that were not copied.