### PR TITLE
Use traditional file name extension for static libraries on Linux and OSX

### DIFF
--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -111,7 +111,7 @@
 
             // Output
             .CompilerOutputPath         = '$OutputBase$\$ProjectName$\'
-            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.lib'
+            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.a'
         }
 
         // Executable
@@ -151,7 +151,7 @@
 
             // Output
             .CompilerOutputPath         = '$OutputBase$\$ProjectName$\'
-            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.lib'
+            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.a'
         }
 
         // Executable

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -107,7 +107,7 @@
 
             // Output
             .CompilerOutputPath         = '$OutputBase$\$ProjectName$\'
-            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.lib'
+            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.a'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
     }


### PR DESCRIPTION
Just a minor consistency fix.