### PR TITLE
Support building with Clang on Linux, support building with Address and Memory sanitizers

### DIFF
--- a/Code/Core/Core.bff
+++ b/Code/Core/Core.bff
@@ -78,9 +78,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -96,9 +96,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
+++ b/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
@@ -12,6 +12,8 @@
 #include "Core/Time/Timer.h"
 #include "Core/Tracing/Tracing.h"
 
+#include <memory.h> // for memset
+
 // Defines
 //------------------------------------------------------------------------------
 #define NUM_TEST_PASSES ( 16 )
@@ -274,6 +276,7 @@ void TestTestTCPConnectionPool::TestConnectionStuckDuringSend() const
     TCPConnectionPool & client = ci->GetTCPConnectionPool();
     // send lots of data to slow server
     AutoPtr< char > mem( (char *)ALLOC( 10 * MEGABYTE ) );
+    memset( mem.Get(), 0, 10 * MEGABYTE );
     for ( size_t i=0; i<1000; ++i )
     {
         if ( !client.Send( ci, mem.Get(), 10 * MEGABYTE ) )

--- a/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
+++ b/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
@@ -273,7 +273,7 @@ void TestTestTCPConnectionPool::TestConnectionStuckDuringSend() const
     const ConnectionInfo * ci = (const ConnectionInfo *)userData;
     TCPConnectionPool & client = ci->GetTCPConnectionPool();
     // send lots of data to slow server
-    AutoPtr< char > mem( FNEW( char[ 10 * MEGABYTE ] ) );
+    AutoPtr< char > mem( (char *)ALLOC( 10 * MEGABYTE ) );
     for ( size_t i=0; i<1000; ++i )
     {
         if ( !client.Send( ci, mem.Get(), 10 * MEGABYTE ) )

--- a/Code/Core/Env/Types.h
+++ b/Code/Core/Env/Types.h
@@ -109,6 +109,12 @@ typedef signed int          int32_t;
     #endif
 #endif
 
+#if defined( _MSC_VER ) && _MSC_VER < 1900
+    #define NOEXCEPT
+#else
+    #define NOEXCEPT noexcept
+#endif
+
 #ifndef LONGLONG
     typedef long long LONGLONG;
 #endif

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -98,9 +98,11 @@ void Free( void * ptr )
     void operator delete( void * ptr, const char *, int ) { Free( ptr ); }
     void operator delete[]( void * ptr, const char *, int ) { Free( ptr ); }
 #endif
+#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
 void * operator new( size_t size ) { return Alloc( size ); }
 void * operator new[]( size_t size ) { return Alloc( size ); }
 void operator delete( void * ptr ) NOEXCEPT { Free( ptr ); }
 void operator delete[]( void * ptr ) NOEXCEPT { Free( ptr ); }
+#endif
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -100,7 +100,7 @@ void Free( void * ptr )
 #endif
 void * operator new( size_t size ) { return Alloc( size ); }
 void * operator new[]( size_t size ) { return Alloc( size ); }
-void operator delete( void * ptr ) { Free( ptr ); }
-void operator delete[]( void * ptr ) { Free( ptr ); }
+void operator delete( void * ptr ) NOEXCEPT { Free( ptr ); }
+void operator delete[]( void * ptr ) NOEXCEPT { Free( ptr ); }
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -98,7 +98,7 @@ void Free( void * ptr )
     void operator delete( void * ptr, const char *, int ) { Free( ptr ); }
     void operator delete[]( void * ptr, const char *, int ) { Free( ptr ); }
 #endif
-#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
+#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !__SANITIZE_ADDRESS__
 void * operator new( size_t size ) { return Alloc( size ); }
 void * operator new[]( size_t size ) { return Alloc( size ); }
 void operator delete( void * ptr ) NOEXCEPT { Free( ptr ); }

--- a/Code/Core/Mem/Mem.h
+++ b/Code/Core/Mem/Mem.h
@@ -51,9 +51,14 @@ void Free( void * ptr );
     void operator delete( void * ptr, const char *, int );
     void operator delete[]( void * ptr, const char *, int );
 #endif
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
 void * operator new( size_t size );
 void * operator new[]( size_t size );
 void operator delete( void * ptr ) NOEXCEPT;
 void operator delete[]( void * ptr ) NOEXCEPT;
+#endif
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/Mem.h
+++ b/Code/Core/Mem/Mem.h
@@ -54,7 +54,7 @@ void Free( void * ptr );
 #if !defined( __has_feature )
     #define __has_feature( ... ) 0
 #endif
-#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
+#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !__SANITIZE_ADDRESS__
 void * operator new( size_t size );
 void * operator new[]( size_t size );
 void operator delete( void * ptr ) NOEXCEPT;

--- a/Code/Core/Mem/Mem.h
+++ b/Code/Core/Mem/Mem.h
@@ -53,7 +53,7 @@ void Free( void * ptr );
 #endif
 void * operator new( size_t size );
 void * operator new[]( size_t size );
-void operator delete( void * ptr );
-void operator delete[]( void * ptr );
+void operator delete( void * ptr ) NOEXCEPT;
+void operator delete[]( void * ptr ) NOEXCEPT;
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/MemDebug.h
+++ b/Code/Core/Mem/MemDebug.h
@@ -8,7 +8,14 @@
 
 // Placement new/delete
 //------------------------------------------------------------------------------
-#if defined( DEBUG )
+// Fill new and freed memory in Debug builds unless:
+//   * We are using MemorySanitizer, in which case it is better to not
+//     initialize allocated memory because doing so will hide uninitialized reads
+//     from MemorySanitizer.
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+#if defined( DEBUG ) && !__has_feature( memory_sanitizer )
     #define MEM_DEBUG_ENABLED
 #endif
 #if defined( MEM_DEBUG_ENABLED )

--- a/Code/Core/Mem/SmallBlockAllocator.cpp
+++ b/Code/Core/Mem/SmallBlockAllocator.cpp
@@ -7,8 +7,6 @@
 
 #include "SmallBlockAllocator.h"
 
-#if defined( SMALL_BLOCK_ALLOCATOR_ENABLED )
-
 // Core
 #include "Core/Env/Types.h"
 #include "Core/Math/Conversions.h"
@@ -274,4 +272,3 @@ bool SmallBlockAllocator::Free( void * ptr )
 }
 
 //------------------------------------------------------------------------------
-#endif // SMALL_BLOCK_ALLOCATOR_ENABLED

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -4,7 +4,15 @@
 
 // Defines
 //------------------------------------------------------------------------------
-#define SMALL_BLOCK_ALLOCATOR_ENABLED
+// Enable SmallBlockAllocator unless:
+//   * We are using AddressSanitizer, in which case it is better to have a
+//     separate block for each allocation to catch out-of-bounds reads/writes.
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
+    #define SMALL_BLOCK_ALLOCATOR_ENABLED
+#endif
 
 // Includes
 //------------------------------------------------------------------------------
@@ -13,7 +21,6 @@
 
 // SmallBlockAllocator
 //------------------------------------------------------------------------------
-#if defined( SMALL_BLOCK_ALLOCATOR_ENABLED )
     class SmallBlockAllocator
     {
     public:
@@ -72,6 +79,5 @@
         // A table to allow 0(1) conversion of any address to the bucket that owns it
         static uint8_t      s_BucketMappingTable[ BUCKET_MAPPING_TABLE_SIZE ];
     };
-#endif
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -7,10 +7,13 @@
 // Enable SmallBlockAllocator unless:
 //   * We are using AddressSanitizer, in which case it is better to have a
 //     separate block for each allocation to catch out-of-bounds reads/writes.
+//   * We are using MemorySanitizer, in which case it is better to not reuse
+//     allocated blocks because doing so will hide uninitialized reads from
+//     reused blocks from MemorySanitizer.
 #if !defined( __has_feature )
     #define __has_feature( ... ) 0
 #endif
-#if !__has_feature( address_sanitizer ) && !__SANITIZE_ADDRESS__
+#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !__SANITIZE_ADDRESS__
     #define SMALL_BLOCK_ALLOCATOR_ENABLED
 #endif
 

--- a/Code/Core/Reflection/ReflectedProperty.cpp
+++ b/Code/Core/Reflection/ReflectedProperty.cpp
@@ -44,6 +44,19 @@ ReflectedProperty::ReflectedProperty( const char * name, uint32_t offset, Proper
     m_MetaDataChain = nullptr;
 }
 
+// DESTRUCTOR
+//------------------------------------------------------------------------------
+ReflectedProperty::~ReflectedProperty()
+{
+    const IMetaData * m = m_MetaDataChain;
+    while ( m )
+    {
+        const IMetaData * next = m->GetNext();
+        FDELETE m;
+        m = next;
+    }
+}
+
 // GetPropertySize
 //------------------------------------------------------------------------------
 size_t ReflectedProperty::GetPropertySize() const

--- a/Code/Core/Reflection/ReflectedProperty.h
+++ b/Code/Core/Reflection/ReflectedProperty.h
@@ -29,6 +29,7 @@ class ReflectedProperty
 {
 public:
     ReflectedProperty( const char * name, uint32_t offset, PropertyType type, bool isArray );
+    ~ReflectedProperty();
 
     inline uint32_t GetNameCRC() const { return m_NameCRC; }
     inline PropertyType GetType() const { return (PropertyType)m_Type; }

--- a/Code/Core/Reflection/ReflectionInfo.cpp
+++ b/Code/Core/Reflection/ReflectionInfo.cpp
@@ -45,7 +45,14 @@ ReflectionInfo::ReflectionInfo()
 
 // DESTRUCTOR
 //------------------------------------------------------------------------------
-ReflectionInfo::~ReflectionInfo() = default;
+ReflectionInfo::~ReflectionInfo()
+{
+    auto end = m_Properties.End();
+    for ( auto it = m_Properties.Begin(); it != end; ++it )
+    {
+        delete *it;
+    }
+}
 
 // Begin
 //------------------------------------------------------------------------------

--- a/Code/OSUI/OSUI.bff
+++ b/Code/OSUI/OSUI.bff
@@ -77,9 +77,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/TestFramework/TestFramework.bff
+++ b/Code/TestFramework/TestFramework.bff
@@ -73,9 +73,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
+++ b/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
@@ -82,9 +82,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -87,9 +87,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -192,7 +192,7 @@ NodeGraph::LoadResult NodeGraph::Load( const char * nodeGraphDBFile )
 
     // Read it into memory to avoid lots of tiny disk accesses
     const size_t fileSize = (size_t)fs.GetFileSize();
-    AutoPtr< char > memory( FNEW( char[ fileSize ] ) );
+    AutoPtr< char > memory( (char *)ALLOC( fileSize ) );
     if ( fs.ReadBuffer( memory.Get(), fileSize ) != fileSize )
     {
         return LoadResult::LOAD_ERROR;

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.cpp
@@ -49,6 +49,7 @@ Protocol::IMessage::IMessage( Protocol::MessageType msgType, uint32_t msgSize, b
     , m_MsgSize( msgSize )
     , m_HasPayload( hasPayload )
 {
+    memset( m_Padding1, 0, sizeof( m_Padding1 ) );
 }
 
 // IMessage::Send
@@ -103,6 +104,7 @@ Protocol::MsgConnection::MsgConnection( uint32_t numJobsAvailable )
     , m_ProtocolVersion( PROTOCOL_VERSION )
     , m_NumJobsAvailable( numJobsAvailable )
 {
+    memset( m_HostName, 0, sizeof( m_HostName ) );
     if ( ::gethostname( m_HostName, 64 ) != 0 )
     {
         AString::Copy( "Unavailable", m_HostName, 12 ); // inc terminator in copy
@@ -137,6 +139,7 @@ Protocol::MsgJob::MsgJob( uint64_t toolId )
     : Protocol::IMessage( Protocol::MSG_JOB, sizeof( MsgJob ), true )
     , m_ToolId( toolId )
 {
+    memset( m_Padding2, 0, sizeof( m_Padding2 ) );
     ASSERT( toolId );
 }
 
@@ -153,6 +156,7 @@ Protocol::MsgRequestManifest::MsgRequestManifest( uint64_t toolId )
     : Protocol::IMessage( Protocol::MSG_REQUEST_MANIFEST, sizeof( MsgRequestManifest ), false )
     , m_ToolId( toolId )
 {
+    memset( m_Padding2, 0, sizeof( m_Padding2 ) );
 }
 
 // MsgManifest
@@ -161,6 +165,7 @@ Protocol::MsgManifest::MsgManifest( uint64_t toolId )
     : Protocol::IMessage( Protocol::MSG_MANIFEST, sizeof( MsgManifest ), true )
     , m_ToolId( toolId )
 {
+    memset( m_Padding2, 0, sizeof( m_Padding2 ) );
 }
 
 // MsgRequestFile
@@ -170,6 +175,8 @@ Protocol::MsgRequestFile::MsgRequestFile( uint64_t toolId, uint32_t fileId )
     , m_ToolId( toolId )
     , m_FileId( fileId )
 {
+    memset( m_Padding2, 0, sizeof( m_Padding2 ) );
+    memset( m_Padding3, 0, sizeof( m_Padding3 ) );
 }
 
 // MsgFile
@@ -179,6 +186,8 @@ Protocol::MsgFile::MsgFile( uint64_t toolId, uint32_t fileId )
     , m_ToolId( toolId )
     , m_FileId( fileId )
 {
+    memset( m_Padding2, 0, sizeof( m_Padding2 ) );
+    memset( m_Padding3, 0, sizeof( m_Padding3 ) );
 }
 
 // MsgServerStatus

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
@@ -85,6 +85,7 @@ namespace Protocol
         MessageType     m_MsgType;
         uint32_t        m_MsgSize;
         bool            m_HasPayload;
+        char            m_Padding1[ 3 ];
     };
     static_assert( sizeof( IMessage ) == 9 + 3/*padding*/, "Message base class has incorrect size" );
 
@@ -145,6 +146,7 @@ namespace Protocol
 
         inline uint64_t GetToolId() const { return m_ToolId; }
     private:
+        char     m_Padding2[ 4 ];
         uint64_t m_ToolId;
     };
     static_assert( sizeof( MsgJob ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgJob message has incorrect size" );
@@ -167,6 +169,7 @@ namespace Protocol
 
         inline uint64_t GetToolId() const { return m_ToolId; }
     private:
+        char     m_Padding2[ 4 ];
         uint64_t m_ToolId;
     };
     static_assert( sizeof( MsgRequestManifest ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgRequestManifest message has incorrect size" );
@@ -180,6 +183,7 @@ namespace Protocol
 
         inline uint64_t GetToolId() const { return m_ToolId; }
     private:
+        char     m_Padding2[ 4 ];
         uint64_t m_ToolId;
     };
     static_assert( sizeof( MsgManifest ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgManifest message has incorrect size" );
@@ -194,8 +198,10 @@ namespace Protocol
         inline uint64_t GetToolId() const { return m_ToolId; }
         inline uint32_t GetFileId() const { return m_FileId; }
     private:
+        char     m_Padding2[ 4 ];
         uint64_t m_ToolId;
         uint32_t m_FileId;
+        char     m_Padding3[ 4 ];
     };
     static_assert( sizeof( MsgRequestFile ) == sizeof( IMessage ) + 4/*alignment*/ + 12 + 4/*padding*/, "MsgRequestFile message has incorrect size" );
 
@@ -209,8 +215,10 @@ namespace Protocol
         inline uint64_t GetToolId() const { return m_ToolId; }
         inline uint32_t GetFileId() const { return m_FileId; }
     private:
+        char     m_Padding2[ 4 ];
         uint64_t m_ToolId;
         uint32_t m_FileId;
+        char     m_Padding3[ 4 ];
     };
     static_assert( sizeof( MsgFile ) == sizeof( IMessage ) + 4/*alignment*/ + 12 + 4/*padding*/, "MsgFile message has incorrect size" );
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
@@ -86,6 +86,7 @@ namespace Protocol
         uint32_t        m_MsgSize;
         bool            m_HasPayload;
     };
+    static_assert( sizeof( IMessage ) == 9 + 3/*padding*/, "Message base class has incorrect size" );
 
     // MsgConnection
     //------------------------------------------------------------------------------
@@ -102,6 +103,7 @@ namespace Protocol
         uint32_t        m_NumJobsAvailable;
         char            m_HostName[ 64 ];
     };
+    static_assert( sizeof( MsgConnection ) == sizeof( IMessage ) + 72, "MsgConnection message has incorrect size" );
 
     // MsgStatus
     //------------------------------------------------------------------------------
@@ -114,6 +116,7 @@ namespace Protocol
     private:
         uint32_t        m_NumJobsAvailable;
     };
+    static_assert( sizeof( MsgStatus ) == sizeof( IMessage ) + 4, "MsgStatus message has incorrect size" );
 
     // MsgRequestJob
     //------------------------------------------------------------------------------
@@ -122,6 +125,7 @@ namespace Protocol
     public:
         MsgRequestJob();
     };
+    static_assert( sizeof( MsgRequestJob ) == sizeof( IMessage ), "MsgRequestJob message has incorrect size" );
 
     // MsgNoJobAvailable
     //------------------------------------------------------------------------------
@@ -130,6 +134,7 @@ namespace Protocol
     public:
         MsgNoJobAvailable();
     };
+    static_assert( sizeof( MsgNoJobAvailable ) == sizeof( IMessage ), "MsgNoJobAvailable message has incorrect size" );
 
     // MsgJob
     //------------------------------------------------------------------------------
@@ -142,6 +147,7 @@ namespace Protocol
     private:
         uint64_t m_ToolId;
     };
