### PR TITLE
Fixes remote compilation errors treated as system errors on clang

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2178,7 +2178,7 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
             if ( result == 0x01 )
             {
                 // TODO:C Should we check for localized msg?
-                if ( stdErr && ( strcmp( stdErr, "IO failure on output stream" ) ) )
+                if ( stdErr && ( strstr( stdErr, "IO failure on output stream" ) ) )
                 {
                     job->OnSystemError();
                     return;
@@ -2193,7 +2193,7 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
             if ( result == 0x01 )
             {
                 // TODO:C Should we check for localized msg?
-                if ( stdErr && ( strcmp( stdErr, "No space left on device" ) ) )
+                if ( stdErr && ( strstr( stdErr, "No space left on device" ) ) )
                 {
                     job->OnSystemError();
                     return;


### PR DESCRIPTION
On remote workers whenever compilation fails it is reported as a system error when clang is used. This is because clang returns 1 on failed compilations. 

I am unsure about gcc, but it seems to me that this version will be safer anyway.