### PR TITLE
Fix name of ExecExecutable property

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -50,9 +50,9 @@ bool ExecNode::Initialize( NodeGraph & nodeGraph, const BFFIterator & iter, cons
         return false; // InitializePreBuildDependencies will have emitted an error
     }
 
-    // .ExecExcecutable
+    // .ExecExecutable
     Dependencies executable;
-    if ( !function->GetFileNode( nodeGraph, iter, m_ExecExecutable, "ExecExcecutable", executable ) )
+    if ( !function->GetFileNode( nodeGraph, iter, m_ExecExecutable, "ExecExecutable", executable ) )
     {
         return false; // GetFileNode will have emitted an error
     }


### PR DESCRIPTION
I was updating Vim syntax highlight for FASTBuild 0.95 and [my script](https://github.com/dummyunit/vim-fastbuild/blob/master/check_properties.sh) reported this string as a potential new property: `ExecExcecutable`. This is suspiciously similar to existing property `ExecExecutable` and is probably a typo.