### PR TITLE
Fix one more case of partially copied AString

### DIFF
--- a/Code/Core/Strings/AString.cpp
+++ b/Code/Core/Strings/AString.cpp
@@ -1042,7 +1042,7 @@ void AString::Grow( uint32_t newLength )
     char * newMem = (char *)ALLOC( reserve + 1 ); // also allocate for \0 terminator
 
     // transfer existing string data
-    Copy( m_Contents, newMem ); // copy handles terminator
+    Copy( m_Contents, newMem, m_Length ); // copy handles terminator
 
     if ( MemoryMustBeFreed() )
     {


### PR DESCRIPTION
See detailed reasoning in e88b121fb5ccaeba0728417a27695b8ac18e2d40.

This case was found with libFuzzer and MemorySanitizer on an input with a null character embedded in BFF string. Minimal reproducer is (5th character should be `\0` instead of `0`):
```
.S='01234567'+.S+.S+.S+.S+.S+.S+.S+.S
+'X'
-' '
```
In this case the first line creates a string of length 2048 which is the maximum that can be stored inside variable `value` in `BFFParser::StoreVariableString`. Also this string has `\0` as the first character.  
Second line triggers allocation of a new buffer on the heap, and `AString::Grow` copies data only up to the first null.  
Third line scans all 2049 characters of `.S` for a space and triggers MSan diagnostic in `AString::StrNCmp`.