### PR TITLE
Limit number of files in TestProjectGenerator.TestFunction_Speed to 5000

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -261,6 +261,10 @@ void TestProjectGeneration::TestFunction_Speed() const
     // files (about 5,000)
     Array< AString > files;
     FileIO::GetFiles( baseDir, AStackString<>( "*" ), true, &files );
+    if ( files.GetSize() > 5000 )
+    {
+        files.SetSize( 5000 );
+    }
     pg.AddFiles( files );
 
     Array< VSProjectFileType > fileTypes;


### PR DESCRIPTION
Logic for excluding duplicate files in `VSProjectGenerator` has O(n^2) complexity. This leads to apparent hanging of `TestFunction_Speed` if the user has large amount of extra files in the `Code` directory. In my case I had several copies of corpus for BFFFuzzer inside `Code` directory, about 90000 files in total.

To prevent confusion (it's not obvious what is the cause of hang) limit number of files passed to `VSProjectGenerator::AddFiles` to 5000, that many files can be handled in a reasonable time.