### PR TITLE
Refactor generation of All-* aliases

### DIFF
--- a/Code/Core/Core.bff
+++ b/Code/Core/Core.bff
@@ -31,6 +31,7 @@
             .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -57,6 +57,7 @@
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
 
         // Run Test
         //--------------------------------------------------------------------------

--- a/Code/OSUI/OSUI.bff
+++ b/Code/OSUI/OSUI.bff
@@ -33,6 +33,7 @@
             .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/TestFramework/TestFramework.bff
+++ b/Code/TestFramework/TestFramework.bff
@@ -34,6 +34,7 @@
             .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
+++ b/Code/Tools/FBuild/BFFFuzzer/BFFFuzzer.bff
@@ -53,6 +53,7 @@
                                         + .'ExtraLinkerOptions_$Config$'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
+++ b/Code/Tools/FBuild/FBuildApp/FBuildApp.bff
@@ -53,6 +53,7 @@
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -33,6 +33,7 @@
             .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -61,6 +61,7 @@
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
 
         // Run Test
         //--------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
@@ -72,6 +72,7 @@
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$Config$' }
+        ^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
     }
 
     // Aliases

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -506,11 +506,6 @@ VCXProject( 'UpdateSolution-proj' )
                             .X64ClangASanConfig_Linux, .X64ClangMSanConfig_Linux }
 .Configs_OSX_Clang      = { .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
 
-.ConfigsAll             = { .Configs_Windows_MSVC
-                            .Configs_Windows_Clang
-                            .Configs_Linux
-                            .Configs_OSX_Clang
-                          }
 #if __WINDOWS__
     .Configs    = .Configs_Windows_MSVC
                 + .Configs_Windows_Clang
@@ -521,6 +516,27 @@ VCXProject( 'UpdateSolution-proj' )
 #if __OSX__
     .Configs    = .Configs_OSX_Clang
 #endif
+
+.Targets_x64_Debug = {}
+.Targets_x64_Profile = {}
+.Targets_x64_Release = {}
+.Targets_x64Clang_Debug = {}
+.Targets_x64Clang_Profile = {}
+.Targets_x64Clang_Release = {}
+
+.Targets_x64Linux_Debug = {}
+.Targets_x64Linux_Profile = {}
+.Targets_x64Linux_Release = {}
+.Targets_x64Linux_ASan = {}
+.Targets_x64ClangLinux_Debug = {}
+.Targets_x64ClangLinux_Profile = {}
+.Targets_x64ClangLinux_Release = {}
+.Targets_x64ClangLinux_ASan = {}
+.Targets_x64ClangLinux_MSan = {}
+
+.Targets_x64OSX_Debug = {}
+.Targets_x64OSX_Profile = {}
+.Targets_x64OSX_Release = {}
 
 // External
 #include "..\External\LZ4\LZ4.bff"
@@ -544,25 +560,11 @@ VCXProject( 'UpdateSolution-proj' )
 
 // Aliases : All-$Platform$-$Config$
 //------------------------------------------------------------------------------
-ForEach( .Config in .ConfigsAll )
+ForEach( .Config in .Configs )
 {
     Using( .Config )
 
-    Alias( 'All-$Platform$-$Config$' )
-    {
-        .Targets        = { // tests
-                            'CoreTest-$Platform$-$Config$',
-                            'FBuildTest-$Platform$-$Config$',
-                            // executables
-                            'FBuildApp-$Platform$-$Config$',
-                            'FBuildWorker-$Platform$-$Config$'
-                          }
-#if __LINUX__
-        .Targets        + { // libFuzzer targets
-                            'BFFFuzzer-$Platform$-$Config$'
-                          }
-#endif
-    }
+    Alias( 'All-$Platform$-$Config$' ) { .Targets = .'Targets_$Platform$_$Config$' }
 }
 
 // Aliases : All-$Platform$

--- a/External/LZ4/LZ4.bff
+++ b/External/LZ4/LZ4.bff
@@ -52,6 +52,7 @@
             .LibrarianOutput            = '$OutputBase$/$ProjectName$/$ProjectName$$LibExtension$'
 		}
 		Alias( '$ProjectName$-$Platform$-$Config$' ) { .Targets = '$ProjectName$-Lib-$Platform$-$Config$' }
+		^'Targets_$Platform$_$Config$' + { '$ProjectName$-$Platform$-$Config$' }
 	}
 
 	// Aliases


### PR DESCRIPTION
This change allows a project to exclude itself from `All-$Platform$-$Config$` alias for a configuration in which it can't be built. This is used by BFFFuzzer which builds only in `x64ClangLinux-ASan` and `x64ClangLinux-MSan`.
Without this change building (for example) alias `All-x64Linux-Debug` fails with an error that says that file `Code/BFFFuzzer-x64Linux-Debug` is missing. Also because TestBuildFBuild uses such aliases it was also broken.

Additionally this change removes `All-$Platform$-$Config$` aliases which can't be built on the current platform, e.g. `All-x64Linux-Debug` won't be defined on Windows anymore.