### PR TITLE
Handle failure to skip a string in BFFIterator::ParseToMatchingBrace

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
@@ -193,7 +193,12 @@ bool BFFIterator::ParseToMatchingBrace( char openBrace, char closeBrace )
         // hit a string?
         if ( ( *m_Pos == '\'' ) || ( *m_Pos == '"' ) )
         {
+            const char quote = *m_Pos;
             SkipString( *m_Pos );
+            if ( *m_Pos != quote )
+            {
+                return false;
+            }
         }
 
         // hit the close brace?


### PR DESCRIPTION
When `SkipString` fails to find the end of a string it leaves `m_Pos` pointing at the last character of iterator range. When we are parsing some inner scope that last character might be a closing brace. In that case `ParseToMatchingBrace` will be tricked into thinking that matching closing brace is found, when in reality that brace is a part of unterminated string.

Later this breaks logic in places that expect all strings inside a region parsed by `ParseToMatchingBrace` to be terminated.
For example in `StoreVariableArray` ([BFFParser.cpp:1468](https://github.com/fastbuild/fastbuild/blob/b76a1920b91d9ca65a37becabe6af79581a888ee/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp#L1468)), here iterator is incremented past the end and in Release build it ultimately leads to infinite loop in `FormatError`.

That infinite loop was found by BFFFuzzer, minimal reproducer is:
```
{#ifB'
#endif
.a={'}
```