### PR TITLE
Not using LIB from Settings when looking for libs

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -941,10 +941,8 @@ bool LinkerNode::GetOtherLibraries( NodeGraph & nodeGraph,
 
     // extract lib path from system if present
     AStackString< 1024 > libVar;
-    if ( Env::GetEnvVariable( "LIB", libVar ) )
-    {
-        libVar.Tokenize( envLibPaths, ';' );
-    }
+    FBuild::Get().GetLibEnvVar( libVar );
+    libVar.Tokenize( envLibPaths, ';' );
 
     const AString * const end = tokens.End();
     for ( const AString * it = tokens.Begin(); it != end; ++it )


### PR DESCRIPTION
`LinkerNode` should request the `LIB` variable from FBuild directly instead of going to the environment.