### PR TITLE
Add new compiler: orbis-wave-psslc

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -119,7 +119,8 @@ Compiler( 'Test' )
         <tr><td>greenhills-wiiu</td><td>GreenHills compiler for the Wii U</td></tr>
         <tr><td>cuda-nvcc</td><td>NVIDIA's CUDA compiler</td></tr>
         <tr><td>qt-rcc</td><td>Qt's resource compiler</td></tr>
-        <tr><td>vbcc</td><td>vbcc compiler</td></tr>        
+        <tr><td>vbcc</td><td>vbcc compiler</td></tr>   
+        <tr><td>orbis-wave-psslc</td><td>orbis wave psslc shader compiler</td></tr>      
         <tr><td>&nbsp;</td><td></td></tr>
         <tr><th>Value</th><th>Notes</th></tr>
         <tr><td>custom</td><td>Any custom compiler. <font color=red>NOTE:</font> Only primary input and output dependencies will be tracked. No additional

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -197,6 +197,13 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
             return true;
         }
 
+		// Orbis wave shader compiler
+		if (compiler.EndsWithI("orbis-wave-psslc.exe"))
+		{
+			m_CompilerFamilyEnum = ORBIS_WAVE_PSSLC;
+			return true;
+		}
+
         // Auto-detect failed
         Error::Error_1500_CompilerDetectionFailed( iter, function, compiler );
         return false;
@@ -253,6 +260,11 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
         m_CompilerFamilyEnum = VBCC;
         return true;
     }
+	if (m_CompilerFamilyString.EqualsI("orbis-wave-psslc"))
+	{
+		m_CompilerFamilyEnum = ORBIS_WAVE_PSSLC;
+		return true;
+	}
 
     // Invalid option
     Error::Error_1501_CompilerFamilyUnrecognized( iter, function, m_CompilerFamilyString );

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -48,6 +48,7 @@ public:
         CUDA_NVCC       = 7,
         QT_RCC          = 8,
         VBCC            = 9,
+		ORBIS_WAVE_PSSLC = 10,
     };
     CompilerFamily GetCompilerFamily() const { return static_cast<CompilerFamily>( m_CompilerFamilyEnum ); }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -238,7 +238,7 @@ ObjectNode::~ObjectNode()
     bool useCache = ShouldUseCache();
     bool useDist = GetFlag( FLAG_CAN_BE_DISTRIBUTED ) && m_AllowDistribution && FBuild::Get().GetOptions().m_AllowDistributed;
     bool useSimpleDist = GetCompiler()->CastTo< CompilerNode >()->SimpleDistributionMode();
-    bool usePreProcessor = !useSimpleDist && ( useCache || useDist || GetFlag( FLAG_GCC ) || GetFlag( FLAG_SNC ) || GetFlag( FLAG_CLANG ) || GetFlag( CODEWARRIOR_WII ) || GetFlag( GREENHILLS_WIIU ) || GetFlag( ObjectNode::FLAG_VBCC ) );
+    bool usePreProcessor = !useSimpleDist && ( useCache || useDist || GetFlag( FLAG_GCC ) || GetFlag( FLAG_SNC ) || GetFlag( FLAG_CLANG ) || GetFlag( CODEWARRIOR_WII ) || GetFlag( GREENHILLS_WIIU ) || GetFlag( ObjectNode::FLAG_VBCC ) || GetFlag(FLAG_ORBIS_WAVE_PSSLC));
     if ( GetDedicatedPreprocessor() )
     {
         usePreProcessor = true;
@@ -800,15 +800,16 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
     switch ( compilerFamily )
     {
         case CompilerNode::CompilerFamily::CUSTOM:          break; // Nothing to do
-        case CompilerNode::CompilerFamily::MSVC:            flags |= FLAG_MSVC;        break;
-        case CompilerNode::CompilerFamily::CLANG:           flags |= FLAG_CLANG;       break;
-        case CompilerNode::CompilerFamily::GCC:             flags |= FLAG_GCC;         break;
-        case CompilerNode::CompilerFamily::SNC:             flags |= FLAG_SNC;         break;
-        case CompilerNode::CompilerFamily::CODEWARRIOR_WII: flags |= CODEWARRIOR_WII;  break;
-        case CompilerNode::CompilerFamily::GREENHILLS_WIIU: flags |= GREENHILLS_WIIU;  break;
-        case CompilerNode::CompilerFamily::CUDA_NVCC:       flags |= FLAG_CUDA_NVCC;   break;
-        case CompilerNode::CompilerFamily::QT_RCC:          flags |= FLAG_QT_RCC;      break;
-        case CompilerNode::CompilerFamily::VBCC:            flags |= FLAG_VBCC;        break;
+        case CompilerNode::CompilerFamily::MSVC:            flags |= FLAG_MSVC;             break;
+        case CompilerNode::CompilerFamily::CLANG:           flags |= FLAG_CLANG;            break;
+        case CompilerNode::CompilerFamily::GCC:             flags |= FLAG_GCC;              break;
+        case CompilerNode::CompilerFamily::SNC:             flags |= FLAG_SNC;              break;
+        case CompilerNode::CompilerFamily::CODEWARRIOR_WII: flags |= CODEWARRIOR_WII;       break;
+        case CompilerNode::CompilerFamily::GREENHILLS_WIIU: flags |= GREENHILLS_WIIU;       break;
+        case CompilerNode::CompilerFamily::CUDA_NVCC:       flags |= FLAG_CUDA_NVCC;        break;
+        case CompilerNode::CompilerFamily::QT_RCC:          flags |= FLAG_QT_RCC;           break;
+        case CompilerNode::CompilerFamily::VBCC:            flags |= FLAG_VBCC;             break;
+		case CompilerNode::CompilerFamily::ORBIS_WAVE_PSSLC:flags |= FLAG_ORBIS_WAVE_PSSLC; break;
     }
 
     // Check MS compiler options
@@ -902,6 +903,17 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
         // Can cache objects
         flags |= ObjectNode::FLAG_CAN_BE_CACHED;
     }
