### PR TITLE
Update bash completion script

### DIFF
--- a/Code/Tools/FBuild/Integration/fbuild.bash-completion
+++ b/Code/Tools/FBuild/Integration/fbuild.bash-completion
@@ -5,18 +5,25 @@ _fbuild() {
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
 	local opts="
 		-cache
+		-cacheinfo
 		-cacheread
+		-cachetrim
 		-cachewrite
 		-clean
 		-config
 		-dist
+		-distverbose
+		-fastcancel
 		-fixuperrorpaths
+		-forceremote
 		-help
 		-ide
 		-j
 		-monitor
 		-noprogress
 		-nostoponerror
+		-nosummaryonerror
+		-quiet
 		-report
 		-showcmds
 		-showtargets
@@ -27,6 +34,13 @@ _fbuild() {
 		-wait
 		-wrapper
 	"
+
+	# Offer nothing after -cachetrim to indicate that this option requires an argument
+	case ${prev} in
+	-cachetrim)
+		return 0
+		;;
+	esac
 
 	# Offer files after -config
 	case ${prev} in
@@ -61,11 +75,11 @@ _fbuild() {
 	COMPREPLY=( $( compgen -W "${opts} ${targets}" -- "${cur}" ) )
 }
 
-complete -o bashdefault -o default -F _fbuild fbuild
-complete -o bashdefault -o default -F _fbuild FBuild
+complete -F _fbuild fbuild
+complete -F _fbuild FBuild
 case "$(uname)" in
 MINGW32*|MSYS*|CYGWIN*)
-	complete -o bashdefault -o default -F _fbuild fbuild.exe
-	complete -o bashdefault -o default -F _fbuild FBuild.exe
+	complete -F _fbuild fbuild.exe
+	complete -F _fbuild FBuild.exe
 	;;
 esac


### PR DESCRIPTION
   * Added new FBuild options.
   * Disabled default completion source that was adding files from current directory to the list (which are not very useful as an argument to FBuild).
   * Disabled completion after `-cachetrim` to indicate that an argument is required.