### PR TITLE
Fixes not finding libraries in LinkerOptions

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -1119,33 +1119,32 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     {
         bool found = false;
 
-        // is the file a full path?
-        if ( ( itL->GetLength() > 2 ) && ( (*itL)[ 1 ] == ':' ) )
+        // check file exists in current location
+        if ( !GetOtherLibrary( nodeGraph, iter, function, otherLibraries, AString::GetEmpty(), *itL, found ) )
         {
-            // check file exists in current location
-            if ( !GetOtherLibrary( nodeGraph, iter, function, otherLibraries, AString::GetEmpty(), *itL, found ) )
+            return false; // GetOtherLibrary will have emitted error
+        }
+
+        if ( found )
+        {
+            continue;
+        }
+
+        // check each libpath
+        const AString * const endP = libPaths.End();
+        for ( const AString * itP = libPaths.Begin(); itP != endP; ++itP )
+        {
+            if ( !GetOtherLibrary( nodeGraph, iter, function, otherLibraries, *itP, *itL, found ) )
             {
                 return false; // GetOtherLibrary will have emitted error
             }
-        }
-        else
-        {
-            // check each libpath
-            const AString * const endP = libPaths.End();
-            for ( const AString * itP = libPaths.Begin(); itP != endP; ++itP )
+
+            if ( found )
             {
-                if ( !GetOtherLibrary( nodeGraph, iter, function, otherLibraries, *itP, *itL, found ) )
-                {
-                    return false; // GetOtherLibrary will have emitted error
-                }
-
-                if ( found )
-                {
-                    break;
-                }
-
-                // keep searching lib paths...
+                break;
             }
+
+            // keep searching lib paths...
         }
 
         // file does not exist on disk, and there is no rule to build it

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -614,34 +614,36 @@ void LinkerNode::GetAssemblyResourceFiles( Args & fullArgs, const AString & pre,
 
     if ( linkerType.IsEmpty() || ( linkerType == "auto" ))
     {
+        const char * filename = linkerName.FindLast( NATIVE_SLASH );
+        AStackString<> linker (filename ? ( filename  + 1 ) : linkerName.Get());
+
         // Detect based upon linker executable name
-        if ( ( linkerName.EndsWithI( "link.exe" ) ) ||
-            ( linkerName.EndsWithI( "link" ) ) )
+        if ( linker.BeginsWithI( "link" ) )
         {
             flags |= LinkerNode::LINK_FLAG_MSVC;
         }
-        else if ( ( linkerName.EndsWithI( "gcc.exe" ) ) ||
-            ( linkerName.EndsWithI( "gcc" ) ) )
+        else if ( linker.BeginsWithI( "gcc" ) ||
+            linker.BeginsWithI( "g++" ) )
         {
             flags |= LinkerNode::LINK_FLAG_GCC;
         }
-        else if ( ( linkerName.EndsWithI( "ps3ppuld.exe" ) ) ||
-            ( linkerName.EndsWithI( "ps3ppuld" ) ) )
+        else if ( linker.BeginsWithI( "clang" ) )
+        {
+            flags |= LinkerNode::LINK_FLAG_GCC;
+        }
+        else if ( linker.BeginsWithI( "ps3ppuld" ) )
         {
             flags |= LinkerNode::LINK_FLAG_SNC;
         }
-        else if ( ( linkerName.EndsWithI( "orbis-ld.exe" ) ) ||
-            ( linkerName.EndsWithI( "orbis-ld" ) ) )
+        else if ( linker.BeginsWithI( "orbis-ld" ) )
         {
             flags |= LinkerNode::LINK_FLAG_ORBIS_LD;
         }
-        else if ( ( linkerName.EndsWithI( "elxr.exe" ) ) ||
-            ( linkerName.EndsWithI( "elxr" ) ) )
+        else if ( linker.BeginsWithI( "elxr" ) )
         {
             flags |= LinkerNode::LINK_FLAG_GREENHILLS_ELXR;
         }
-        else if ( ( linkerName.EndsWithI( "mwldeppc.exe" ) ) ||
-            ( linkerName.EndsWithI( "mwldeppc." ) ) )
+        else if ( linker.BeginsWithI( "mwldeppc" ) )
         {
             flags |= LinkerNode::LINK_FLAG_CODEWARRIOR_LD;
         }

--- a/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/a.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/a.cpp
@@ -1,0 +1,7 @@
+
+#include "a.h"
+
+ClassA::ClassA()
+: m_Int( 1 )
+{
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/a.h
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/a.h
@@ -1,0 +1,10 @@
+
+class ClassA
+{
+public:
+    ClassA();
+
+    inline int FunctionA() const { return m_Int; }
+private:
+    int m_Int;
+};

--- a/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/exe.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/exe.cpp
@@ -1,0 +1,8 @@
+//
+// An simple executable to run
+//
+
+int main(int, char **)
+{
+    return 99;
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/fbuild.bff
@@ -1,0 +1,28 @@
+;
+; Build a test library
+;
+#include "../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+.CompilerOutputPath = "$Out$/Test/LinkerDependencies/"
+
+Library( 'libA' )
+{
+    .CompilerInputFiles = 'Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/a.cpp'
+    .LibrarianOutput    = '$Out$/Test/LinkerDependencies/a.lib'
+}
+ObjectList( "Exe-Lib" )
+{
+    .CompilerInputFiles = "Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/exe.cpp"
+}
+Executable( "Exe" )
+{
+    #if __WINDOWS__
+        .LinkerOptions      + ' /SUBSYSTEM:CONSOLE'
+                            + ' /ENTRY:main'
+    #endif
+    .LinkerOutput       = '$Out$/Test/LinkerDependencies/exe.exe'
+    .Libraries          = { "Exe-Lib" }
+    .LinkerOptions      + ' $Out$/Test/LinkerDependencies/a.lib'
+}

--- a/Code/Tools/FBuild/FBuildTest/TestMain.cpp
+++ b/Code/Tools/FBuild/FBuildTest/TestMain.cpp
@@ -40,6 +40,7 @@ int main(int , char * [])
     REGISTER_TESTGROUP( TestUnity )
     REGISTER_TESTGROUP( TestVariableStack )
     REGISTER_TESTGROUP( TestWarnings )
+    REGISTER_TESTGROUP( TestLinkerDependencies )
 
     // Windows-specific tests
     #if defined( __WINDOWS__ )

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestLinkerDependencies.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestLinkerDependencies.cpp
@@ -1,0 +1,82 @@
+// TestLinkerDependencies.cpp
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "FBuildTest.h"
+
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+
+#include "Core/FileIO/FileIO.h"
+#include "Core/Strings/AStackString.h"
+
+// TestLinkerDependencies
+//------------------------------------------------------------------------------
+class TestLinkerDependencies : public FBuildTest
+{
+private:
+    DECLARE_TESTS
+
+    void TestParseBFF() const;
+    void TestBuildExe() const;
+
+    const char * GetBuildExeDBFileName() const { return "../tmp/Test/LinkerDependencies/exe.fdb"; }
+};
+
+// Register Tests
+//------------------------------------------------------------------------------
+REGISTER_TESTS_BEGIN( TestLinkerDependencies )
+    REGISTER_TEST( TestParseBFF )
+    REGISTER_TEST( TestBuildExe )
+REGISTER_TESTS_END
+
+// TestStackFramesEmpty
+//------------------------------------------------------------------------------
+void TestLinkerDependencies::TestParseBFF() const
+{
+    FBuildOptions options;
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/fbuild.bff";
+
+    FBuild fBuild( options );
+    TEST_ASSERT( fBuild.Initialize() );
+}
+
+// TestBuildExe
+//------------------------------------------------------------------------------
+void TestLinkerDependencies::TestBuildExe() const
+{
+    FBuildOptions options;
+    options.m_ShowSummary = true; // required to generate stats for node count checks
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestLinkerDependencies/fbuild.bff";
+
+    FBuild fBuild( options );
+    TEST_ASSERT( fBuild.Initialize() );
+
+    const AStackString<> exe( "../tmp/Test/LinkerDependencies/exe.exe" );
+    #if defined( __WINDOWS__ )
+        const AStackString<> obj1( "../tmp/Test/LinkerDependencies/a.obj" );
+    #else
+        const AStackString<> obj1( "../tmp/Test/LinkerDependencies/a.o" );
+    #endif
+
+    // clean up anything left over from previous runs
+    EnsureFileDoesNotExist( exe );
+    EnsureFileDoesNotExist( obj1 );
+
+    // Build
+    TEST_ASSERT( fBuild.Build( exe ) );
+    TEST_ASSERT( fBuild.SaveDependencyGraph( GetBuildExeDBFileName() ) );
+
+    // make sure all output files are as expected
+    EnsureFileExists( exe );
+    EnsureFileExists( obj1 );
+
+    // Check stats
+    //               Seen,  Built,  Type
+    CheckStatsNode ( 5,     4,      Node::FILE_NODE ); // 2 cpps + exe
+    CheckStatsNode ( 1,     1,      Node::COMPILER_NODE );
+    CheckStatsNode ( 2,     2,      Node::OBJECT_NODE );
+    CheckStatsNode ( 1,     1,      Node::LIBRARY_NODE );
+    CheckStatsNode ( 1,     1,      Node::EXE_NODE );
+    CheckStatsTotal( 11,    10 );
+}


### PR DESCRIPTION
Libraries defined as part of `LinkerOptions` are ignored, breaking dependencies. This fixes a couple of bugs:

- The full path check worked only on Windows
- If `libPaths` is empty and the libraries are defined in relative form