### PR TITLE
Add support for running tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,172 @@
+language: cpp
+
+matrix:
+  include:
+    # Linux, default compilers
+    - os: linux
+    # OSX, default compilers
+    - os: osx
+      compiler: clang
+    # Windows, we expect MSVC 14.16.27023 to be installed.
+    - os: windows
+    # Linux, latest supported compilers
+    - os: linux
+      env: GCC=gcc-8 CLANG=clang-8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
+          packages:
+            - gcc-8
+            - g++-8
+            - clang-8
+    # Linux, AddressSanitizer
+    - os: linux
+      env: CFG=asan CLANG=clang-8
+      # Use latest clang when building with sanitizers.
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
+          packages:
+            - clang-8
+            - llvm-8 # for llvm-symbolizer
+      sudo: true # LeakSanitizer doesn't work inside Travis containers, see https://github.com/travis-ci/travis-ci/issues/9033.
+    # Linux, MemorySanitizer
+    - os: linux
+      env: CFG=msan CLANG=clang-8
+      # Use latest clang when building with sanitizers.
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
+          packages:
+            - clang-8
+            - llvm-8 # for llvm-symbolizer
+  allow_failures:
+    - env: CFG=asan CLANG=clang-8
+    - env: CFG=msan CLANG=clang-8
+  fast_finish: true
+
+install:
+  # Download and unpack archive for a release version.
+  - DL_VER=0.98
+  - |
+    case "${TRAVIS_OS_NAME}" in
+    linux)   FN=FASTBuild-Linux-x64-v${DL_VER}.zip   FBUILD=fbuild ;;
+    osx)     FN=FASTBuild-OSX-x64-v${DL_VER}.zip     FBUILD=FBuild ;;
+    windows) FN=FASTBuild-Windows-x64-v${DL_VER}.zip FBUILD=FBuild.exe ;;
+    esac
+  - wget http://fastbuild.org/downloads/v${DL_VER}/${FN}
+  - unzip ${FN}
+  - chmod +x ./${FBUILD}
+  # Set up some variables for convenience.
+  - |
+    case "${TRAVIS_OS_NAME}" in
+    linux)   NCPU=$(nproc) ;;
+    osx)     NCPU=$(sysctl -n hw.ncpu) ;;
+    windows) NCPU=${NUMBER_OF_PROCESSORS} ;;
+    esac
+  - FBUILD_CMD="../${FBUILD} -j${NCPU} -noprogress"
+  - GCC=${GCC:-gcc}
+  - GXX=${GCC/gcc/g++}
+  - CLANG=${CLANG:-clang}
+  - CLANGXX=${CLANG/clang/clang++}
+  # On Linux/OSX print paths to binaries for the installed compilers.
+  # On Windows check that all tools are present at paths we expect, if not then try to find them on the disk and fail the build.
+  - |
+    case "${TRAVIS_OS_NAME}" in
+    linux)
+      for x in ${GCC} ${GXX} $(${GCC} -print-prog-name=cc1) $(${GCC} -print-prog-name=cc1plus) ${CLANG} ${CLANGXX}; do
+        echo $x; which $x && readlink -f $(which $x)
+        echo
+      done
+      true # These commands are purely informational, don't fail the build if they fail.
+      ;;
+    osx)
+      for x in ${CLANG} ${CLANGXX}; do
+        echo $x; which $x
+        echo
+      done
+      true # These commands are purely informational, don't fail the build if they fail.
+      ;;
+    windows)
+      SUCCESS=true
+      if [[ ! -f 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\cl.exe' ]]; then
+        find 'C:\Program Files (x86)' 'C:\Program Files' -iname cl.exe
+        SUCCESS=false
+      fi
+      if [[ ! -f 'C:\Program Files (x86)\Windows Kits\10\Bin\10.0.17134.0\x64\RC.exe' ]]; then
+        find 'C:\Program Files (x86)' 'C:\Program Files' -iname rc.exe
+        SUCCESS=false
+      fi
+      if [[ ! -f 'C:\Program Files\LLVM\bin\clang++.exe' ]]; then
+        find 'C:\Program Files' -iname clang++.exe
+        SUCCESS=false
+      fi
+      if [[ ! -f 'C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe' ]]; then
+        find 'C:\Windows' -iname csc.exe
+        SUCCESS=false
+      fi
+      ${SUCCESS}
+    ;;
+    esac
+
+script:
+  - cd Code
+  # Inject a #define into root configs to activate CI logic.
+  - |
+    sed -i -e "1i\\
+    #define CI_BUILD
+    " fbuild.bff Tools/FBuild/FBuildTest/Data/testcommon.bff
+  # Put full paths to GCC binaries into config files.
+  - |
+    case "${TRAVIS_OS_NAME}" in
+    linux)
+      sed -i -e "
+      s:GCC_BINARY:$(which ${GCC}):
+      s:GXX_BINARY:$(which ${GXX}):
+      s:CC1_BINARY:$(${GCC} -print-prog-name=cc1):
+      s:CC1PLUS_BINARY:$(${GCC} -print-prog-name=cc1plus):
+      " ../External/SDK/GCC/Linux/GCC_CI.bff
+      ;;
+    esac
+  # Put full paths to Clang binaries into config files.
+  - |
+    case "${TRAVIS_OS_NAME}" in
+    linux|osx)
+      sed -i -e "
+      s:CLANG_BINARY:$(which ${CLANG}):
+      s:CLANGXX_BINARY:$(which ${CLANGXX}):
+      " ../External/SDK/Clang/{Linux,OSX}/Clang_CI.bff
+      ;;
+    esac
+  # Run tests in the selected configuration.
+  - |
+    case "${TRAVIS_OS_NAME}:${CFG}" in
+      linux:|osx:|windows:)
+        ${FBUILD_CMD} Tests
+        ;;
+      linux:asan)
+        ${FBUILD_CMD} {CoreTest,FBuildTest}-RunTest-x64ClangLinux-ASan
+        ;;
+      linux:msan)
+        ${FBUILD_CMD} {CoreTest,FBuildTest}-RunTest-x64ClangLinux-MSan
+        ;;
+    esac
+  # Check non-unity build.
+  - |
+    case "${TRAVIS_OS_NAME}:${CFG}" in
+      linux:)
+        ${FBUILD_CMD} -nounity -clean All-x64{,Clang}Linux-Debug
+        ;;
+      osx:)
+        ${FBUILD_CMD} -nounity -clean All-x64OSX-Debug
+        ;;
+      windows:)
+        ${FBUILD_CMD} -nounity -clean All-x64{,Clang}-Debug
+        ;;
+    esac

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCSharp/csharp.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCSharp/csharp.bff
@@ -11,6 +11,9 @@ Settings {}
 Compiler( 'CSharpCompiler' )
 {
     .Executable        = "C:\Windows\Microsoft.NET\Framework\v3.5\csc.exe"
+    #if CI_BUILD
+        .Executable    = "C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe"
+    #endif
     .CompilerFamily    = "custom"
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_timeout.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestTest/test_timeout.cpp
@@ -8,4 +8,9 @@ int main(int , char **)
     {
         // busy wait spin to avoid pulling dependencies for sleep/yield
     }
+    #if defined( __GNUC__ )
+        // GCC 4.8 warns about function not returning if value is return is omitted.
+        // MSVC warns about unreachable code is the return is present.
+        return 0;
+    #endif
 }

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -70,6 +70,13 @@
             .TestOutput                     = "$OutputBase$/$ProjectPath$/TestOutput.txt"
             .TestWorkingDir                 = 'Tools/FBuild/FBuildTest'
             .TestTimeOut                    = 300