+    static_assert( sizeof( MsgJob ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgJob message has incorrect size" );
 
     // MsgJobResult
     //------------------------------------------------------------------------------
@@ -150,6 +156,7 @@ namespace Protocol
     public:
         MsgJobResult();
     };
+    static_assert( sizeof( MsgJobResult ) == sizeof( IMessage ), "MsgJobResult message has incorrect size" );
 
     // MsgRequestManifest
     //------------------------------------------------------------------------------
@@ -162,6 +169,7 @@ namespace Protocol
     private:
         uint64_t m_ToolId;
     };
+    static_assert( sizeof( MsgRequestManifest ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgRequestManifest message has incorrect size" );
 
     // MsgManifest
     //------------------------------------------------------------------------------
@@ -174,6 +182,7 @@ namespace Protocol
     private:
         uint64_t m_ToolId;
     };
+    static_assert( sizeof( MsgManifest ) == sizeof( IMessage ) + 4/*alignment*/ + 8, "MsgManifest message has incorrect size" );
 
     // MsgRequestFile
     //------------------------------------------------------------------------------
@@ -188,6 +197,7 @@ namespace Protocol
         uint64_t m_ToolId;
         uint32_t m_FileId;
     };
+    static_assert( sizeof( MsgRequestFile ) == sizeof( IMessage ) + 4/*alignment*/ + 12 + 4/*padding*/, "MsgRequestFile message has incorrect size" );
 
     // MsgFile
     //------------------------------------------------------------------------------
