### PR TITLE
Build only Debug and Release configurations in TestBuildFBuild

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestBuildFBuild.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestBuildFBuild.cpp
@@ -52,9 +52,25 @@ FBuildStats TestBuildFBuild::BuildInternal( FBuildTestOptions options, bool useD
     FBuild fBuild( options );
     TEST_ASSERT( fBuild.Initialize( useDB ? GetDBFile() : nullptr ) );
 
-    const AStackString<> target( "all" );
+    Array< AString > targets;
+    #if defined( __WINDOWS__ )
+        targets.Append( AStackString<>( "All-x64-Debug" ) );
+        targets.Append( AStackString<>( "All-x64-Release" ) );
+        targets.Append( AStackString<>( "All-x64Clang-Debug" ) );
+        targets.Append( AStackString<>( "All-x64Clang-Release" ) );
+    #elif defined( __LINUX__ )
+        targets.Append( AStackString<>( "All-x64Linux-Debug" ) );
+        targets.Append( AStackString<>( "All-x64Linux-Release" ) );
+        targets.Append( AStackString<>( "All-x64ClangLinux-Debug" ) );
+        targets.Append( AStackString<>( "All-x64ClangLinux-Release" ) );
+    #elif defined( __OSX__ )
+        targets.Append( AStackString<>( "All-x64OSX-Debug" ) );
+        targets.Append( AStackString<>( "All-x64OSX-Release" ) );
+    #else
+        #error Unknown platform
+    #endif
 
-    TEST_ASSERT( fBuild.Build( target ) );
+    TEST_ASSERT( fBuild.Build( targets ) );
 
     // save the db file - make sure it exists
     TEST_ASSERT( fBuild.SaveDependencyGraph( GetDBFile() ) );


### PR DESCRIPTION
This change speeds up `BuildFBuild` tests by minimizing amount of build configurations while maintaining almost the same amount of code exposed to compilers. Resulting speedup is especially significant on Linux (from 459 seconds down to 109 seconds in my case).

1. Sanitizer configurations are excluded because they have the same defines as Release configuration. Also just building code with sanitizers doesn't uncover any bugs by itself.
2. Profile configuration has a different set of defines than Debug and Release configurations but almost all code is already covered by them. (There are only trivial code behind `defined( RELEASE ) &&
   defined( PROFILING_ENABLED )` condition.)