### PR TITLE
Correctly interpret status code of waitpid(), add test

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_crash.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_crash.bff
@@ -15,7 +15,7 @@ Settings {}
 //------------------------------------------------------------------------------
 ObjectList( "Exe-Lib" )
 {
-    .CompilerInputFiles = 'Data/TestTest/test_timeout.cpp'
+    .CompilerInputFiles = 'Data/TestTest/test_crash.cpp'
     .CompilerOutputPath = '$Out$/Test/Test/'
 }
 
@@ -25,7 +25,7 @@ Executable( "Exe" )
         .LinkerOptions      + ' /SUBSYSTEM:CONSOLE'
                             + ' /ENTRY:main'
     #endif
-    .LinkerOutput       = '$Out$/Test/Test/test_timeout.exe'
+    .LinkerOutput       = '$Out$/Test/Test/test_crash.exe'
     .Libraries          = { 'Exe-Lib' }
 }
 
@@ -34,6 +34,5 @@ Executable( "Exe" )
 Test( "Test" )
 {
     .TestExecutable     = 'Exe'
-    .TestOutput         = '$Out$/Test/Test/test_timeout_output.txt'
-    .TestTimeOut        = 1 // kill after 1ms
+    .TestOutput         = '$Out$/Test/Test/test_crash_output.txt'
 }

--- a/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_crash.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_crash.cpp
@@ -1,0 +1,10 @@
+//
+// An test that crashes
+//
+
+int main(int , char **)
+{
+    volatile int * volatile p = 0;
+    *p = 42;
+    return 0;
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestTest.cpp
@@ -22,6 +22,7 @@ private:
     void Build() const;
     void Build_NoRebuild() const;
     void TimeOut() const;
+    void Crash() const;
 };
 
 // Register Tests
@@ -31,6 +32,7 @@ REGISTER_TESTS_BEGIN( TestTest )
     REGISTER_TEST( Build )
     REGISTER_TEST( Build_NoRebuild )
     REGISTER_TEST( TimeOut )
+    REGISTER_TEST( Crash )
 REGISTER_TESTS_END
 
 // CreateNode
@@ -116,6 +118,20 @@ void TestTest::TimeOut() const
 {
     FBuildOptions options;
     options.m_ConfigFile = "Data/TestTest/test_timeout.bff";
+    options.m_FastCancel = true;
+    FBuild fBuild( options );
+    TEST_ASSERT( fBuild.Initialize() );
+
+    // build (via alias)
+    TEST_ASSERT( fBuild.Build( AStackString<>( "Test" ) ) == false );
+}
+
+// Crash
+//------------------------------------------------------------------------------
+void TestTest::Crash() const
+{
+    FBuildOptions options;
+    options.m_ConfigFile = "Data/TestTest/test_crash.bff";
     options.m_FastCancel = true;
     FBuild fBuild( options );
     TEST_ASSERT( fBuild.Initialize() );


### PR DESCRIPTION
`WEXITSTATUS` can be used only if `WIFEXITED` returns true, in fact `WEXITSTATUS` returns 0 if the process was terminated by a signal. This resulted in crashed tests being treated as passed by TestNode.

This change expands status checks to handle all state changes (normal termination, termination by a signal, process receiving `SIGSTOP`).

Also added a test for TestNode that verifies that crash of a test executable is detected and treated as test failure.