### PR TITLE
Linux and gcc adaptations

### DIFF
--- a/Code/Core/Mem/MemDebug.cpp
+++ b/Code/Core/Mem/MemDebug.cpp
@@ -9,6 +9,10 @@
 
 #if defined( MEM_DEBUG_ENABLED )
 
+#if defined( __GNUC__ ) && __GNUC__ >= 7
+    #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 // Core
 #include "Core/Env/Assert.h"
 #include "Core/Env/Types.h"

--- a/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
+++ b/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
@@ -15,11 +15,11 @@
     // Executable
     //--------------------------------------------------------------------------
     // These options are a valid for Clang <= 5.0.0:
-    .ExtraLinkerOptions_ASan = ' -lLLVMFuzzer'
-    .ExtraLinkerOptions_MSan = ' -lLLVMFuzzerMSan -lc++'
+    //.ExtraLinkerOptions_ASan = ' -lLLVMFuzzer'
+    //.ExtraLinkerOptions_MSan = ' -lLLVMFuzzerMSan -lc++'
     // These options are expected to be valid for Clang > 5.0.0:
-    // .ExtraLinkerOptions_ASan = ' -fsanitize=fuzzer'
-    // .ExtraLinkerOptions_MSan = ' -fsanitize=fuzzer -lc++'
+    .ExtraLinkerOptions_ASan = ' -fsanitize=fuzzer'
+    .ExtraLinkerOptions_MSan = ' -fsanitize=fuzzer -lc++'
 
     .MyConfigs = { .X64ClangASanConfig_Linux , .X64ClangMSanConfig_Linux }
     ForEach( .Config in .MyConfigs )

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -742,28 +742,32 @@ bool FBuild::DisplayDependencyDB( const Array< AString > & targets ) const
 //------------------------------------------------------------------------------
 /*static*/ bool FBuild::GetTempDir( AString & outTempDir )
 {
-    #if defined( __WINDOWS__ )
+    #if defined( __WINDOWS__ ) || defined( __LINUX__ )
         // Check for override environment variable
         if ( Env::GetEnvVariable( "FASTBUILD_TEMP_PATH", outTempDir ) )
         {
             // Ensure env var was slash terminated
-            const bool slashTerminated = ( outTempDir.EndsWith( '/' ) || outTempDir.EndsWith( '\\' ) );
-            if ( !slashTerminated )
-            {
-                outTempDir += '\\';
-            }
+            #if defined( __WINDOWS__ )
+                const bool slashTerminated = ( outTempDir.EndsWith( '/' ) || outTempDir.EndsWith( '\\' ) );
+                if ( !slashTerminated )
+                {
+                    outTempDir += '\\';
+                }
+            #elif defined( __LINUX__ )
+                const bool slashTerminated = outTempDir.EndsWith( '/' );
+                if ( !slashTerminated )
+                {
+                    outTempDir += '/';
+                }
+            #endif
 
             return true;
         }
 
         // Use regular system temp path
         return FileIO::GetTempDir( outTempDir );
-    #elif defined( __LINUX__ ) || defined( __APPLE__ )
-        outTempDir = "/tmp/";
-        return true;
     #else
-        #error Unknown platform
-        return false;
+        return FileIO::GetTempDir( outTempDir );
     #endif
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -135,11 +135,14 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
             return true;
         }
 
+        AStackString<> compilerWithoutVersion( compiler.Get(), compiler.FindLast( '-' ) );
         // GCC
         if ( compiler.EndsWithI( "gcc.exe" ) ||
              compiler.EndsWithI( "gcc" ) ||
+             compilerWithoutVersion.EndsWithI( "gcc" ) ||
              compiler.EndsWithI( "g++.exe" ) ||
              compiler.EndsWithI( "g++" ) ||
+             compilerWithoutVersion.EndsWithI( "g++" ) ||
              compiler.EndsWithI( "dcc.exe" ) || // WindRiver
              compiler.EndsWithI( "dcc" ) )      // WindRiver
         {

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2021,6 +2021,10 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
 
     FileStream tmpFile;
     AStackString<> fileName( sourceFile->GetName().FindLast( NATIVE_SLASH ) + 1 );
+    if (GetFlag( FLAG_GCC ))
+    {
+       fileName += ".i";
+    }
 
     void const * dataToWrite = job->GetData();
     size_t dataToWriteSize = job->GetDataSize();

--- a/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
@@ -54,13 +54,13 @@
 //==============================================================================
 .LinuxGCCToolChain =
 [
-    .Compiler           = '/usr/bin/gcc'
+    .Compiler           = '/usr/bin/g++'
     Compiler( 'Compiler-GCC-Dist' )
     {
-        .Executable     = '/usr/bin/gcc'
+        .Executable     = '/usr/bin/g++'
         .ExtraFiles     = {
                             '/usr/bin/as'
-                            '/usr/lib/gcc/x86_64-linux-gnu/4.9/cc1plus'
+                            '/usr/lib/gcc/x86_64-linux-gnu/7/cc1plus'
                           }
     }
     .CompilerDist       = 'Compiler-GCC-Dist'

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -38,16 +38,15 @@ Compiler( 'Compiler-x64Clang' )
 }
 Compiler( 'Compiler-x64-Linux' )
 {
-    .Executable     = '/usr/bin/gcc'
+    .Executable     = '/usr/bin/g++'
     .ExtraFiles     = {
                         '/usr/bin/as'
-                        '/usr/lib/gcc/x86_64-linux-gnu/4.9/cc1'
-                        '/usr/lib/gcc/x86_64-linux-gnu/4.9/cc1plus'
+                        '/usr/lib/gcc/x86_64-linux-gnu/7/cc1plus'
                       }
 }
 Compiler( 'Compiler-x64Clang-LinuxOSX' )
 {
-    .Executable = '/usr/bin/clang++'
+    .Executable = '/home/szubersk/bin/clang-6/bin/clang++'
 }
 
 //------------------------------------------------------------------------------
@@ -346,7 +345,7 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
     Using( .LinuxBaseConfig )
     .Platform               = 'x64ClangLinux'
     .Compiler               = 'Compiler-x64Clang-LinuxOSX'
-    .Linker                 = '/usr/bin/clang++'
+    .Linker                 = '/home/szubersk/bin/clang-6/bin/clang++'
 ]
 .X64ClangDebugConfig_Linux  = .X64ClangBaseConfig_Linux
                             + .Debug_Config


### PR DESCRIPTION
Few small adaptations for Linux:

- ability to compile the project with g++ 7
- FASTBUILD_TEMP_PATH is respected on Linux systems
- gcc/g++ requires preprocessed files to have *.i extension to operate correctly
- gcc compiler type will be detected if binary name is in a form "gcc-${version}" e. g. gcc-7