### PR TITLE
Fix path simplification unit-test on non-windows platforms

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -495,7 +495,7 @@ void TestGraph::TestCleanPathPartial() const
     // ".." collapsing
     CHECK("one\\two\\..\\..\\three\\four\\file.dat", "three\\four\\file.dat", "three/four/file.dat")
     CHECK("one\\two\\..\\three\\file.dat", "one\\three\\file.dat", "one/three/file.dat")
-    CHECK("one\\two\\..\\..\\..\\..\\three\\four\\file.dat", "..\\..\\three\\four\\file.dat", "..//..//three/four/file.dat")
+    CHECK("one\\two\\..\\..\\..\\..\\three\\four\\file.dat", "..\\..\\three\\four\\file.dat", "../../three/four/file.dat")
 
     //   full path '\'
 #if defined( __WINDOWS__ )


### PR DESCRIPTION
Fix dual forward slash leftover in the expected simplified result for non-windows platforms.

Sorry about that...