+            #if CI_BUILD
+                #if __WINDOWS__
+                    // Compilation on Travis's Windows nodes is significantly slower than on Linux/OSX.
+                    // So the tests need more time to complete succefully.
+                    .TestTimeOut            = 900
+                #endif
+            #endif
         }
     }
 

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -42,6 +42,10 @@ Settings
         // - Only in Debug as this impacts performance (inlining)
         // - Only when not building from tests (FASTBuild building itself)
         .UnityInputIsolateWritableFiles = true
+        // Also not when building on CI (which build from git)
+        #if CI_BUILD
+            .UnityInputIsolateWritableFiles = false
+        #endif
     #endif
 ]
 .Profile_Config =
@@ -350,7 +354,9 @@ VCXProject( 'UpdateSolution-proj' )
 #include "Tools\FBuild\FBuildApp\FBuildApp.bff"
 #include "Tools\FBuild\FBuildWorker\FBuildWorker.bff"
 #include "Tools\FBuild\FBuildTest\FBuildTest.bff"
-#include "Tools\FBuild\BFFFuzzer\BFFFuzzer.bff"
+#if !CI_BUILD
+    #include "Tools\FBuild\BFFFuzzer\BFFFuzzer.bff"
+#endif
 
 // Aliases : All-$Platform$-$Config$
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Clang.bff
+++ b/External/SDK/Clang/Clang.bff
@@ -18,16 +18,24 @@
 // Activate
 //------------------------------------------------------------------------------
 #if__LINUX__