+
+		if (flags & ObjectNode::FLAG_ORBIS_WAVE_PSSLC)
+	{
+		if (isDistributableCompiler)
+		{
+			flags |= ObjectNode::FLAG_CAN_BE_DISTRIBUTED;
+		}
+
+		// Can cache objects
+		flags |= ObjectNode::FLAG_CAN_BE_CACHED;
+	}
 
     return flags;
 }
@@ -1437,15 +1449,16 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
     }
     fullArgs.Clear();
 
-    const bool isMSVC   = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_MSVC ) : GetFlag( FLAG_MSVC );
-    const bool isClang  = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_CLANG ) : GetFlag( FLAG_CLANG );
-    const bool isGCC    = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_GCC ) : GetFlag( FLAG_GCC );
-    const bool isSNC    = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_SNC ) : GetFlag( FLAG_SNC );
-    const bool isCWWii  = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( CODEWARRIOR_WII ) : GetFlag( CODEWARRIOR_WII );
-    const bool isGHWiiU = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( GREENHILLS_WIIU ) : GetFlag( GREENHILLS_WIIU );
-    const bool isCUDA   = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_CUDA_NVCC ) : GetFlag( FLAG_CUDA_NVCC );
-    const bool isQtRCC  = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_QT_RCC ) : GetFlag( FLAG_QT_RCC );
-    const bool isVBCC   = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_VBCC ) : GetFlag( FLAG_VBCC );
+    const bool isMSVC           = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_MSVC ) : GetFlag( FLAG_MSVC );
+    const bool isClang          = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_CLANG ) : GetFlag( FLAG_CLANG );
+    const bool isGCC            = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_GCC ) : GetFlag( FLAG_GCC );
+    const bool isSNC            = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_SNC ) : GetFlag( FLAG_SNC );
+    const bool isCWWii          = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( CODEWARRIOR_WII ) : GetFlag( CODEWARRIOR_WII );
+    const bool isGHWiiU         = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( GREENHILLS_WIIU ) : GetFlag( GREENHILLS_WIIU );
+    const bool isCUDA           = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_CUDA_NVCC ) : GetFlag( FLAG_CUDA_NVCC );
+    const bool isQtRCC          = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_QT_RCC ) : GetFlag( FLAG_QT_RCC );
+    const bool isVBCC           = ( useDedicatedPreprocessor ) ? GetPreprocessorFlag( FLAG_VBCC ) : GetFlag( FLAG_VBCC );
+	const bool isOrbisWavePsslc = (useDedicatedPreprocessor)   ? GetPreprocessorFlag( FLAG_ORBIS_WAVE_PSSLC) : GetFlag(FLAG_ORBIS_WAVE_PSSLC);
 
     const size_t numTokens = tokens.GetSize();
     for ( size_t i = 0; i < numTokens; ++i )
@@ -1456,7 +1469,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
         // -o removal for preprocessor
         if ( pass == PASS_PREPROCESSOR_ONLY )
         {
-            if ( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isCUDA || isVBCC )
+            if ( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isCUDA || isVBCC || isOrbisWavePsslc)
             {
                 if ( StripTokenWithArg( "-o", token, i ) )
                 {
@@ -1549,7 +1562,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                     continue; // skip this token in both cases
                 }
             }
-            if ( isGCC || isClang || isVBCC )
+            if ( isGCC || isClang || isVBCC || isOrbisWavePsslc )
             {
                 // Remove forced includes so they aren't forced twice
                 if ( StripTokenWithArg( "-include", token, i ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -59,7 +59,8 @@ public:
         FLAG_QT_RCC             =   0x40000,
         FLAG_WARNINGS_AS_ERRORS_MSVC    = 0x80000,
         FLAG_VBCC               =   0x100000,
-        FLAG_STATIC_ANALYSIS_MSVC = 0x200000
+        FLAG_STATIC_ANALYSIS_MSVC = 0x200000,
+		FLAG_ORBIS_WAVE_PSSLC	=   0x400000
     };
     static uint32_t DetermineFlags( const CompilerNode * compilerNode,
                                     const AString & args,


### PR DESCRIPTION
I was previously using simple distribution mode to support the orbis wave shader compiler, however adding it as a real compiler seems like a better choice.