### PR TITLE
Don't allow to replace nodes with CopyDir/RemoveDir nodes

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
@@ -31,6 +31,12 @@ FunctionCopyDir::FunctionCopyDir()
 //------------------------------------------------------------------------------
 /*virtual*/ bool FunctionCopyDir::Commit( NodeGraph & nodeGraph, const BFFIterator & funcStartIter ) const
 {
+    if ( nodeGraph.FindNode( m_AliasForFunction ) )
+    {
+        Error::Error_1100_AlreadyDefined( funcStartIter, this, m_AliasForFunction );
+        return false;
+    }
+
     CopyDirNode * copyDirNode = nodeGraph.CreateCopyDirNode( m_AliasForFunction );
 
     if ( !PopulateProperties( nodeGraph, funcStartIter, copyDirNode ) )

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
@@ -31,6 +31,12 @@ FunctionRemoveDir::FunctionRemoveDir()
 //------------------------------------------------------------------------------
 /*virtual*/ bool FunctionRemoveDir::Commit( NodeGraph & nodeGraph, const BFFIterator & funcStartIter ) const
 {
+    if ( nodeGraph.FindNode( m_AliasForFunction ) )
+    {
+        Error::Error_1100_AlreadyDefined( funcStartIter, this, m_AliasForFunction );
+        return false;
+    }
+
     RemoveDirNode * removeDirNode = nodeGraph.CreateRemoveDirNode( m_AliasForFunction );
 
     if ( !PopulateProperties( nodeGraph, funcStartIter, removeDirNode ) )


### PR DESCRIPTION
During conversion of CopyDir and RemoveDir to reflection system (9e6c46e3 and bde40a70) checks for uniqueness of the node name were lost.