### PR TITLE
Fix crash when struct variable is replaced by its member in Using()

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionUsing.cpp
@@ -108,13 +108,25 @@ FunctionUsing::FunctionUsing()
             return false;
         }
 
+        const BFFVariable * sameNameMember = nullptr;
         const Array< const BFFVariable * > & members = v->GetStructMembers();
         for ( const BFFVariable ** it = members.Begin();
               it != members.End();
               ++it )
         {
             const BFFVariable * member = ( *it );
+            if ( ( nullptr == sameNameMember ) && ( false == parentScope ) && ( member->GetName() == v->GetName() ) )
+            {
+                // We have a struct member with the same name as the struct variable itself.
+                // We have to delay putting it in the current scope because it may delete the struct variable and invalidate members array.
+                sameNameMember = member;
+                continue;
+            }
             BFFStackFrame::SetVar( member, frame );
+        }
+        if ( nullptr != sameNameMember )
+        {
+            BFFStackFrame::SetVar( sameNameMember, frame );
         }
     }
 


### PR DESCRIPTION
When we are importing members of a struct into current scope via function `Using()` we have to ensure that struct won't get deleted while we iterating its members. This may happen if a struct has a member with the same name as the struct itself.

This issue was found by BFFFuzzer, minimal reproducer is:
```
.A=[.A=[]]Using(.A)
```