### PR TITLE
FBuildWorker: Don't show notification when minimizing and on start-up

### DIFF
--- a/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
@@ -206,14 +206,17 @@ void WorkerWindow::UIUpdateThread()
         m_Menu = CreatePopupMenu();
         AppendMenu( m_Menu, MF_STRING, ID_TRAY_EXIT_CONTEXT_MENU_ITEM, TEXT( "Exit" ) );
 
-        // Display the window, and minimize it
-        // - we do this so the user can see the application has run
-        ShowWindow( (HWND)GetHandle(), SW_SHOW );
-        UpdateWindow( (HWND)GetHandle() );
-        ShowWindow( (HWND)GetHandle(), SW_SHOW ); // First call can be ignored
+        // Display the window or and minimize it.
         if ( WorkerSettings::Get().GetStartMinimzed() )
         {
+            UpdateWindow( (HWND)GetHandle() );
             ToggleMinimized(); // minimze
+        }
+        else
+        {
+          ShowWindow( (HWND)GetHandle(), SW_SHOW );
+          UpdateWindow( (HWND)GetHandle() );
+          ShowWindow( (HWND)GetHandle(), SW_SHOW ); // First call can be ignored
         }
 
         SetStatus( "Idle" );
@@ -341,9 +344,6 @@ void WorkerWindow::ToggleMinimized()
         {
             // hide the main window
             ShowWindow( (HWND)GetHandle(), SW_HIDE );
-
-            // balloon
-            m_TrayIcon->ShowNotification( "FBuildWorker minimized to tray." );
         }
         else
         {


### PR DESCRIPTION
Please consider this or a different mechanism to solve two issues with the "FBuildWorker minimized to tray." notification. On applies to all versions of Windows (AFAIK), the other only to recent Windows 10:

- Showing and hiding the window on start-up steals the focus. This is quite
  annoying because it prevents me from using my system until every background
  process like FBuildWorker has started up. I firmly believe that software should not
  steal a user's focus unless it comes to the foreground and stays there.

- Since Windows 10 1709, notifications for tray icons are added to the
  notification area. They will stay there until the user dismisses them.
  This is distracting since Windows shows that I have one new notification that 
  after /every/ log-in + start of FBuildWorker. It reads:
  "FBuildWorker minimized to tray." 
