### PR TITLE
Support colored output from Clang and GCC 

### DIFF
--- a/Code/Core/Env/Env.cpp
+++ b/Code/Core/Env/Env.cpp
@@ -229,9 +229,9 @@ void Env::GetExePath( AString & output )
     #endif
 }
 
-// IsStdOutRedirected
+// IsStdOutRedirectedInternal
 //------------------------------------------------------------------------------
-/*static*/ bool Env::IsStdOutRedirected()
+static bool IsStdOutRedirectedInternal()
 {
     #if defined( __WINDOWS__ )
         HANDLE h = GetStdHandle( STD_OUTPUT_HANDLE );
@@ -309,6 +309,31 @@ void Env::GetExePath( AString & output )
     #else
         return GetEnvVariable( "USER", outUserName );
     #endif
+}
+
+// IsStdOutRedirected
+//------------------------------------------------------------------------------
+/*static*/ bool Env::IsStdOutRedirected( const bool recheck )
+{
+    static volatile int32_t result = 0; // 0 - not checked, 1 - true, 2 - false
+    const int32_t the_result = result;
+    if ( recheck || ( the_result == 0 ) )
+    {
+        if ( IsStdOutRedirectedInternal() )
+        {
+            result = 1;
+            return true;
+        }
+        else
+        {
+            result = 2;
+            return false;
+        }
+    }
+    else
+    {
+        return ( the_result == 1 );
+    }
 }
 
 // GetLastErr

--- a/Code/Core/Env/Env.h
+++ b/Code/Core/Env/Env.h
@@ -34,7 +34,7 @@ public:
     static bool SetEnvVariable( const char * envVarName, const AString & envVarValue );
     static void GetCmdLine( AString & cmdLine );
     static void GetExePath( AString & path );
-    static bool IsStdOutRedirected();
+    static bool IsStdOutRedirected( const bool recheck = false );
     static bool GetLocalUserName( AString & outUserName );
 
     static uint32_t GetLastErr();

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -60,7 +60,8 @@ public:
         FLAG_WARNINGS_AS_ERRORS_MSVC    = 0x80000,
         FLAG_VBCC               =   0x100000,
         FLAG_STATIC_ANALYSIS_MSVC = 0x200000,
-        FLAG_ORBIS_WAVE_PSSLC   =   0x400000
+        FLAG_ORBIS_WAVE_PSSLC   =   0x400000,
+        FLAG_DIAGNOSTICS_COLOR_AUTO = 0x800000,
     };
     static uint32_t DetermineFlags( const CompilerNode * compilerNode,
                                     const AString & args,


### PR DESCRIPTION
Both Clang and GCC (since 4.9) have support for colored diagnostic output. Also both by default enable colored output when their stderr is not redirected. This works well with other build drivers like `make` and `ninja` because they don't intercept command output.

To make colored output work with FASTBuild we need to force it by passing `-fdiagnostics-color=always` option to Clang/GCC when FASTBuild output is not redirected.
Because not all GCC versions support `-fdiagnostics-color` options we add that option only if `-fdiagnostics-color=auto` (which is the default) is explicitly specified in `.CompilerOptions`.
Also we don't add that option if colored output is explicitly forced to disabled or enabled in `.CompilerOptions`.

The second commit adds caching for the result of `Env::IsStdOutRedirected` because now it can potentially be called 1-2 times for each ObjectNode and that check is expensive on Windows.