### PR TITLE
Added support for Android standalone toolchain clang compiler (windows)

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -125,10 +125,12 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
 
         // Clang
         if ( compiler.EndsWithI( "clang++.exe" ) ||
+             compiler.EndsWithI( "clang++.cmd") ||
              compiler.EndsWithI( "clang++" ) ||
              compiler.EndsWithI( "clang.exe" ) ||
+             compiler.EndsWithI( "clang.cmd") ||
              compiler.EndsWithI( "clang" ) ||
-             compiler.EndsWithI( "clang-cl.exe" ) ||
+             compiler.EndsWithI( "clang-cl.exe" ) ||			 			 
              compiler.EndsWithI( "clang-cl" ) )
         {
             m_CompilerFamilyEnum = CLANG;


### PR DESCRIPTION
Installing  android standalone toolchain for windows requires to use compiler wrappers with .cmd
extensions, fastbuild didn't recognize them properly as clang and failed with error 1501.


