### PR TITLE
SimpleDistributionAllowCache

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -29,6 +29,7 @@ distribution, caching and more.
   .AllowDistribution            // (optional) Allow distributed compilation (if available) (default: true)
   .ExecutableRootPath           // (optional) Override default path for executable distribution
   .SimpleDistributionMode       // (optional) Allow distribution of otherwise unsuported "compilers" (default: false)
+  .SimpleDistributionAllowCache // (optional) Allow simple distribution compilers to cache their results (default: false)
   .CustomEnvironmentVariables   // (optional) Environment variables to set on remote host
   .ClangRewriteIncludes         // (optional) Use Clang's -frewrite-includes option when preprocessing (default: true)
   .VS2012EnumBugFix             // (optional) Enable work-around for bug in VS2012 compiler (default: false)
@@ -147,6 +148,11 @@ Compiler( 'Test' )
     of custom tools or other useful work like texture conversion.<p>
 
   	<p><hr></p>
+
+  <p><b>.SimpleDistributionAllowCache</b> - Boolean - (Optional)</p>
+  <p>When using SimpleDistributionMode this flag can be set to allow caching of results.<p>
+
+    <p><hr></p>
     
 	<p><b>.CustomEnvironmentVariables</b> - String or ArrayOfStrings - (Optional)</p>
 	<p>When compiling on a remote host, a clean environment is used. If needed, environment variables can be set.<p>

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -26,6 +26,7 @@ REFLECT_NODE_BEGIN( CompilerNode, Node, MetaName( "Executable" ) + MetaFile() )
     REFLECT( m_ClangRewriteIncludes, "ClangRewriteIncludes", MetaOptional() )
     REFLECT( m_ExecutableRootPath,  "ExecutableRootPath",   MetaOptional() + MetaPath() )
     REFLECT( m_SimpleDistributionMode,  "SimpleDistributionMode",   MetaOptional() )
+	REFLECT( m_SimpleDistributionAllowCache, "SimpleDistributionAllowCache", MetaOptional())
     REFLECT( m_CompilerFamilyString,"CompilerFamily",       MetaOptional() )
 
     // Internal
@@ -42,6 +43,7 @@ CompilerNode::CompilerNode()
     , m_CompilerFamilyString( "auto" )
     , m_CompilerFamilyEnum( static_cast< uint8_t >( CUSTOM ) )
     , m_SimpleDistributionMode( false )
+	, m_SimpleDistributionAllowCache( false )
 {
     m_Type = Node::COMPILER_NODE;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -30,6 +30,7 @@ public:
     inline const ToolManifest & GetManifest() const { return m_Manifest; }
 
     inline bool SimpleDistributionMode() const { return m_SimpleDistributionMode; }
+	inline bool SimpleDistributionAllowCache() const { return m_SimpleDistributionAllowCache; }
     inline bool CanBeDistributed() const { return m_AllowDistribution; }
     #if defined( __WINDOWS__ )
         inline bool IsVS2012EnumBugFixEnabled() const { return m_VS2012EnumBugFix; }
@@ -68,6 +69,7 @@ private:
     AString         m_CompilerFamilyString;
     uint8_t         m_CompilerFamilyEnum;
     bool            m_SimpleDistributionMode;
+	bool			m_SimpleDistributionAllowCache;
     ToolManifest    m_Manifest;
 };
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -903,6 +903,13 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
         flags |= ObjectNode::FLAG_CAN_BE_CACHED;
     }
 
