### PR TITLE
Allow a variable to be frozen multiple times

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
@@ -29,7 +29,7 @@
 BFFVariable::BFFVariable( const AString & name, VarType type )
 : m_Name( name )
 , m_Type( type )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -43,7 +43,7 @@ BFFVariable::BFFVariable( const AString & name, VarType type )
 BFFVariable::BFFVariable( const BFFVariable & other )
 : m_Name( other.m_Name )
 , m_Type( other.m_Type )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -68,7 +68,7 @@ BFFVariable::BFFVariable( const BFFVariable & other )
 BFFVariable::BFFVariable( const AString & name, const AString & value )
 : m_Name( name )
 , m_Type( VAR_STRING )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 , m_StringValue( value )
@@ -82,7 +82,7 @@ BFFVariable::BFFVariable( const AString & name, const AString & value )
 BFFVariable::BFFVariable( const AString & name, bool value )
 : m_Name( name )
 , m_Type( VAR_BOOL )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( value )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -96,7 +96,7 @@ BFFVariable::BFFVariable( const AString & name, bool value )
 BFFVariable::BFFVariable( const AString & name, const Array< AString > & values )
 : m_Name( name )
 , m_Type( VAR_ARRAY_OF_STRINGS )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -111,7 +111,7 @@ BFFVariable::BFFVariable( const AString & name, const Array< AString > & values 
 BFFVariable::BFFVariable( const AString & name, int i )
 : m_Name( name )
 , m_Type( VAR_INT )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( i )
 //, m_StringValue() // default construct this
@@ -125,7 +125,7 @@ BFFVariable::BFFVariable( const AString & name, int i )
 BFFVariable::BFFVariable( const AString & name, const Array< const BFFVariable * > & values )
 : m_Name( name )
 , m_Type( VAR_STRUCT )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -142,7 +142,7 @@ BFFVariable::BFFVariable( const AString & name,
                           VarType type ) // type for disambiguation
 : m_Name( name )
 , m_Type( VAR_ARRAY_OF_STRUCTS )
-, m_Frozen( false )
+, m_FreezeCount( 0 )
 , m_BoolValue( false )
 , m_IntValue( 0 )
 //, m_StringValue() // default construct this
@@ -172,7 +172,7 @@ BFFVariable::~BFFVariable()
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueString( const AString & value )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
     m_Type = VAR_STRING;
     m_StringValue = value;
 }
@@ -181,7 +181,7 @@ void BFFVariable::SetValueString( const AString & value )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueBool( bool value )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
     m_Type = VAR_BOOL;
     m_BoolValue = value;
 }
@@ -190,7 +190,7 @@ void BFFVariable::SetValueBool( bool value )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueArrayOfStrings( const Array< AString > & values )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
     m_Type = VAR_ARRAY_OF_STRINGS;
     m_ArrayValues = values;
 }
@@ -199,7 +199,7 @@ void BFFVariable::SetValueArrayOfStrings( const Array< AString > & values )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueInt( int i )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
     m_Type = VAR_INT;
     m_IntValue = i;
 }
@@ -208,7 +208,7 @@ void BFFVariable::SetValueInt( int i )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueStruct( const Array< const BFFVariable * > & values )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
 
     // build list of new members, but don't touch old ones yet to gracefully
     // handle self-assignment
@@ -240,7 +240,7 @@ void BFFVariable::SetValueStruct( const Array< const BFFVariable * > & values )
 //------------------------------------------------------------------------------
 void BFFVariable::SetValueArrayOfStructs( const Array< const BFFVariable * > & values )
 {
-    ASSERT( false == m_Frozen );
+    ASSERT( 0 == m_FreezeCount );
 
     // build list of new members, but don't touch old ones yet to gracefully
     // handle self-assignment

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.h
@@ -60,9 +60,9 @@ public:
     inline bool IsStruct() const    { return m_Type == BFFVariable::VAR_STRUCT; }
     inline bool IsArrayOfStructs() const { return m_Type == BFFVariable::VAR_ARRAY_OF_STRUCTS; }
 
-    inline bool Frozen() const { return m_Frozen; }
-    inline void Freeze() const { ASSERT( false == m_Frozen ); m_Frozen = true; }
-    inline void Unfreeze() const { ASSERT( m_Frozen ); m_Frozen = false; }
+    inline bool Frozen() const { return m_FreezeCount > 0; }
+    inline void Freeze() const { ++m_FreezeCount; }
+    inline void Unfreeze() const { ASSERT( m_FreezeCount != 0 ); --m_FreezeCount; }
 
     BFFVariable * ConcatVarsRecurse( const AString & dstName, const BFFVariable & other, const BFFIterator & operatorIter ) const;
 
@@ -92,7 +92,7 @@ private:
     AString m_Name;
     VarType m_Type;
 
-    mutable bool m_Frozen;
+    mutable uint32_t m_FreezeCount;
 
     //
     bool                m_BoolValue;


### PR DESCRIPTION
This effectively legalizes nested `ForEach` loops over the same array.
Previously there was an `ASSERT` that prevented such loops, but `ASSERT` works only Debug builds and in Release such loops worked just fine in most cases.

Issues were appearing only if the BFF code was trying to modify the array after the end of a nested loop. In that case the array, which was marked as not frozen at that point, was replaced without producing a visible error. And later `FunctionForEach::ParseFunction` was accessing already deleted variable on the second iteration.

This issue was found by BFFFuzzer, minimal(-ish) reproducer is:
```
.a={'' 'X'}
ForEach(.x in .a) {
    ForEach(.y in .a) {}
    ^a={}
}
```
Unfortunately this reproducer doesn't trigger a crash in Release build (only diagnostic output in ASan build), so it probably not so useful as a test case for FBuildTest.