### PR TITLE
Reset FLAG_STATIC_ANALYSIS_MSVC when /analyze- is specified

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -849,7 +849,14 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
             }
             else if ( IsStartOfCompilerArg_MSVC( token, "analyze" ) )
             {
-                flags |= ObjectNode::FLAG_STATIC_ANALYSIS_MSVC;
+                if ( IsCompilerArg_MSVC( token, "analyze-" ) )
+                {
+                    flags &= ( ~ObjectNode::FLAG_STATIC_ANALYSIS_MSVC );
+                }
+                else
+                {
+                    flags |= ObjectNode::FLAG_STATIC_ANALYSIS_MSVC;
+                }
             }
         }
 


### PR DESCRIPTION
Previously presence of option `/analyze-` in `.CompilerOptions` was enabling `FLAG_STATIC_ANALYSIS_MSVC`. This resulted in failing cache writes because FASTBuild was trying to open `.nativecodeanalysis.xml` files which weren't produced in that case.

This change resets `FLAG_STATIC_ANALYSIS_MSVC` when `/analyze-` is encountered.