+	// Custom simple compiler
+	if( compilerNode->SimpleDistributionMode() && compilerNode->SimpleDistributionAllowCache())
+	{
+		// Can cache objects
+		flags |= ObjectNode::FLAG_CAN_BE_CACHED;
+	}
+
     return flags;
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/SimpleCompiler.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/SimpleCompiler.cpp
@@ -1,0 +1,21 @@
+//
+// An simple compiler that takes an input filename and output filename and creates the output file
+//
+#include <stdio.h>
+
+int main(int argc, char ** argv)
+{
+	if (argc != 3)
+	{
+		printf("Bad Args!\n");
+		return 1;
+	}
+
+	//const char* input = argv[1];
+	const char* output = argv[2];
+
+	FILE* f = fopen(output, "wb");
+	fwrite((char*)&argc, sizeof(argc), 1, f);
+	fclose(f);
+    return 0; // test will check this
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/cache.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/cache.bff
@@ -1,0 +1,46 @@
+//
+// Cache
+//
+// Build and link an executable.
+//
+//------------------------------------------------------------------------------
+
+// Use the standard test environment
+//------------------------------------------------------------------------------
+#include "../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+Compiler( "Compiler-SimpleCompiler-Caching")
+{
+	.Executable = '$Out$/Test/Cache/SimpleCompiler-Caching.exe'
+	.CompilerFamily = 'Custom'
+	.SimpleDistributionMode = true
+	.SimpleDistributionAllowCache = true
+}
+
+ObjectList( 'CompileResources-Caching' )
+{
+    .Compiler                   = 'Compiler-SimpleCompiler-Caching'
+    .CompilerOptions            = '"%1" "%2"'
+    .CompilerInputPath          = 'Tools/FBuild/FBuildTest/Data/TestCache'
+    .CompilerInputPattern       = '*.resource'
+    .CompilerOutputExtension    = '.compiledresource'
+    .CompilerOutputPath         = '$Out$/Test/Cache/GeneratedCaching/'
+}
+
+Compiler( "Compiler-SimpleCompiler-NonCaching")
+{
+	.Executable = '$Out$/Test/Cache/SimpleCompiler-NonCaching.exe'
+	.CompilerFamily = 'Custom'
+}
+
+ObjectList( 'CompileResources-NonCaching' )
+{
+    .Compiler                   = 'Compiler-SimpleCompiler-NonCaching'
+    .CompilerOptions            = '"%1" "%2"'
+    .CompilerInputPath          = 'Tools/FBuild/FBuildTest/Data/TestCache'
+    .CompilerInputPattern       = '*.resource'
+    .CompilerOutputExtension    = '.compiledresource'
+    .CompilerOutputPath         = '$Out$/Test/Cache/GeneratedNonCaching/'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/compiler.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/compiler.bff
@@ -1,0 +1,47 @@
+//
+// SimpleCompiler
+//
+// Build and link an executable.
+//
+//------------------------------------------------------------------------------
+
+// Use the standard test environment
+//------------------------------------------------------------------------------
+#include "../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+
+ObjectList( "SimpleCompiler-Lib" )
+{
+	#if __WINDOWS__
+        .CompilerOptions    + ' /MT'
+    #endif
+
+    .CompilerInputFiles = "Tools/FBuild/FBuildTest/Data/TestCache/SimpleCompiler.cpp"
+    .CompilerOutputPath = "$Out$/Test/Cache/"
+}
+
+Executable( "SimpleCompiler-Exe-Caching" )
+{
+    #if __WINDOWS__
+        .LinkerOptions      + ' /SUBSYSTEM:CONSOLE'
+                            + ' kernel32.lib'
+                            + .CRTLibs_Static
+    #endif
+    .LinkerOutput       = '$Out$/Test/Cache/SimpleCompiler-Caching.exe'
+    .Libraries          = { "SimpleCompiler-Lib" }
+}
+
+Executable( "SimpleCompiler-Exe-NonCaching" )
+{
+    #if __WINDOWS__
+        .LinkerOptions      + ' /SUBSYSTEM:CONSOLE'
+                            + ' kernel32.lib'
+                            + .CRTLibs_Static
+    #endif
+    .LinkerOutput       = '$Out$/Test/Cache/SimpleCompiler-NonCaching.exe'
+    .Libraries          = { "SimpleCompiler-Lib" }
+}
+
+Alias('all') { .Targets={'SimpleCompiler-Exe-Caching' 'SimpleCompiler-Exe-NonCaching'}}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/test.resource
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/test.resource
@@ -1,0 +1,1 @@
+test resource

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
@@ -1,0 +1,85 @@
+// TestExe.cpp
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "FBuildTest.h"
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+//#include "Tools/FBuild/FBuildCore/Graph/ExeNode.h"
+//#include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+
+//#include "Core/FileIO/FileIO.h"
+//#include "Core/Process/Process.h"
+#include "Core/Strings/AStackString.h"
+
+// TestCache
+//------------------------------------------------------------------------------
+class TestCache : public FBuildTest
+{
+private:
+    DECLARE_TESTS
+
+    void CacheCustomCompilerOutput() const;
+};
+
+// Register Tests
+//------------------------------------------------------------------------------
+REGISTER_TESTS_BEGIN( TestCache )
+    REGISTER_TEST( CacheCustomCompilerOutput )
+REGISTER_TESTS_END
+
+// CacheCustomCompilerOutput
+//------------------------------------------------------------------------------
+void TestCache::CacheCustomCompilerOutput() const
+{
+	FBuildTestOptions options;
+	options.m_ForceCleanBuild = true;
+	options.m_UseCacheRead = true;
+	options.m_UseCacheWrite = true;
+	options.m_ShowInfo = true;
+	options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestCache/compiler.bff";
+
+	// Create SimpleCompiler
+	{
+		FBuild fBuild(options);
+		TEST_ASSERT(fBuild.Initialize());
+
+		TEST_ASSERT(fBuild.Build(AStackString<>("all")));
+	}
+	
+	
+	options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestCache/cache.bff";
+
+	// Test cache not being filled
+	{
+		FBuild fBuild(options);
+		TEST_ASSERT(fBuild.Initialize());
+
+		TEST_ASSERT(fBuild.Build(AStackString<>("CompileResources-NonCaching")));
+		TEST_ASSERT(fBuild.GetStats().GetCacheStores() == 0);
+		TEST_ASSERT(fBuild.GetStats().GetCacheHits() == 0);
+	}
+
+	// Test cache getting filled
+	{
+		FBuild fBuild(options);
+		TEST_ASSERT(fBuild.Initialize());
+
+		TEST_ASSERT(fBuild.Build(AStackString<>("CompileResources-Caching")));
+		TEST_ASSERT(fBuild.GetStats().GetCacheStores() == 1);
+		TEST_ASSERT(fBuild.GetStats().GetCacheHits() == 0);
+	}
+
+	// Test cache getting filled
+	{
+		options.m_UseCacheWrite = false;
+		FBuild fBuild(options);
+		TEST_ASSERT(fBuild.Initialize());
+
+		TEST_ASSERT(fBuild.Build(AStackString<>("CompileResources-Caching")));
+		TEST_ASSERT(fBuild.GetStats().GetCacheStores() == 0);
+		TEST_ASSERT(fBuild.GetStats().GetCacheHits() == 1);
+	}
+}
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
The simple distribution mode compilers did not have the ability to cache their results. This pull request adds that ability.