### PR TITLE
Correctly handle closing brace right after the end of iterator range

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFIterator.cpp
@@ -199,12 +199,13 @@ bool BFFIterator::ParseToMatchingBrace( char openBrace, char closeBrace )
             {
                 return false;
             }
+            continue;
         }
 
         // hit the close brace?
         if ( *m_Pos == closeBrace )
         {
-            return true;
+            return !IsAtEnd();
         }
 
         // a regular charater.... keep searching


### PR DESCRIPTION
Recent fix for brace parsing (c253336d) addressed only one source of incorrect parsing: unterminated strings, but the same incorrect behaviour might be triggered by a comment at the end of iterator range.
Such case was found by BFFFuzzer:
```
{#ifB'
#endif
{;'}
```

The real problem in all cases is that #if directive can change meaning of a text by conditionally wrapping it in strings an that `ParseToMatchingBrace` ignores `#if` directives and parses bodies unconditionally.
While this problem is hard to fix, `ParseToMatchingBrace` can be fixed to at least not return true when iterator has reached the end of its range.