### PR TITLE
By default show progress bar only if stdout goes to the terminal

### DIFF
--- a/Code/Core/Env/Env.cpp
+++ b/Code/Core/Env/Env.cpp
@@ -228,6 +228,54 @@ void Env::GetExePath( AString & output )
     #endif
 }
 
+// IsStdOutRedirected
+//------------------------------------------------------------------------------
+/*static*/ bool Env::IsStdOutRedirected()
+{
+    #if defined( __WINDOWS__ )
+        HANDLE h = GetStdHandle( STD_OUTPUT_HANDLE );
+        ASSERT( h != INVALID_HANDLE_VALUE );
+        if ( h == NULL )
+            return true; // There is no handle associated with stdout, this is essentially a redirection to NUL
+
+        // Check if the handle belongs to a console window
+        DWORD unused;
+        if ( GetConsoleMode( h, (LPDWORD)&unused ) )
+            return false; // Console window exists, so there is no redirection
+
+        // Check if the handle belongs to a pipe used by Cygwin/MSYS to forward output to a terminal
+        if ( GetFileType( h ) != FILE_TYPE_PIPE )
+            return true; // Redirected to something that is not a pipe
+
+        char buffer[ sizeof( FILE_NAME_INFO ) + MAX_PATH * sizeof( wchar_t ) ];
+        if ( ! GetFileInformationByHandleEx( h, FileNameInfo, buffer, sizeof( buffer ) ) )
+            return true; // Redirected to something that doesn't have a name
+
+        FILE_NAME_INFO * info = reinterpret_cast< FILE_NAME_INFO * >( buffer );
+        info->FileName[ info->FileNameLength / sizeof( wchar_t ) ] = L'\0';
+
+        // Check if name of the pipe matches pattern "\cygwin-%llx-pty%d-to-master" or "\msys-%llx-pty%d-to-master"
+        const wchar_t * p = nullptr;
+        if ( ( p = wcsstr( info->FileName, L"\\cygwin-" ) ) != nullptr )
+            p += 7;
+        else if ( ( p = wcsstr( info->FileName, L"\\msys-" ) ) != nullptr )
+            p += 5;
+        else
+            return true; // Redirected to a pipe that is not related to Cygwin/MSYS
+        int nChars = 0;
+        if ( ( swscanf( p, L"%*llx-pty%*d-to-master%n", &nChars ) == 0 ) && ( nChars > 0 ) )
+            return false; // Pipe name matches the pattern, stdout is forwarded to a terminal by Cygwin/MSYS
+
+        return true;
+    #elif defined( __LINUX__ )
+        return ( isatty( STDOUT_FILENO ) == 0 );
+    #elif defined( __APPLE__ )
+        return false; // TODO:MAC Implement IsStdOutRedirected
+    #else
+        #error Unknown platform
+    #endif
+}
+
 // GetLastErr
 //------------------------------------------------------------------------------
 /*static*/ uint32_t Env::GetLastErr()

--- a/Code/Core/Env/Env.h
+++ b/Code/Core/Env/Env.h
@@ -34,6 +34,7 @@ public:
     static bool SetEnvVariable( const char * envVarName, const AString & envVarValue );
     static void GetCmdLine( AString & cmdLine );
     static void GetExePath( AString & path );
+    static bool IsStdOutRedirected();
 
     static uint32_t GetLastErr();
 };

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -55,6 +55,8 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
         }
     }
 
+    bool progressOptionSpecified = false;
+
     // Parse options
     for ( int32_t i=1; i<argc; ++i ) // start from 1 to skip exe name
     {
@@ -181,6 +183,13 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
             else if ( thisArg == "-noprogress" )
             {
                 m_ShowProgress = false;
+                progressOptionSpecified = true;
+                continue;
+            }
+            else if ( thisArg == "-progress" )
+            {
+                m_ShowProgress = true;
+                progressOptionSpecified = true;
                 continue;
             }
             else if ( thisArg == "-nostoponerror")
@@ -241,6 +250,7 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
             else if ( ( thisArg == "-ide" ) || ( thisArg == "-vs" ) )
             {
                 m_ShowProgress = false;
+                progressOptionSpecified = true;
                 #if defined( __WINDOWS__ )
                     m_FixupErrorPaths = true;
                     m_WrapperMode = WRAPPER_MODE_MAIN_PROCESS;
@@ -295,6 +305,12 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
             // assume target
             m_Targets.Append( thisArg );
         }
+    }
+
+    if ( progressOptionSpecified == false )
+    {
+        // By default show progress bar only if stdout goes to the terminal
+        m_ShowProgress = ( Env::IsStdOutRedirected() == false );
     }
 
     // Default to build "all"
@@ -456,6 +472,7 @@ void FBuildOptions::DisplayHelp( const AString & programName ) const
             " -j[x]          Explicitly set LOCAL worker thread count X, instead of\n"
             "                default of hardware thread count.\n"
             " -noprogress    Don't show the progress bar while building.\n"
+            " -progress      Show the progress bar while building, even if stdout is redirected.\n"
             " -nostoponerror Don't stop building on first error. Try to build as much\n"
             "                as possible.\n"
             " -nosummaryonerror Hide the summary if the build fails. Implies -summary.\n"


### PR DESCRIPTION
This allows to redirect `FBuild` output to file or pager (like `less`) without needing to specify `-noprogress` to get a readable result.

Also added option `-progress` to force the old behaviour – to show progress bar unconditionally.

Windows implementation of redirect detection supports both native console windows and Cygwin/MSYS terminals. I was unable to test it with MSVS 2013 (don't have it installed right now), but it works fine when `FBuild.exe` is compiled with MSVS 2017.

There is no implementation for MacOS. In theory it should be the same as for Linux, but since I can't check that (don't have a Mac) there is a stub currently.