### PR TITLE
BFF fixes for Linux

### DIFF
--- a/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
+++ b/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
@@ -6,28 +6,13 @@
 
     // Unity
     //--------------------------------------------------------------------------
+    Unity( '$ProjectName$-Unity' )
     {
-        // Common options
         .UnityInputPath             = '$ProjectPath$\'
         .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
-
-        // Windows
-        Unity( '$ProjectName$-Unity-Windows' )
-        {
-        }
-
-        // Linux
-        Unity( '$ProjectName$-Unity-Linux' )
-        {
-        }
-
-        // OSX
-        Unity( '$ProjectName$-Unity-OSX' )
-        {
-        }
     }
 
-    // Linux (Clang)
+    // Executable
     //--------------------------------------------------------------------------
     // These options are a valid for Clang <= 5.0.0:
     .ExtraLinkerOptions_ASan = ' -lLLVMFuzzer'
@@ -42,15 +27,16 @@
         Using( .Config )
         .OutputBase + '\$Platform$-$Config$'
 
-        // Objects
+        // Library
+        //--------------------------------------------------------------------------
         ObjectList( '$ProjectName$-Lib-$Platform$-$Config$' )
         {
             // Input (Unity)
-            .CompilerInputUnity         = '$ProjectName$-Unity-Linux'
+            .CompilerInputUnity         = '$ProjectName$-Unity'
 
             // Output
-            .CompilerOutputPath         = '$OutputBase$\$ProjectName$\'
-            .LibrarianOutput            = '$OutputBase$\$ProjectName$\$ProjectName$.a'
+            .CompilerOutputPath         = '$OutputBase$/$ProjectName$/'
+            .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
         }
 
         // Executable
@@ -62,7 +48,7 @@
                                             'Core-Lib-$Platform$-$Config$',
                                             'LZ4-Lib-$Platform$-$Config$'
                                           }
-            .LinkerOutput               = '$OutputBase$\Tools\FBuild\BFFFuzzer\bfffuzzer'
+            .LinkerOutput               = '$OutputBase$/$ProjectPath$/bfffuzzer$ExeExtension$'
             .LinkerOptions              + ' -pthread -ldl -lrt'
                                         + .'ExtraLinkerOptions_$Config$'
         }

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -82,8 +82,6 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
 [
     .CompilerOptions                = ' -DRELEASE'
                                     + ' -fsanitize=address -fno-omit-frame-pointer'
-                                    + ' -fsanitize-coverage=trace-pc-guard' // These options are a valid for Clang <= 5.0.0:
-                                    //+ ' -fsanitize=fuzzer-no-link'          // These options are expected to be valid for Clang > 5.0.0:
     .CompilerOptionsC               = .CompilerOptions
     .CompilerOptionsPCH             = .CompilerOptions
     .LinkerOptions                  = ' -fsanitize=address'
@@ -94,13 +92,18 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
 [
     .CompilerOptions                = ' -DRELEASE'
                                     + ' -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer'
-                                    + ' -fsanitize-coverage=trace-pc-guard' // These options are a valid for Clang <= 5.0.0:
-                                    //+ ' -fsanitize=fuzzer-no-link'          // These options are expected to be valid for Clang > 5.0.0:
     .CompilerOptionsC               = .CompilerOptions
     .CompilerOptionsPCH             = .CompilerOptions
     .LinkerOptions                  = ' -fsanitize=memory'
 
     .Config                         = 'MSan'
+]
+.Fuzzer_Config =
+[
+    .CompilerOptions                = ' -fsanitize-coverage=trace-pc-guard' // These options are a valid for Clang <= 5.0.0:
+                                    //+ ' -fsanitize=fuzzer-no-link'          // These options are expected to be valid for Clang > 5.0.0:
+    .CompilerOptionsC               = .CompilerOptions
+    .CompilerOptionsPCH             = .CompilerOptions
 ]
 
 //------------------------------------------------------------------------------
@@ -375,9 +378,11 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
                             + .Profile_Optimizations
 .X64ClangASanConfig_Linux   = .X64ClangBaseConfig_Linux
                             + .ASan_Config
+                            + .Fuzzer_Config
                             + .Release_Optimizations
 .X64ClangMSanConfig_Linux   = .X64ClangBaseConfig_Linux
                             + .MSan_Config
+                            + .Fuzzer_Config
                             + .Release_Optimizations
 
 // OSX


### PR DESCRIPTION
First commit fixes build in configuration `x64Linux-ASan` (with GCC) by removing compiler options related to fuzzer, which GCC don't support.
Second commit applies BFF cleanup changes from recent commits to `BFFFuzzer.bff`.