### PR TITLE
Surround config file path with "

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -127,7 +127,9 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
 
                 // add to args we might pass to subprocess
                 m_Args += ' ';
+                m_Args += '"'; // surround config file with quotes to avoid problems with spaces in the path
                 m_Args += m_ConfigFile;
+                m_Args += '"';
                 continue;
             }
             #ifdef DEBUG


### PR DESCRIPTION
To avoid problems with spaces in the path. As mentioned here https://github.com/fastbuild/fastbuild/issues/146