@@ -202,6 +212,7 @@ namespace Protocol
         uint64_t m_ToolId;
         uint32_t m_FileId;
     };
+    static_assert( sizeof( MsgFile ) == sizeof( IMessage ) + 4/*alignment*/ + 12 + 4/*padding*/, "MsgFile message has incorrect size" );
 
     // MsgServerStatus
     //------------------------------------------------------------------------------
@@ -210,6 +221,7 @@ namespace Protocol
     public:
         MsgServerStatus();
     };
+    static_assert( sizeof( MsgServerStatus ) == sizeof( IMessage ), "MsgServerStatus message has incorrect size" );
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -97,9 +97,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '/$Platform$-$Config$'

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
@@ -99,9 +99,9 @@
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }
 
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -424,6 +424,9 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
     .Platform               = 'x64Linux'
     .Compiler               = 'Compiler-x64-Linux'
     .Linker                 = '/usr/bin/g++'
+
+    .CompilerOptions_ASan   = ' -fsanitize=address -fno-omit-frame-pointer'
+    .LinkerOptions_ASan     = ' -fsanitize=address'
 ]
 .X64DebugConfig_Linux =
 [
@@ -454,12 +457,23 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
     .CompilerOptions        + ' -DPROFILING_ENABLED'
     .CompilerOptionsC       + ' -DPROFILING_ENABLED'
 ]
