### PR TITLE
Fixes OSX compilation

### DIFF
--- a/Code/Core/Mem/MemDebug.cpp
+++ b/Code/Core/Mem/MemDebug.cpp
@@ -9,6 +9,8 @@
 
 #if defined( MEM_DEBUG_ENABLED )
 
+#include <cstdint>
+
 // Core
 #include "Core/Env/Assert.h"
 


### PR DESCRIPTION
Getting error that `uintptr_t` doesn't exist.