### PR TITLE
Fix alloc/dealloc mismatch in ToolManifest

### DIFF
--- a/Code/Core/Containers/AutoPtr.h
+++ b/Code/Core/Containers/AutoPtr.h
@@ -6,17 +6,26 @@
 //------------------------------------------------------------------------------
 #include "Core/Mem/Mem.h"
 
-// DefaultDeletor - free using "Free"
+// FreeDeletor - free using FREE
 //------------------------------------------------------------------------------
-class DefaultDeletor
+class FreeDeletor
 {
 public:
     static inline void Delete( void * ptr ) { FREE( ptr ); }
 };
 
+// DeleteDeletor - free using FDELETE
+//------------------------------------------------------------------------------
+class DeleteDeletor
+{
+public:
+    template < class T >
+    static inline void Delete( T * ptr ) { FDELETE ptr; }
+};
+
 // AutoPtr
 //------------------------------------------------------------------------------
-template < class T, class DELETOR = DefaultDeletor >
+template < class T, class DELETOR = FreeDeletor >
 class AutoPtr
 {
 public:

--- a/Code/Core/Reflection/PropertyType.h
+++ b/Code/Core/Reflection/PropertyType.h
@@ -9,7 +9,6 @@
 // Forward Declarations
 //------------------------------------------------------------------------------
 class AString;
-class DefaultDeletor;
 class Vec2;
 class Vec3;
 class Vec4;

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
@@ -220,7 +220,7 @@ void ToolManifest::DeserializeFromRemote( IOStream & ms )
         GetRemoteFilePath( (uint32_t)i, localFile );
 
         // is this file already present?
-        AutoPtr< FileStream > fileStream( FNEW( FileStream ) );
+        AutoPtr< FileStream, DeleteDeletor > fileStream( FNEW( FileStream ) );
         FileStream & f = *( fileStream.Get() );
         if ( f.Open( localFile.Get() ) == false )
         {
@@ -448,7 +448,7 @@ bool ToolManifest::ReceiveFileData( uint32_t fileId, const void * data, size_t &
     #endif
 
     // open read-only
-    AutoPtr< FileStream > fileStream( FNEW( FileStream ) );
+    AutoPtr< FileStream, DeleteDeletor > fileStream( FNEW( FileStream ) );
     if ( fileStream.Get()->Open( fileName.Get(), FileStream::READ_ONLY ) == false )
     {
         return false; // FAILED


### PR DESCRIPTION
This was found by AddressSanitizer.
In two places a `FileStream` object is allocated with `new` (obviously) and deallocated with `::Free` by `AutoPtr`. This case of alloc/dealloc mismatch is actually bad because `FileStream` has a non-trivial destructor and in `ToolManifest::Deserialize` it could be deleted while file is open which leads to a handle leak.

To fix this I added a new deleter class that uses `FDELETE`.
I also renamed `DefaultDeletor` to `FreeDeletor` to expose the fact that it uses `free` instead of `delete` operator (which people might expect given that the name is similar to `std::default_delete`). A hope this rename won't cause many problems in other (non-FASTBuild) code that uses `AutoPtr`.