### PR TITLE
Call ShutdownAllConnections in dtor of all TCPConnectionPool descendants

### DIFF
--- a/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
+++ b/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
@@ -167,6 +167,10 @@ void TestTestTCPConnectionPool::TestDataTransfer() const
     class TestServer : public TCPConnectionPool
     {
     public:
+        ~TestServer()
+        {
+            ShutdownAllConnections();
+        }
         virtual void OnReceive( const ConnectionInfo *, void * data, uint32_t size, bool & )
         {
             TEST_ASSERT( size == m_DataSize );
@@ -236,6 +240,10 @@ void TestTestTCPConnectionPool::TestConnectionStuckDuringSend() const
     class SlowServer : public TCPConnectionPool
     {
     public:
+        ~SlowServer()
+        {
+            ShutdownAllConnections();
+        }
         virtual void OnReceive( const ConnectionInfo *, void *, uint32_t, bool & )
         {
             Thread::Sleep( 1000 );


### PR DESCRIPTION
This fixes [data race on vtable pointer](https://github.com/google/sanitizers/wiki/ThreadSanitizerPopularDataRaces#data-race-on-vptr) caused by destruction of `TCPConnectionPool`-based class in one thread while there are connection threads that execute virtual functions (`OnReceive`) of that class.
This issue was found by [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html).