### PR TITLE
Reuse base paths to VS an WinSDK in fbuild.bff for TestZW

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Data/TestZW/Caching/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestZW/Caching/fbuild.bff
@@ -19,16 +19,16 @@ ObjectList( 'Caching' )
     .CompilerOptions            + ' /ZW'
                                 + ' /EHsc'
                                 #if USING_VS2013
-                                    + ' /AI"../External/SDK/VisualStudio/2013/VC/vcpackages"'
-                                    + ' /AI"../External/SDK/Windows/8.1/References/CommonConfiguration/Neutral"'
+                                    + ' /AI"$VS2013_BasePath$/VC/vcpackages"'
+                                    + ' /AI"$Windows81_SDKBasePath$/References/CommonConfiguration/Neutral"'
                                 #endif
                                 #if USING_VS2015
-                                    + ' /AI"../External/SDK/VisualStudio/2015/VC/vcpackages"'
-                                    + ' /AI"../External/SDK/Windows/10/App Certification Kit/winmds/windows81"'
+                                    + ' /AI"$VS2015_BasePath$/VC/vcpackages"'
+                                    + ' /AI"$Windows10_SDKBasePath$/App Certification Kit/winmds/windows81"'
                                 #endif
                                 #if USING_VS2017
-                                    + ' /AI"../External/SDK/VisualStudio/2017/Community/Common7/IDE/VC/vcpackages"'
-                                    + ' /AI"../External/SDK/Windows/10/App Certification Kit/winmds/windows81"'
+                                    + ' /AI"$VS2017_BasePath$/Common7/IDE/VC/vcpackages"'
+                                    + ' /AI"$Windows10_SDKBasePath$/App Certification Kit/winmds/windows81"'
                                 #endif
 
     .CompilerInputPath          = 'Tools/FBuild/FBuildTest/Data/TestZW/Caching/'


### PR DESCRIPTION
This allows to override paths to VS and WinSDK installation places once in the corresponding .bff in `External/SDK/` folder.
Without this change it has to be done here too, otherwise TestZw fails with this error message:
> fatal error C1107: could not find assembly 'platform.winmd': please specify the assembly search path using /AI or by setting the LIBPATH environment variable