### PR TITLE
Fix running FBuildTest from Code directory

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -9,6 +9,7 @@
 #include "Tools/FBuild/FBuildCore/FLog.h"
 
 #include "Core/FileIO/FileIO.h"
+#include "Core/FileIO/PathUtils.h"
 #include "Core/Strings/AStackString.h"
 #include "Core/Tracing/Tracing.h"
 
@@ -148,6 +149,10 @@ void FBuildTest::CheckStatsTotal( size_t numSeen, size_t numBuilt ) const
 {
     // we want the working dir to be the 'Code' directory
     TEST_ASSERT( FileIO::GetCurrentDir( codeDir ) );
+    if ( !codeDir.EndsWith( NATIVE_SLASH ) )
+    {
+        codeDir += NATIVE_SLASH;
+    }
     #if defined( __WINDOWS__ )
         const char * codePos = codeDir.FindI( "\\code\\" );
     #else


### PR DESCRIPTION
After FBuildTest cleanup (02e2979f) it became possible to successfully run FBuildTest from any subdirectory of the Code directory, but not from Code directory itself.
This change fixes corner case in `FBuildTest::GetCodeDir()` that prevents that.