### PR TITLE
Update build instructions for BFFFuzzer and MSan configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # FASTBuild
 External/SDK
+External/MSan
 *.exe
 *.fdb
 *.log

--- a/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
+++ b/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
@@ -14,12 +14,12 @@
 
     // Executable
     //--------------------------------------------------------------------------
-    // These options are a valid for Clang <= 5.0.0:
-    .ExtraLinkerOptions_ASan = ' -lLLVMFuzzer'
-    .ExtraLinkerOptions_MSan = ' -lLLVMFuzzerMSan -lc++'
-    // These options are expected to be valid for Clang > 5.0.0:
+    // These options are a valid for Clang < 6.0.0:
+    .ExtraLinkerOptions_ASan = ' -lFuzzer'
+    .ExtraLinkerOptions_MSan = ' -lFuzzer -nodefaultlibs -Wl,-Bstatic -lc++ -Wl,-Bdynamic -lc++abi -lunwind -lpthread -lc -lrt -ldl -lm'
+    // These options are valid for Clang >= 6.0.0:
     // .ExtraLinkerOptions_ASan = ' -fsanitize=fuzzer'
-    // .ExtraLinkerOptions_MSan = ' -fsanitize=fuzzer -lc++'
+    // .ExtraLinkerOptions_MSan = ' -lFuzzer -nodefaultlibs -Wl,-Bstatic -lc++ -Wl,-Bdynamic -lc++abi -lunwind -lpthread -lc -lrt -ldl -lm'
 
     .MyConfigs = { .X64ClangASanConfig_Linux , .X64ClangMSanConfig_Linux }
     ForEach( .Config in .MyConfigs )

--- a/Code/Tools/FBuild/BFFFuzzer/README.md
+++ b/Code/Tools/FBuild/BFFFuzzer/README.md
@@ -24,7 +24,7 @@ Currently there are build configurations only for Linux, although it can be buil
 *   Build libFuzzer: `./build.sh`
 *   Copy resulting library to some place known to the linker (e.g. `/usr/local/lib`):
     ```bash
-    cp libFuzzer.a /usr/local/lib/libLLVMFuzzer.a
+    cp libFuzzer.a /usr/local/lib/
     ```
 
 ### (optional) Building libc++ with MemorySanitizer
@@ -42,10 +42,13 @@ Currently there are build configurations only for Linux, although it can be buil
 *   Build minimal version of libc++ (no tests, documentation, etc.)
     ```bash
     mkdir build && cd build
-    cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=MemoryWithOrigins -DLIBCXX_USE_COMPILER_RT=ON -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=NO -DLIBCXX_INCLUDE_BENCHMARKS=NO -DLIBCXX_INCLUDE_TESTS=NO -DLIBCXX_INCLUDE_DOCS=NO
+    cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=MemoryWithOrigins -DLIBCXX_USE_COMPILER_RT=ON -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS=/usr/include/c++/v1 -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=NO -DLIBCXX_INCLUDE_BENCHMARKS=NO -DLIBCXX_INCLUDE_TESTS=NO -DLIBCXX_INCLUDE_DOCS=NO
     make -j4
     ```
-*   Resulting library will be in `lib64/`.
+*   Copy resulting library to `External/MSan/` subdirectory in the FASTBuild repo:
+    ```bash
+    cp lib64/libc++.a /path/to/fastbuild/External/MSan/
+    ```
 
 ### (optional) Building libFuzzer with MemorySanitizer
 *   Get libFuzzer source code (see above).
@@ -55,9 +58,9 @@ Currently there are build configurations only for Linux, although it can be buil
     echo "fun:_ZNK6fuzzer*" >> blacklist.txt
     CXX='clang -stdlib=libc++ -fsanitize=memory -fsanitize-memory-track-origins -fsanitize-blacklist=blacklist.txt' ./build.sh
     ```
-*   Copy resulting library to some place known to the linker (e.g. `/usr/local/lib`):
+*   Copy resulting library to `External/MSan/` subdirectory in the FASTBuild repo:
     ```bash
