### PR TITLE
Fix TestPCH with clang on windows

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/fbuild.bff
@@ -68,7 +68,7 @@ Executable( "PCHTest" )
 
         .PCHOptions         = ' -c -x c++-header $PCHInputFile$ -o"$PCHOutputFile$"'
 
-        .Compiler           = '$ClangPath$\bin\clang++.exe'
+        .Compiler           = 'Compiler-ClangForWindows-Dist'
         .CompilerOptions    = ' -c -g -include-pch "$PCHOutputFile$" %1 -o "%2" -integrated-as'
                             + ' "-ITools/FBuild/FBuildTest/Data/TestPrecompiledHeaders"'
 

--- a/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
@@ -39,7 +39,7 @@
 //.ClangPath            = 'C:\Program Files (x86)\LLVM'
 .WindowsClangToolChain =
 [
-    .Compiler           = '$ClangPath$/bin/clang++.exe'
+    .Compiler           = 'Compiler-ClangForWindows-Dist'
     Compiler( 'Compiler-ClangForWindows-Dist' )
     {
         .Executable     = '$ClangPath$/bin/clang++.exe'


### PR DESCRIPTION
Hello!

Here is a fix for an error I got when running the tests on the dev branch:

```
 - Test 'TestPCH'
E:\RD\FastBuild\Code\Tools\FBuild\FBuildTest\Data\TestPrecompiledHeaders\fbuild.bff(64,5): FASTBuild Error #1102 - ObjectList() - 'Compiler' ('C:\Program Files\LLVM\bin\clang++.exe') is of unexpected type 'File'. Expected 'Compiler'.
```

It seems that this was missed by 27d2f4e.

(Note that I locally changed ClangPath in testcommon.bff to the path on my machine, but that should be of no consequence in that case.)

Thanks!