### PR TITLE
Protect build output collection in tests with a Mutex

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -15,6 +15,7 @@
 // Static Data
 //------------------------------------------------------------------------------
 /*static*/ bool FBuildTest::s_DebuggerAttached( false );
+/*static*/ Mutex FBuildTest::s_OutputMutex;
 /*static*/ AString FBuildTest::s_RecordedOutput( 1024 * 1024 );
 
 // CONSTRUCTOR (FBuildTest)
@@ -161,6 +162,7 @@ void FBuildTest::CheckStatsTotal( size_t numSeen, size_t numBuilt ) const
 //------------------------------------------------------------------------------
 bool FBuildTest::LoggingCallback( const char * message )
 {
+    MutexHolder mh( s_OutputMutex );
     s_RecordedOutput.Append( message, AString::StrLen( message ) );
     // If in the debugger, print the output normally as well, otherwise
     // suppress and only print on failure

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
@@ -9,6 +9,8 @@
 #include "Tools/FBuild/FBuildCore/Graph/Node.h"
 #include "Tools/FBuild/FBuildCore/FBuildOptions.h"
 
+#include "Core/Process/Mutex.h"
+
 // Forward Declarations
 //------------------------------------------------------------------------------
 struct FBuildStats;
@@ -47,6 +49,7 @@ private:
     mutable AString m_OriginalWorkingDir;
     static bool s_DebuggerAttached;
     static bool LoggingCallback( const char * message );
+    static Mutex s_OutputMutex;
     static AString s_RecordedOutput;
 };
 


### PR DESCRIPTION
Output messages are produced by multiple worker threads, but they were concatenated into a single `AString` in `FBuildTest::LoggingCallback` without any synchronization.
This issue was found by ThreadSanitizer.