### PR TITLE
Fix assertion when referencing variable with dynamic name from parent scope

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -261,14 +261,14 @@ bool BFFParser::Parse( BFFIterator & iter )
 
         // store variable name
         name.Assign( varNameStart.GetCurrent(), varNameEnd.GetCurrent() );
-    }
 
-    ASSERT( name.GetLength() > 0 );
-    if ( parentScope )
-    {
-        // exchange '^' with '.'
-        ASSERT( BFF_DECLARE_VAR_PARENT == name[0] );
-        name[0] = BFF_DECLARE_VAR_INTERNAL;
+        ASSERT( name.GetLength() > 0 );
+        if ( parentScope )
+        {
+            // exchange '^' with '.'
+            ASSERT( BFF_DECLARE_VAR_PARENT == name[0] );
+            name[0] = BFF_DECLARE_VAR_INTERNAL;
+        }
     }
 
     return true;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/dynamic_var_name_construction.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/dynamic_var_name_construction.bff
@@ -12,9 +12,29 @@
 
 // Assignment LHS
 {
-    .Var1       = 'Value'
+    .Var1       = 'OldValue'
     .Var2       = 'Var1'
     .'$Var2$'   = 'Value'
+    Print( .Var1 ) // Should print "Value"
+}
+
+// Assignment RHS from parent scope
+{
+    .Var1         = 'Value'
+    .Var2         = 'Var1'
+    {
+        .Var3     = ^'$Var2$'
+        Print( .Var3 ) // Should print "Value"
+    }
+}
+
+// Assignment LHS to parent scope
+{
+    .Var1         = 'OldValue'
+    .Var2         = 'Var1'
+    {
+        ^'$Var2$' = 'Value'
+    }
     Print( .Var1 ) // Should print "Value"
 }
 


### PR DESCRIPTION
An if block at the end of `BFFParser::ParseVariableName` that sets first symbol to `.` is moved (with both related assertions) into block for handling variables with a fixed name.
Block that handles variables with dynamic names already produces names starting with `.` regardless of `parentScope` value, so assertion in the moved block was triggering when it shouldn't be.