### PR TITLE
Fix assertion when FileIO::GetFiles functions are called on non-existent directory

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -803,7 +803,10 @@
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // Special case symlinks.
         struct stat stat_source;
-        VERIFY( lstat( pathCopy.Get(), &stat_source ) == 0 );
+        if ( lstat( pathCopy.Get(), &stat_source ) != 0 )
+        {
+            return;
+        }
         if ( S_ISLNK( stat_source.st_mode ) )
         {
             return;
@@ -912,7 +915,10 @@
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // Special case symlinks.
         struct stat stat_source;
-        VERIFY( lstat( pathCopy.Get(), &stat_source ) == 0 );
+        if ( lstat( pathCopy.Get(), &stat_source ) != 0 )
+        {
+            return;
+        }
         if ( S_ISLNK( stat_source.st_mode ) )
         {
             return;
@@ -1047,7 +1053,10 @@
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // Special case symlinks.
         struct stat stat_source;
-        VERIFY( lstat( pathCopy.Get(), &stat_source ) == 0 );
+        if ( lstat( pathCopy.Get(), &stat_source ) != 0 )
+        {
+            return;
+        }
         if ( S_ISLNK( stat_source.st_mode ) )
         {
             return;
@@ -1184,7 +1193,10 @@
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // Special case symlinks.
         struct stat stat_source;
-        VERIFY( lstat( pathCopy.Get(), &stat_source ) == 0 );
+        if ( lstat( pathCopy.Get(), &stat_source ) != 0 )
+        {
+            return;
+        }
         if ( S_ISLNK( stat_source.st_mode ) )
         {
             return;


### PR DESCRIPTION
After symlink-related changes in e12a8d2a `GetFiles` functions started to fail with assertion when called on non-existent directory. But calling them on non-existent directory should be allowed (at least from looking at the older version of code).
To fix that don't expect `lstat` call on original `pathCopy` to succeed.

This fixes `TestBuildFBuild` and `TestDistributed` tests in the case when `../tmp/Test` directory is missing.