+.X64ASanConfig_Linux =
+[
+    Using( .X64ReleaseConfig_Linux ) // Note: based on Release config
+    .Config                 = 'ASan'
+    .CompilerOptions        + .CompilerOptions_ASan
+    .CompilerOptionsC       + .CompilerOptions_ASan
+    .LinkerOptions          + .LinkerOptions_ASan
+]
 .X64ClangBaseConfig_Linux =
 [
     Using( .LinuxBaseConfig )
     .Platform               = 'x64ClangLinux'
     .Compiler               = 'Compiler-x64Clang-LinuxOSX'
     .Linker                 = '/usr/bin/clang++'
+
+    .CompilerOptions_ASan   = ' -fsanitize=address -fno-omit-frame-pointer'
+    .LinkerOptions_ASan     = ' -fsanitize=address'
 ]
 .X64ClangDebugConfig_Linux =
 [
@@ -486,6 +500,14 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
     Using( .X64ClangReleaseConfig_Linux ) // Note: based on Release config
     .Config                 = 'Profile'
     .CompilerOptions        + ' -DPROFILING_ENABLED'
+]
+.X64ClangASanConfig_Linux =
+[
+    Using( .X64ClangReleaseConfig_Linux ) // Note: based on Release config
+    .Config                 = 'ASan'
+    .CompilerOptions        + .CompilerOptions_ASan
+    .CompilerOptionsC       + .CompilerOptions_ASan
+    .LinkerOptions          + .LinkerOptions_ASan
 ]
 
 // OSX