-    #if USING_CLANG_3
-        #include "Linux/Clang3.bff"
-    #endif
-    #if USING_CLANG_6
-        #include "Linux/Clang6.bff"
+    #if CI_BUILD
+        #include "Linux/Clang_CI.bff"
+    #else
+        #if USING_CLANG_3
+            #include "Linux/Clang3.bff"
+        #endif
+        #if USING_CLANG_6
+            #include "Linux/Clang6.bff"
+        #endif
     #endif
 #endif
 #if __OSX__
-    #if USING_CLANG_8
-        #include "OSX/Clang8.bff"
+    #if CI_BUILD
+        #include "OSX/Clang_CI.bff"
+    #else
+        #if USING_CLANG_8
+            #include "OSX/Clang8.bff"
+        #endif
     #endif
 #endif
 #if __WINDOWS__

--- a/External/SDK/Clang/Linux/Clang_CI.bff
+++ b/External/SDK/Clang/Linux/Clang_CI.bff
@@ -1,0 +1,54 @@
+// Clang
+//------------------------------------------------------------------------------
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-Clang' )
+{
+    .Executable                     = 'CLANG_BINARY'
+    .CompilerFamily                 = 'clang' // Specify compiler family explicitly because binary name may change at any moment
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_Clang_Linux =
+[
+    .Platform                       = 'x64ClangLinux'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-Clang'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -m64'           // x86_64
+                                    + ' -D__LINUX__'    // Platform define
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'   // warnings as errors
+                                    + ' -Wextra'
+                                    + ' -Wshadow'
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+                                    + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'CLANGXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2"'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -1,0 +1,59 @@
+// Clang
+//------------------------------------------------------------------------------
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-Clang' )
+{
+    .Executable                     = 'CLANGXX_BINARY'
+    .CompilerFamily                 = 'clang' // Specify compiler family explicitly because binary name may change at any moment
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_Clang_OSX =
+[
+    .Platform                       = 'x64OSX'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-Clang'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -m64'           // x86_64
+                                    + ' -D__OSX__'      // Platform define
+                                    + ' -D__APPLE__'    // Platform define
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'       // warnings as errors
+                                    + ' -Wextra'
+
+                                    // Disabled warnings
+                                    + ' -Wno-#pragma-messages'
+                                    + ' -Wno-invalid-offsetof'      // we get the offset of members in non-POD types
+                                    + ' -Wno-implicit-exception-spec-mismatch' // Fires on our new/delete operator (Clang bug?)
+
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'CLANGXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2" -g'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/Clang/Windows/Clang7.bff
+++ b/External/SDK/Clang/Windows/Clang7.bff
@@ -1,6 +1,9 @@
 // Clang 7.x.x
 //------------------------------------------------------------------------------
-.Clang7_BasePath = '../External/SDK/Clang/Windows/7.0.1'
+.Clang7_BasePath     = '../External/SDK/Clang/Windows/7.0.1'
+#if CI_BUILD
+    .Clang7_BasePath = 'C:\Program Files\LLVM'
+#endif
 
 // Compiler
 //------------------------------------------------------------------------------

--- a/External/SDK/GCC/GCC.bff
+++ b/External/SDK/GCC/GCC.bff
@@ -11,11 +11,15 @@
 // Activate
 //------------------------------------------------------------------------------
 #if__LINUX__
-    #if USING_GCC_4
-        #include "Linux/GCC4.bff"
-    #endif
-    #if USING_GCC_7
-        #include "Linux/GCC7.bff"
+    #if CI_BUILD
+        #include "Linux/GCC_CI.bff"
+    #else
+        #if USING_GCC_4
+            #include "Linux/GCC4.bff"
+        #endif
+        #if USING_GCC_7
+            #include "Linux/GCC7.bff"
+        #endif
     #endif
 #endif
 

--- a/External/SDK/GCC/Linux/GCC_CI.bff
+++ b/External/SDK/GCC/Linux/GCC_CI.bff
@@ -1,0 +1,60 @@
+// GCC
+//------------------------------------------------------------------------------
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-GCC' )
+{
+    .Executable                     = 'GXX_BINARY'
+    .ExtraFiles                     = {
+                                        '/usr/bin/as'
+                                        'CC1_BINARY'
+                                        'CC1PLUS_BINARY'
+                                      }
+    .CompilerFamily                 = 'gcc' // Specify compiler family explicitly because binary name may change at any moment
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_GCC_Linux =
+[
+    .Platform                       = 'x64Linux'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-GCC'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -m64'           // x86_64
+                                    + ' -D__LINUX__'    // Platform define
+                                    + ' -ffreestanding' // prevent extra magic includes like stdc-predefs.h
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'   // warnings as errors
+                                    + ' -Wextra'
+                                    + ' -Wshadow'
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+                                    + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'GXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2"'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/VisualStudio/VS2017.bff
+++ b/External/SDK/VisualStudio/VS2017.bff
@@ -2,6 +2,9 @@
 //------------------------------------------------------------------------------
 .VS2017_BasePath         = '$_CURRENT_BFF_DIR_$/2017/Community'
 .VS2017_Version          = '14.16.27023'
+#if CI_BUILD
+    .VS2017_BasePath     = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools'
+#endif
 
 // X64 Compiler
 //------------------------------------------------------------------------------

--- a/External/SDK/Windows/Windows10SDK.bff
+++ b/External/SDK/Windows/Windows10SDK.bff
@@ -5,6 +5,10 @@
 //------------------------------------------------------------------------------
 .Windows10_SDKBasePath          = '$_CURRENT_BFF_DIR_$/10'
 .Windows10_SDKVersion           = '10.0.17763.0'
+#if CI_BUILD
+    .Windows10_SDKBasePath      = 'C:\Program Files (x86)\Windows Kits/10'
+    .Windows10_SDKVersion       = '10.0.17134.0'
+#endif
 
 // Defines
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Hi Franta.
This is my attempt at bringing continuous integration to FASTBuild, this time for Linux builds using Travis CI.

I hope that this attempt won't fail (efbced9b) as the last one (#151) because, as I understand, the only thing that is required to set this up (aside from merging this PR of course) is to "install" [TravisCI GitHub app](https://github.com/marketplace/travis-ci) to fastbuild/fastbuild repo. This should enable automatic builds on new commits for branches that have a `.travis.yml` file and for pull requests to such branches.
Also you can look how integration with GitHub will look in the FASTBuild case [in my fork](https://github.com/dummyunit/fastbuild/pull/1).

Currently there are build jobs for these configurations:
1. Linux, default compiler versions for Ubuntu 14.04 (GCC 4.8 and Clang 5.0), running default set of tests (`Tests` target).
2. Linux, latest compiler versions supported by FASTBuild (GCC 6 and Clang 6.0), running default set of tests (`Tests` target).
3. Linux, Clang, running tests in AddresSanitizer build.
4. Linux, Clang, running tests in MemorySanitizer build.

AddresSanitizer and MemorySanitizer are currently allowed to fail because they often break on flaky tests that currently exist (these tests need to fixed first).

There is also a disabled (commented out) configuration for runnig tests on OSX. It is disabled because some tests are failing consistently on Travis OSX VMs, so somebody has to fix these tests first.

Now the bad parts:
1. Some tests in FASTBuild are currently broken: #441, #448, #449. So merging this PR before those three is pointless because Travis builds will fail every time.
2. Some tests for build distribution (at least RegressionTest_RemoteCrashOnErrorFormatting and TestLocalRace) fail _sometimes_, this is probably related to #447 and #437. So until those issues are fixed Travis builds wouldn't be a reliable indicator for problems in new PRs (although build for a PR can be restarted even without leaving GitHub from the Checks tab of the PR).
3. Test TestSharedMemory.CreateAccessDestroy also sometimes fails (Assert: t.GetElapsed() < 10.0f), but only on Travis. It never failed for me locally, so I don't know what to with it.