### PR TITLE
Fix incremental link when at least one /OPT:NO* option is present in the command line

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -711,17 +711,17 @@ void LinkerNode::GetAssemblyResourceFiles( Args & fullArgs, const AString & pre,
 
             if ( IsStartOfLinkerArg_MSVC( token, "OPT" ) )
             {
-                if ( token.FindI( "REF" ) )
+                if ( token.FindI( ":REF" ) )
                 {
                     optREFFlag = true;
                 }
 
-                if ( token.FindI( "ICF" ) )
+                if ( token.FindI( ":ICF" ) )
                 {
                     optICFFlag = true;
                 }
 
-                if ( token.FindI( "LBR" ) )
+                if ( token.FindI( ":LBR" ) )
                 {
                     optLBRFlag = true;
                 }


### PR DESCRIPTION
Hello!

A fix from a fellow developer at Ubisoft.

This occurred when we had /OPT:NOREF in the linker command line for instance.