### PR TITLE
Fix crash in Client::OnDisconnected when connection closes before UserData is set

### DIFF
--- a/Code/Core/Network/TCPConnectionPool.cpp
+++ b/Code/Core/Network/TCPConnectionPool.cpp
@@ -190,7 +190,7 @@ bool TCPConnectionPool::Listen( uint16_t port )
 
 // Connect
 //------------------------------------------------------------------------------
-const ConnectionInfo * TCPConnectionPool::Connect( const AString & host, uint16_t port, uint32_t timeout )
+const ConnectionInfo * TCPConnectionPool::Connect( const AString & host, uint16_t port, uint32_t timeout, void * userData )
 {
     ASSERT( !host.IsEmpty() );
 
@@ -201,12 +201,12 @@ const ConnectionInfo * TCPConnectionPool::Connect( const AString & host, uint16_
         TCPDEBUG( "Failed to get address for '%s'\n" , host.Get() );
         return nullptr;
     }
-    return Connect( hostIP, port, timeout );
+    return Connect( hostIP, port, timeout, userData );
 }
 
 // Connect
 //------------------------------------------------------------------------------
-const ConnectionInfo * TCPConnectionPool::Connect( uint32_t hostIP, uint16_t port, uint32_t timeout )
+const ConnectionInfo * TCPConnectionPool::Connect( uint32_t hostIP, uint16_t port, uint32_t timeout, void * userData )
 {
     PROFILE_FUNCTION
 
@@ -348,7 +348,7 @@ const ConnectionInfo * TCPConnectionPool::Connect( uint32_t hostIP, uint16_t por
         ASSERT( false ); // should never get here
     }
 
-    return CreateConnectionThread( sockfd, hostIP, port );
+    return CreateConnectionThread( sockfd, hostIP, port, userData );
 }
 
 // Disconnect
@@ -842,7 +842,7 @@ void TCPConnectionPool::ListenThreadFunction( ConnectionInfo * ci )
 
 // CreateConnectionThread
 //------------------------------------------------------------------------------
-ConnectionInfo * TCPConnectionPool::CreateConnectionThread( TCPSocket socket, uint32_t host, uint16_t port )
+ConnectionInfo * TCPConnectionPool::CreateConnectionThread( TCPSocket socket, uint32_t host, uint16_t port, void * userData )
 {
     MutexHolder mh( m_ConnectionsMutex );
 
@@ -851,6 +851,7 @@ ConnectionInfo * TCPConnectionPool::CreateConnectionThread( TCPSocket socket, ui
     ci->m_RemoteAddress = host;
     ci->m_RemotePort = port;
     ci->m_ThreadQuitNotification = false;
+    ci->m_UserData = userData;
 
     #ifdef TCPCONNECTION_DEBUG
         AStackString<32> addr;

--- a/Code/Core/Network/TCPConnectionPool.h
+++ b/Code/Core/Network/TCPConnectionPool.h
@@ -66,8 +66,8 @@ public:
     // manage connections
     bool Listen( uint16_t port );
     void StopListening();
-    const ConnectionInfo * Connect( const AString & host, uint16_t port, uint32_t timeout = 2000 );
-    const ConnectionInfo * Connect( uint32_t hostIP, uint16_t port, uint32_t timeout = 2000 );
+    const ConnectionInfo * Connect( const AString & host, uint16_t port, uint32_t timeout = 2000, void * userData = nullptr );
+    const ConnectionInfo * Connect( uint32_t hostIP, uint16_t port, uint32_t timeout = 2000, void * userData = nullptr );
     void Disconnect( const ConnectionInfo * ci );
     void SetShuttingDown() { m_ShuttingDown = true; }
 
@@ -119,7 +119,7 @@ private:
     void                CreateListenThread( TCPSocket socket, uint32_t host, uint16_t port );
     static uint32_t     ListenThreadWrapperFunction( void * data );
     void                ListenThreadFunction( ConnectionInfo * ci );
-    ConnectionInfo *    CreateConnectionThread( TCPSocket socket, uint32_t host, uint16_t port );
+    ConnectionInfo *    CreateConnectionThread( TCPSocket socket, uint32_t host, uint16_t port, void * userData = nullptr );
     static uint32_t     ConnectionThreadWrapperFunction( void * data );
     void                ConnectionThreadFunction( ConnectionInfo * ci );
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -218,7 +218,7 @@ void Client::LookForWorkers()
             continue;
         }
 
-        const ConnectionInfo * ci = Connect( m_WorkerList[ i ], m_Port, 2000 ); // 2000ms connection timeout
+        const ConnectionInfo * ci = Connect( m_WorkerList[ i ], m_Port, 2000, &ss ); // 2000ms connection timeout
         if ( ci == nullptr )
         {
             ss.m_DelayTimer.Start(); // reset connection attempt delay
@@ -228,7 +228,6 @@ void Client::LookForWorkers()
             DIST_INFO( "Connected: %s\n", m_WorkerList[ i ].Get() );
             const uint32_t numJobsAvailable( JobQueue::IsValid() ? (uint32_t)JobQueue::Get().GetNumDistributableJobsAvailable() : 0 );
 
-            ci->SetUserData( &ss );
             ss.m_RemoteName = m_WorkerList[ i ];
             ss.m_Connection = ci; // success!
             ss.m_NumJobsAvailable = numJobsAvailable;


### PR DESCRIPTION
`Client::LookForWorkers` tries to open a connection by calling `TCPConnectionPool::Connect` and then, if it succeeds, sets pointer to `ServerState` object as `ConnectionInfo::m_UserData`.

The problem is that doing so after `Connect` is finished is too late. All code in `Client` that calls `GetUserData` assumes that returned value is correct, including callbacks `OnReceive` and `OnDisconnected` which are called in a thread created by `Connect`.
It is possible that these callbacks will be called in a new thread before `Connect` returns in a thread executing `LookForWorkers`.

For `OnReceive` this won't result in a crash because both `OnReceive` and `LookForWorkers` acquire `m_ServerListMutex`.
But crash in `OnDisconnected` is easily reproducible in AddressSanitizer and ThreadSanitizer builds of FBuildTest in TestWith1RemoteWorkerThread test.

To fix this problem we set UserData before connection thread is started.