### PR TITLE
Fix pthread leaks

### DIFF
--- a/Code/Core/Network/Network.cpp
+++ b/Code/Core/Network/Network.cpp
@@ -101,6 +101,10 @@
 
         break; // success!
     }
+    if ( timedOut )
+    {
+        Thread::DetachThread( handle );
+    }
     Thread::CloseHandle( handle );
 
     // handle race where timeout occurred before thread marked data as

--- a/Code/Core/Network/TCPConnectionPool.cpp
+++ b/Code/Core/Network/TCPConnectionPool.cpp
@@ -741,6 +741,7 @@ void TCPConnectionPool::CreateListenThread( TCPSocket socket, uint32_t host, uin
                                          ( 32 * KILOBYTE ),
                                          m_ListenConnection ); // user data argument
     ASSERT( h != INVALID_THREAD_HANDLE );
+    Thread::DetachThread( h );
     Thread::CloseHandle( h ); // we don't need this anymore
 }
 
@@ -864,6 +865,7 @@ ConnectionInfo * TCPConnectionPool::CreateConnectionThread( TCPSocket socket, ui
                                             ( 32 * KILOBYTE ),
                                             ci ); // user data argument
     ASSERT( h != INVALID_THREAD_HANDLE );
+    Thread::DetachThread( h );
     Thread::CloseHandle( h ); // we don't need this anymore
 
     m_Connections.Append( ci );

--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -251,6 +251,19 @@ public:
     #endif
 }
 
+// DetachThread
+//------------------------------------------------------------------------------
+/*static*/ void Thread::DetachThread( ThreadHandle handle )
+{
+    #if defined( __WINDOWS__ )
+        (void)handle; // Nothing to do
+    #elif defined( __APPLE__ ) || defined(__LINUX__)
+        VERIFY( pthread_detach( (pthread_t)handle ) == 0 );
+    #else
+        #error Unknown platform
+    #endif
+}
+
 // CloseHandle
 //------------------------------------------------------------------------------
 /*static*/ void Thread::CloseHandle( ThreadHandle h )

--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -151,6 +151,33 @@ public:
 
 // WaitForThread
 //------------------------------------------------------------------------------
+/*static*/ int Thread::WaitForThread( ThreadHandle handle )
+{
+    #if defined( __WINDOWS__ )
+        bool timedOut = true; // default is true to catch cases when timedOut wasn't set by WaitForThread()
+        int ret = WaitForThread( handle, INFINITE, timedOut );
+
+        if ( timedOut )
+        {
+            // something is wrong - we were waiting an INFINITE time
+            ASSERT( false );
+            return 0;
+        }
+
+        return ret;
+    #elif defined( __APPLE__ ) || defined( __LINUX__ )
+        void * ret;
+        if ( pthread_join( (pthread_t)handle, &ret ) == 0 )
+        {
+            return (int)( (size_t)ret );
+        }
+        ASSERT( false ); // usage failure
+        return 0;
+    #else
+        #error Unknown platform
+    #endif
+}
+
 /*static*/ int Thread::WaitForThread( ThreadHandle handle, uint32_t timeoutMS, bool & timedOut )
 {
     #if defined( __WINDOWS__ )
@@ -184,13 +211,7 @@ public:
     #elif defined( __APPLE__ )
         timedOut = false;
         (void)timeoutMS; // TODO:MAC Implement timeout support
-        void * ret;
-        if ( pthread_join( (pthread_t)handle, &ret ) == 0 )
-        {
-            return (int)( (size_t)ret );
-        }
-        ASSERT( false ); // usage failure
-        return 0;
+        return WaitForThread( handle );
     #elif defined( __LINUX__ )
         // timeout is specified in absolute time
         // - get current time

--- a/Code/Core/Process/Thread.h
+++ b/Code/Core/Process/Thread.h
@@ -44,6 +44,7 @@ public:
                                     );
     static int WaitForThread( ThreadHandle handle );
     static int WaitForThread( ThreadHandle handle, uint32_t timeoutMS, bool & timedOut );
+    static void DetachThread( ThreadHandle handle );
     static void CloseHandle( ThreadHandle h );
 
     static void SetThreadName( const char * name );

--- a/Code/Core/Process/Thread.h
+++ b/Code/Core/Process/Thread.h
@@ -42,6 +42,7 @@ public:
                                       uint32_t stackSize = ( 64 * KILOBYTE ),
                                       void * userData = nullptr
                                     );