@@ -646,14 +668,18 @@ VCXProject( 'UpdateSolution-proj' )
              .X64DebugConfig, .X64ProfileConfig, .X64ReleaseConfig,
              .X86ClangDebugConfig, .X86ClangProfileConfig, .X86ClangReleaseConfig,
              .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
+             .X64ASanConfig_Linux,
              .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
+             .X64ClangASanConfig_Linux,
             .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 .Configs_Windows_MSVC   = { .X86DebugConfig, .X86ProfileConfig, .X86ReleaseConfig,
                             .X64DebugConfig, .X64ProfileConfig, .X64ReleaseConfig }
 .Configs_Windows_Clang  = { .X86ClangDebugConfig, .X86ClangProfileConfig, .X86ClangReleaseConfig }
 .Configs_Linux          = { .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
-                            .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux }
+                            .X64ASanConfig_Linux,
+                            .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
+                            .X64ClangASanConfig_Linux }
 .Configs_OSX_Clang      = { .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 // External
@@ -701,14 +727,21 @@ ForEach( .Config in .Configs )
 // Aliases : All-$Platform$
 //------------------------------------------------------------------------------
 .Platforms = { 'x86', 'x64', 'x86Clang', 'x64Linux', 'x64ClangLinux', 'x64OSX' }
+.PlatformConfigs_x86           = { 'Debug', 'Profile', 'Release' }
+.PlatformConfigs_x64           = { 'Debug', 'Profile', 'Release' }
+.PlatformConfigs_x86Clang      = { 'Debug', 'Profile', 'Release' }
+.PlatformConfigs_x64Linux      = { 'Debug', 'Profile', 'Release', 'ASan' }
+.PlatformConfigs_x64ClangLinux = { 'Debug', 'Profile', 'Release', 'ASan' }
+.PlatformConfigs_x64OSX        = { 'Debug', 'Profile', 'Release' }
 ForEach( .Platform in .Platforms )
 {
     Alias( 'All-$Platform$' )
     {
-        .Targets        = { 'All-$Platform$-Debug',
-                            'All-$Platform$-Profile',
-                            'All-$Platform$-Release'
-                          }
+        .Targets = {}
+        ForEach( .Config in .'PlatformConfigs_$Platform$' )
+        {
+            ^Targets + { 'All-$Platform$-$Config$' }
+        }
     }
 }
 

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -80,7 +80,7 @@ Compiler( 'Compiler-x64-Linux' )
 {
     .Executable = '/usr/bin/gcc'
 }
-Compiler( 'Compiler-x64-OSX' )
+Compiler( 'Compiler-x64Clang-LinuxOSX' )
 {
     .Executable = '/usr/bin/clang++'
 }
@@ -384,9 +384,7 @@ Compiler( 'Compiler-x64-OSX' )
 //------------------------------------------------------------------------------
 .LinuxBaseConfig =
 [
-    .Compiler               = 'Compiler-x64-Linux'
     .Librarian              = '/usr/bin/ar'
-    .Linker                 = '/usr/bin/g++'
 
     .BaseCompilerOptions    = '-o "%2" "%1" -c -g'
                             + ' -I./'
@@ -395,9 +393,10 @@ Compiler( 'Compiler-x64-OSX' )
                             + ' -Wextra'
                             + ' -m64'                           // x86-64
 
-    .CompilerOptionsC       = .BaseCompilerOptions
-    .CompilerOptions        = .BaseCompilerOptions
-                            + ' -std=c++11'                     // allow C++11 features
+    .CompilerOptionsC       = '-x c '
+                            + .BaseCompilerOptions
+    .CompilerOptions        = '-std=c++11 '                     // allow C++11 features
+                            + .BaseCompilerOptions
 
                             // Disabled warnings
                             + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
@@ -423,6 +422,8 @@ Compiler( 'Compiler-x64-OSX' )
 [
     Using( .LinuxBaseConfig )
     .Platform               = 'x64Linux'
+    .Compiler               = 'Compiler-x64-Linux'
+    .Linker                 = '/usr/bin/g++'
 ]
 .X64DebugConfig_Linux =
 [
@@ -453,12 +454,45 @@ Compiler( 'Compiler-x64-OSX' )
     .CompilerOptions        + ' -DPROFILING_ENABLED'
     .CompilerOptionsC       + ' -DPROFILING_ENABLED'
 ]
+.X64ClangBaseConfig_Linux =
+[
+    Using( .LinuxBaseConfig )
+    .Platform               = 'x64ClangLinux'
+    .Compiler               = 'Compiler-x64Clang-LinuxOSX'
+    .Linker                 = '/usr/bin/clang++'
+]
+.X64ClangDebugConfig_Linux =
+[
+    Using( .X64ClangBaseConfig_Linux )
+    .Config                 = 'Debug'
+    .CompilerOptions        + ' -DDEBUG -DPROFILING_ENABLED'
+                            + .CompilerDebugOptimizations
+    .CompilerOptionsC       + .CompilerDebugOptimizations
+    .LibrarianOptions       + .LibrarianDebugOptimizations
+    .LinkerOptions          + .LinkerDebugOptimizations
+]
+.X64ClangReleaseConfig_Linux =
+[
+    Using( .X64ClangBaseConfig_Linux )
+    .Config                 = 'Release'
+    .CompilerOptions        + ' -DRELEASE'
+                            + .CompilerReleaseOptimizations
+    .CompilerOptionsC       + .CompilerReleaseOptimizations
+    .LibrarianOptions       + .LibrarianReleaseOptimizations
+    .LinkerOptions          + .LinkerReleaseOptimizations
+]
+.X64ClangProfileConfig_Linux =
+[
+    Using( .X64ClangReleaseConfig_Linux ) // Note: based on Release config
+    .Config                 = 'Profile'
+    .CompilerOptions        + ' -DPROFILING_ENABLED'
+]
 
 // OSX
 //------------------------------------------------------------------------------
 .OSXBaseConfig =
 [
-    .Compiler               = 'Compiler-x64-OSX'
+    .Compiler               = 'Compiler-x64Clang-LinuxOSX'
     .Librarian              = '/usr/bin/ar'
     .Linker                 = '/usr/bin/g++'
 
@@ -612,12 +646,14 @@ VCXProject( 'UpdateSolution-proj' )
              .X64DebugConfig, .X64ProfileConfig, .X64ReleaseConfig,
              .X86ClangDebugConfig, .X86ClangProfileConfig, .X86ClangReleaseConfig,
              .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
+             .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
             .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 .Configs_Windows_MSVC   = { .X86DebugConfig, .X86ProfileConfig, .X86ReleaseConfig,
                             .X64DebugConfig, .X64ProfileConfig, .X64ReleaseConfig }
 .Configs_Windows_Clang  = { .X86ClangDebugConfig, .X86ClangProfileConfig, .X86ClangReleaseConfig }
-.Configs_Linux_GCC      = { .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux }
+.Configs_Linux          = { .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
+                            .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux }
 .Configs_OSX_Clang      = { .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 // External
@@ -664,7 +700,7 @@ ForEach( .Config in .Configs )
 
 // Aliases : All-$Platform$
 //------------------------------------------------------------------------------
-.Platforms = { 'x86', 'x64', 'x86Clang', 'x64Linux', 'x64OSX' }
+.Platforms = { 'x86', 'x64', 'x86Clang', 'x64Linux', 'x64ClangLinux', 'x64OSX' }
 ForEach( .Platform in .Platforms )
 {
     Alias( 'All-$Platform$' )
@@ -696,7 +732,9 @@ ForEach( .Platform in .Platforms )
 #if __LINUX__
     Alias( 'All' )
     {
-        .Targets        = { 'All-x64Linux' }
+        .Targets        = { 'All-x64Linux',
+                            'All-x64ClangLinux'
+                          }
     }
 #endif
 

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -474,6 +474,8 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
 
     .CompilerOptions_ASan   = ' -fsanitize=address -fno-omit-frame-pointer'
     .LinkerOptions_ASan     = ' -fsanitize=address'
+    .CompilerOptions_MSan   = ' -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer'
+    .LinkerOptions_MSan     = ' -fsanitize=memory'
 ]
 .X64ClangDebugConfig_Linux =
 [
@@ -508,6 +510,14 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
     .CompilerOptions        + .CompilerOptions_ASan
     .CompilerOptionsC       + .CompilerOptions_ASan
     .LinkerOptions          + .LinkerOptions_ASan
+]
+.X64ClangMSanConfig_Linux =
+[
+    Using( .X64ClangReleaseConfig_Linux ) // Note: based on Release config
+    .Config                 = 'MSan'
+    .CompilerOptions        + .CompilerOptions_MSan
+    .CompilerOptionsC       + .CompilerOptions_MSan
+    .LinkerOptions          + .LinkerOptions_MSan
 ]
 
 // OSX
@@ -670,7 +680,7 @@ VCXProject( 'UpdateSolution-proj' )
              .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
              .X64ASanConfig_Linux,
              .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
-             .X64ClangASanConfig_Linux,
+             .X64ClangASanConfig_Linux, .X64ClangMSanConfig_Linux,
             .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 .Configs_Windows_MSVC   = { .X86DebugConfig, .X86ProfileConfig, .X86ReleaseConfig,
@@ -679,7 +689,7 @@ VCXProject( 'UpdateSolution-proj' )
 .Configs_Linux          = { .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
                             .X64ASanConfig_Linux,
                             .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
-                            .X64ClangASanConfig_Linux }
+                            .X64ClangASanConfig_Linux, .X64ClangMSanConfig_Linux }
 .Configs_OSX_Clang      = { .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
 // External
@@ -731,7 +741,7 @@ ForEach( .Config in .Configs )
 .PlatformConfigs_x64           = { 'Debug', 'Profile', 'Release' }
 .PlatformConfigs_x86Clang      = { 'Debug', 'Profile', 'Release' }
 .PlatformConfigs_x64Linux      = { 'Debug', 'Profile', 'Release', 'ASan' }
-.PlatformConfigs_x64ClangLinux = { 'Debug', 'Profile', 'Release', 'ASan' }
+.PlatformConfigs_x64ClangLinux = { 'Debug', 'Profile', 'Release', 'ASan', 'MSan' }
 .PlatformConfigs_x64OSX        = { 'Debug', 'Profile', 'Release' }
 ForEach( .Platform in .Platforms )
 {

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -7,9 +7,9 @@ Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X86-Profi
 Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X86-Release', '$ProjectName$-X64-Release' } }
 #endif
 #if __LINUX__
-Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64Linux-Debug' } }
-Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-Profile' } }
-Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release' } }
+Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64Linux-Debug',   '$ProjectName$-X64ClangLinux-Debug' } }
+Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64ClangLinux-Profile' } }
+Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release', '$ProjectName$-X64ClangLinux-Release' } }
 #endif
 #if __OSX__
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64OSX-Debug' } }
@@ -22,6 +22,7 @@ Alias( '$ProjectName$-X86' )             { .Targets = { '$ProjectName$-X86-Debug
 Alias( '$ProjectName$-X64' )             { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
 Alias( '$ProjectName$-X86Clang' )        { .Targets = { '$ProjectName$-X86Clang-Debug' } }
 Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
+Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile' } }
 Alias( '$ProjectName$-X64OSX' )          { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
 
 // All

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -10,6 +10,7 @@ Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X86-Relea
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64Linux-Debug',   '$ProjectName$-X64ClangLinux-Debug' } }
 Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64ClangLinux-Profile' } }
 Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release', '$ProjectName$-X64ClangLinux-Release' } }
+Alias( '$ProjectName$-ASan' )            { .Targets = { '$ProjectName$-X64Linux-ASan',    '$ProjectName$-X64ClangLinux-ASan' } }
 #endif
 #if __OSX__
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64OSX-Debug' } }
@@ -21,12 +22,15 @@ Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64OSX-Re
 Alias( '$ProjectName$-X86' )             { .Targets = { '$ProjectName$-X86-Debug', '$ProjectName$-X86-Release', '$ProjectName$-X86-Profile' } }
 Alias( '$ProjectName$-X64' )             { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
 Alias( '$ProjectName$-X86Clang' )        { .Targets = { '$ProjectName$-X86Clang-Debug' } }
-Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile' } }
-Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile' } }
+Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64Linux-ASan' } }
+Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile', '$ProjectName$-X64ClangLinux-ASan' } }
 Alias( '$ProjectName$-X64OSX' )          { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
 
 // All
 Alias( '$ProjectName$' )
 {
     .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
+#if __LINUX__
+    .Targets + { '$ProjectName$-ASan' }
+#endif
 }

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -11,6 +11,7 @@ Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64Linux-
 Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64ClangLinux-Profile' } }
 Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release', '$ProjectName$-X64ClangLinux-Release' } }
 Alias( '$ProjectName$-ASan' )            { .Targets = { '$ProjectName$-X64Linux-ASan',    '$ProjectName$-X64ClangLinux-ASan' } }
+Alias( '$ProjectName$-MSan' )            { .Targets = { '$ProjectName$-X64ClangLinux-MSan' } }
 #endif
 #if __OSX__
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64OSX-Debug' } }
@@ -23,7 +24,7 @@ Alias( '$ProjectName$-X86' )             { .Targets = { '$ProjectName$-X86-Debug
 Alias( '$ProjectName$-X64' )             { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
 Alias( '$ProjectName$-X86Clang' )        { .Targets = { '$ProjectName$-X86Clang-Debug' } }
 Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64Linux-ASan' } }
-Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile', '$ProjectName$-X64ClangLinux-ASan' } }
+Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile', '$ProjectName$-X64ClangLinux-ASan', '$ProjectName$-X64ClangLinux-MSan' } }
 Alias( '$ProjectName$-X64OSX' )          { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
 
 // All
@@ -31,6 +32,6 @@ Alias( '$ProjectName$' )
 {
     .Targets = { '$ProjectName$-Debug', '$ProjectName$-Profile', '$ProjectName$-Release' }
 #if __LINUX__
-    .Targets + { '$ProjectName$-ASan' }
+    .Targets + { '$ProjectName$-ASan', '$ProjectName$-MSan' }
 #endif
 }

--- a/External/LZ4/LZ4.bff
+++ b/External/LZ4/LZ4.bff
@@ -73,9 +73,9 @@
 		Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
 	}
 	
-    // Linux (GCC)
+    // Linux (GCC, Clang)
     //--------------------------------------------------------------------------
-    ForEach( .Config in .Configs_Linux_GCC )
+    ForEach( .Config in .Configs_Linux )
     {
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'


### PR DESCRIPTION
This PR adds support for building with Clang on Linux (Debug, Release, Profile) and building with [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) (with GCC and Clang) and with [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) (Clang only). More details in the corresponding commits messages.

Main goal is to add required build configurations for a fuzzer based on [libFuzzer](http://llvm.org/docs/LibFuzzer.html) for `BFFParser` which is currently work-in-progress (branch `bff_fuzzer` in my fork).

There is a separate PR (#312) for the first two commits. I also fixed some minor errors found by sanitizers. Let me know if you think that this PR should be split further.