### PR TITLE
Increase thread stack size in AddressSanitizer builds

### DIFF
--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -20,6 +20,10 @@
     #include <unistd.h>
 #endif
 
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+
 // Debug Structure for thread name setting
 //------------------------------------------------------------------------------
 #if defined( __WINDOWS__ )
@@ -134,6 +138,12 @@ public:
                                    nullptr      // LPDWORD lpThreadId
                                  );
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
+        #if __has_feature( address_sanitizer ) || __SANITIZE_ADDRESS__
+            // AddressSanitizer instruments objects created on the stack by inserting redzones around them.
+            // This greatly increases the amount of stack space used by the program.
+            // To account for that double the requested stack size for the thread.
+            stackSize *= 2;
+        #endif
         pthread_t h;
         pthread_attr_t threadAttr;
         VERIFY( pthread_attr_init( &threadAttr ) == 0 );


### PR DESCRIPTION
AddressSanitizer instruments objects created on the stack by inserting redzones around them. This greatly increases the amount of stack space used by the program. To account for that we double the requested stack size when creating a thread.

This fixes recently appeared stack-overflow crashes in RegressionTest_RemoteCrashOnErrorFormatting.