-    cp libFuzzer.a /usr/local/lib/libLLVMFuzzerMSan.a
+    cp libFuzzer.a /path/to/fastbuild/External/MSan/
     ```
 
 ## Using BFFFuzzer
@@ -77,11 +80,11 @@ Then we can run it on that directory:
 # ASan build
 ../../../../tmp/x64ClangLinux-ASan/Tools/FBuild/BFFFuzzer/bfffuzzer corpus
 # or MSan build
-LD_LIBRARY_PATH=/path/to/msan-libc++/ ../../../../tmp/x64ClangLinux-MSan/Tools/FBuild/BFFFuzzer/bfffuzzer corpus
+../../../../tmp/x64ClangLinux-MSan/Tools/FBuild/BFFFuzzer/bfffuzzer corpus
 ```
 Generally it is better to do fuzzing with ASan build because it runs faster, and later retest corpus on MSan build:
 ```bash
-LD_LIBRARY_PATH=/path/to/msan-libc++/ ../../../../tmp/x64ClangLinux-MSan/Tools/FBuild/BFFFuzzer/bfffuzzer corpus/*
+../../../../tmp/x64ClangLinux-MSan/Tools/FBuild/BFFFuzzer/bfffuzzer corpus/*
 ```
 
 ### Creating a seed corpus
@@ -98,8 +101,8 @@ To speedup initial corpus load it is useful to periodically remove redundant fil
 ```bash
 mv corpus corpus-old
 mkdir corpus
-bfffuzzer -merge=1 corpus corpus-old
-LD_LIBRARY_PATH=/path/to/msan/libc++/ bfffuzzer -merge=1 corpus corpus-old
+../../../../tmp/x64ClangLinux-ASan/Tools/FBuild/BFFFuzzer/bfffuzzer -merge=1 corpus corpus-old
+../../../../tmp/x64ClangLinux-MSan/Tools/FBuild/BFFFuzzer/bfffuzzer -merge=1 corpus corpus-old
 rm -r corpus-old
 ```
 

--- a/Code/Tools/FBuild/BFFFuzzer/bff.dict
+++ b/Code/Tools/FBuild/BFFFuzzer/bff.dict
@@ -37,7 +37,10 @@
 
 # Other interesting sequences
 "exists"
+"not"
 "in"
+"=="
+"!="
 "true"
 "false"
 "//"

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -94,14 +94,16 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
                                     + ' -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer'
     .CompilerOptionsC               = .CompilerOptions
     .CompilerOptionsPCH             = .CompilerOptions
-    .LinkerOptions                  = ' -fsanitize=memory'
+    .LinkerOptions                  = ' -fsanitize=memory -L../External/MSan'
 
     .Config                         = 'MSan'
 ]
 .Fuzzer_Config =
 [
-    .CompilerOptions                = ' -fsanitize-coverage=trace-pc-guard' // These options are a valid for Clang <= 5.0.0:
-                                    //+ ' -fsanitize=fuzzer-no-link'          // These options are expected to be valid for Clang > 5.0.0:
+    // These options are valid for Clang < 6.0.0:
+    .CompilerOptions                = ' -fsanitize-coverage=trace-pc-guard,trace-cmp'
+    // These options are valid for Clang >= 6.0.0:
+    // .CompilerOptions                = ' -fsanitize=fuzzer-no-link'
     .CompilerOptionsC               = .CompilerOptions
     .CompilerOptionsPCH             = .CompilerOptions
 ]


### PR DESCRIPTION
* Configuration for MSan build updated to link libc++ statically. This allows to run MSan builds of BFFFuzzer without specifying `LD_LIBRARY_PATH`.
* Instead of using a different name for libFuzzer (and libc++) static library built with MSan it is now expected to be placed in the `External/MSan/` subdirectory inside the repo.
* Fixed instructions for building libc++ with MSan instrumentation: added missing options to enable use of libc++abi as runtime support library.
* Updated and verified compiler and linker options to enable libFuzzer instrumentation in Clang 6.0.0.
* New operators of the If() function introduced in b76a1920 added to the dictionary file.