### PR TITLE
Fix crash when pressing CTRL-C in a commandline because FBuild singleton was null.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -48,9 +48,9 @@ public:
     bool SaveDependencyGraph( const char * nodeGraphDBFile ) const;
     void SaveDependencyGraph( IOStream & memorySteam, const char* nodeGraphDBFile ) const;
 
-    const FBuildOptions & GetOptions() const { return m_Options; }
+    static const FBuildOptions & GetOptions() { return s_Options; }
 
-    const AString & GetWorkingDir() const { return m_Options.GetWorkingDir(); }
+    const AString & GetWorkingDir() const { return s_Options.GetWorkingDir(); }
 
     static const char * GetDefaultBFFFileName();
 
@@ -129,7 +129,7 @@ private:
 
     FBuildStats m_BuildStats;
 
-    FBuildOptions m_Options;
+    static FBuildOptions s_Options;
 
     WorkerBrokerage m_WorkerBrokerage;
 


### PR DESCRIPTION
Hi Franta,

This fixes a 100% crash occuring when building from commandline and pressing CTRL-C because the FBuild singleton was null in the CTRL-C handler. I fixed it by making the FBuildOption static and renamed it to follow the naming convention.

Note: The crash occurs in fastcancel mode.