+    static int WaitForThread( ThreadHandle handle );
     static int WaitForThread( ThreadHandle handle, uint32_t timeoutMS, bool & timedOut );
     static void CloseHandle( ThreadHandle h );
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -40,7 +40,6 @@ Client::Client( const Array< AString > & workerList,
                 bool detailedLogging )
     : m_WorkerList( workerList )
     , m_ShouldExit( false )
-    , m_Exited( false )
     , m_DetailedLogging( detailedLogging )
     , m_WorkerConnectionLimit( workerConnectionLimit )
     , m_Port( port )
@@ -62,10 +61,7 @@ Client::~Client()
     SetShuttingDown();
 
     m_ShouldExit = true;
-    while ( m_Exited == false )
-    {
-        Thread::Sleep( 1 );
-    }
+    Thread::WaitForThread( m_Thread );
 
     ShutdownAllConnections();
 
@@ -149,8 +145,6 @@ void Client::ThreadFunc()
             break;
         }
     }
-
-    m_Exited = true;
 }
 
 // LookForWorkers

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.h
@@ -62,7 +62,6 @@ private:
 
     Array< AString >    m_WorkerList;   // workers to connect to
     volatile bool       m_ShouldExit;   // signal from main thread
-    volatile bool       m_Exited;       // flagged on exit
     bool                m_DetailedLogging;
     Thread::ThreadHandle m_Thread;      // the thread to find and manage workers
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Server.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Server.cpp
@@ -28,7 +28,6 @@
 //------------------------------------------------------------------------------
 Server::Server( uint32_t numThreadsInJobQueue )
     : m_ShouldExit( false )
-    , m_Exited( false )
     , m_ClientList( 32, true )
 {
     m_JobQueueRemote = FNEW( JobQueueRemote( numThreadsInJobQueue ? numThreadsInJobQueue : Env::GetNumProcessors() ) );
@@ -46,10 +45,7 @@ Server::~Server()
 {
     m_ShouldExit = true;
     JobQueueRemote::Get().WakeMainThread();
-    while ( m_Exited == false )
-    {
-        Thread::Sleep( 1 );
-    }
+    Thread::WaitForThread( m_Thread );
 
     ShutdownAllConnections();
 
@@ -519,8 +515,6 @@ void Server::ThreadFunc()
 
         JobQueueRemote::Get().MainThreadWait( 100 );
     }
-
-    m_Exited = true;
 }
 
 // FindNeedyClients

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Server.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Server.h
@@ -83,7 +83,6 @@ private:
     JobQueueRemote *        m_JobQueueRemote;
 
     volatile bool           m_ShouldExit;   // signal from main thread
-    volatile bool           m_Exited;       // flagged on exit
     Thread::ThreadHandle    m_Thread;       // the thread to manage workload
     Mutex                   m_ClientListMutex;
     Array< ClientState * >  m_ClientList;

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.cpp
@@ -46,6 +46,7 @@ void WorkerThread::Init()
                                                    64 * KILOBYTE,
                                                    this );
     ASSERT( h != nullptr );
+    Thread::DetachThread( h );
     Thread::CloseHandle( h ); // we don't want to keep this, so free it now
 }
 

--- a/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
@@ -74,15 +74,7 @@ WorkerWindow::~WorkerWindow()
     ASSERT( m_UIState == ALLOWED_TO_QUIT );
 
     // ensure the thread is shutdown
-    #if defined( __WINDOWS__ )
-        VERIFY( WaitForSingleObject( m_UIThreadHandle, INFINITE ) == WAIT_OBJECT_0 );
-    #elif defined( __APPLE__ )
-        // TODO:MAC WaitForSingleObject equivalent
-    #elif defined( __LINUX__ )
-        // TODO:LINUX WaitForSingleObject equivalent
-    #else
-        #error Unknown Platform
-    #endif
+    Thread::WaitForThread( m_UIThreadHandle );
 
     // clean up the ui thread
     Thread::CloseHandle( m_UIThreadHandle );


### PR DESCRIPTION
POSIX threads that are created as joinable (which is the default) have to be joined (or marked as detached) before all resources used by them are released, see https://man7.org/linux/man-pages/man3/pthread_create.3.html#NOTES , second paragraph.
This issue was found by [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)