### PR TITLE
Store generated unity files in different directories on different platforms

### DIFF
--- a/Code/Core/Core.bff
+++ b/Code/Core/Core.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
         .UnityInputExcludePath      = '$ProjectPath$\CoreTest\' // Exclude Tests
     }
 

--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Executable

--- a/Code/OSUI/OSUI.bff
+++ b/Code/OSUI/OSUI.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Library

--- a/Code/TestFramework/TestFramework.bff
+++ b/Code/TestFramework/TestFramework.bff
@@ -10,7 +10,7 @@
     {
         // Common options
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Library

--- a/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
+++ b/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Executable

--- a/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
+++ b/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Executable

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Library

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
 
         // Ignore test data (some of which is code)
         .UnityInputExcludePath      = 'Tools\FBuild\FBuildTest\Data\'

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
@@ -9,7 +9,7 @@
     Unity( '$ProjectName$-Unity' )
     {
         .UnityInputPath             = '$ProjectPath$\'
-        .UnityOutputPath            = '$OutputBase$\Unity\$ProjectPath$\'
+        .UnityOutputPath            = '$UnityOutputBase$\$ProjectPath$\'
     }
 
     // Windows Resources

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -421,6 +421,15 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
 // Unity/Blob files (shared across configs)
 //------------------------------------------------------------------------------
 .UnityInputIsolateWritableFiles = true
+#if __WINDOWS__
+    .UnityOutputBase = '$OutputBase$\Unity-Windows'
+#endif
+#if __LINUX__
+    .UnityOutputBase = '$OutputBase$\Unity-Linux'
+#endif
+#if __OSX__
+    .UnityOutputBase = '$OutputBase$\Unity-OSX'
+#endif
 
 //------------------------------------------------------------------------------
 // VisualStudio Project Generation


### PR DESCRIPTION
Generated unity files have different contents on different platforms (`\` on Windows vs `/` on Linux/OSX and likely a different absolute paths on Linux and OSX). So it seems logical to use different places to store them.

Main goal of this change is to allow to use the same repository checkout (by using network share or virtual machine shared folder) on different platforms without triggering rebuild on one platform because previous build on the other platform modified shared unity files.