### PR TITLE
New functionality to allow PreBuildDependencyPreprocessor.

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
@@ -56,8 +56,12 @@ Builds a list of objects, typically for later input into a Library, Executable o
   .PCHOptions               ; (optional) Options for compiler for precompiled header
 
   ; Additional options
-  .PreBuildDependencies     ; (optional) Force targets to be built before this ObjectList (Rarely needed,
-                            ; but useful when a ObjectList relies on generated code).
+  .PreBuildDependencies                    ; (optional) Force targets to be built before this ObjectList (Rarely needed,
+                                           ; but useful when a ObjectList relies on generated code).
+  .PreBuildDependencyPreprocessor          ; (optional) Compiler to use for preprocessing a file and gathering
+                                           ; PreBuildDependencies from the source file.
+  .PreBuildDependencyPreprocessorOptions   ; (optional) Args to pass to the Pre Build Dependency Preprocessor
+
 }
 </div>
 <p><b>Build-Time Substitutions</b>
@@ -79,8 +83,39 @@ Builds a list of objects, typically for later input into a Library, Executable o
   </ul>
 </ul>
 </p>
-    </div>
+</div>
 
+<div id='copy' class='newsitemheader'>
+      Other Options
+    </div>	
+    <div class='newsitembody'>
+      <p><b>.PreBuildDependencies</b> - String/ArrayOfStrings - (Optional)</p>
+	  <p>One or more nodes which must be built before this node is built.</p>	  
+	  <p>The .PreBuildDependencies option ensures the specified targets are up-to-date before the 
+	  ObjectList() is executed. This is necessary in situations where files are generated as part of
+	  the build. Failure to specify these dependencies in this way could allow the ObjectList() operation
+	  to be performed before the source files are updated/generated. This will result in unreliable builds
+	  (out of date or missing files) or even build failure (compilation attempted while source file is still 
+	  being written/updated).</p>
+	</div>
+    <div class='newsitembody'>
+      <p><b>.PreBuildDependencyPreprocessor</b> - Compiler - (Optional)</p>
+	  <p>A preprocessor compiler that scans the source file for dependencies.</p>	  
+	  <p>The .PreBuildDependencyPreprocessor option allows a preprocessor to be run on the source file
+	  to search for dependencies. The PreBuildDependencyPreprocessor should only be reliant on the source
+	  file for generating these additional dependencies. The Preprocessor should output one dependency per
+	  line to stdout and errors to stderr. Like other compilers, return 0 for success, any other codes for
+	  failure.</p>
+	  <p>All other static dependencies like PreBuildDependencies and Compilers are guaranteed to be completed
+	  before the preprocessor is run. Dynamic dependencies and the regular code preprocessor are run after
+	  all gathered PreBuildDependencies have been completed.</p>
+	</div>
+    <div class='newsitembody'>
+      <p><b>.PreBuildDependencyPreprocessorOptions</b> - String - (Optional)</p>
+	  <p>Options for the PreBuildDependencyPreprocessor</p>	  
+	  <p>These options use the same Compiler Options Build Time Substitutions as other compilers.</p>
+	</div>
+</div>	
 
   <script>generateFooter()</script>
 </body>

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -252,7 +252,8 @@ Function::~Function() = default;
         {
             const Node* node = nodeGraph.GetNodeByIndex( index );
 
-            const Dependencies * depVectors[ 3 ] = { &node->GetPreBuildDependencies(),
+            const Dependencies * depVectors[ 4 ] = { &node->GetPreBuildDependencies(),
+                                                     &node->GetPreBuildDynamicDependencies(),
                                                      &node->GetStaticDependencies(),
                                                      &node->GetDynamicDependencies() };
             for ( const Dependencies * depVector : depVectors )

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -140,9 +140,17 @@ Node::~Node() = default;
     return true;
 }
 
+// DeterminePreBuildDynamicDependenciesNeedToBuild
+//------------------------------------------------------------------------------
+/*virtual*/ bool Node::DeterminePreBuildDynamicDependenciesNeedToBuild(bool UNUSED( forceClean )) const
+{
+	return false;
+}
+
+
 // DetermineNeedToBuild
 //------------------------------------------------------------------------------
-bool Node::DetermineNeedToBuild( bool forceClean ) const
+/*virtual*/ bool Node::DetermineNeedToBuild( bool forceClean ) const
 {
     if ( forceClean )
     {
@@ -264,6 +272,14 @@ bool Node::DetermineNeedToBuild( bool forceClean ) const
     return false;
 }
 
+// DoPreBuildDynamicDependencies
+//------------------------------------------------------------------------------
+/*virtual*/ Node::BuildResult Node::DoPreBuildDynamicDependencies( Job * UNUSED( job ) )
+{
+    ASSERT( false ); // Derived class is missing implementation
+    return Node::NODE_RESULT_FAILED;
+}
+
 // DoBuild
 //------------------------------------------------------------------------------
 /*virtual*/ Node::BuildResult Node::DoBuild( Job * UNUSED( job ) )
@@ -278,6 +294,14 @@ bool Node::DetermineNeedToBuild( bool forceClean ) const
 {
     ASSERT( false ); // Derived class is missing implementation
     return Node::NODE_RESULT_FAILED;
+}
+
+// PreBuildDynamicDependenciesFinalize
+//------------------------------------------------------------------------------
+/*virtual*/ bool Node::PreBuildDynamicDependenciesFinalize(NodeGraph &)
+{
+	// most nodes have nothing to do
+	return true;
 }
 
 // Finalize

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -37,6 +37,7 @@ public:
 
     CompilerNode * GetCompiler() const;
     CompilerNode * GetPreprocessor() const;
+	CompilerNode * GetPreBuildDependencyPreprocessor() const;
 
     inline const AString & GetCompilerOptions() const { return m_CompilerOptions; }
 protected:
@@ -57,6 +58,8 @@ protected:
                                    const AString & compilerOptionsDeoptimized,
                                    const AString & preprocessor,
                                    const AString & preprocessorOptions,
+                                   const AString & preBuildDependencyPreprocessor,
+                                   const AString & preBuildDependencyPreprocessorOptions,
                                    const AString & objectName,
                                    const AString & objectInput,
                                    const AString & pchObjectName );
@@ -89,7 +92,9 @@ protected:
     AString             m_PCHOptions;
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
-    Array< AString >    m_PreBuildDependencyNames;
+	AString             m_PreBuildDependencyPreprocessor;
+	AString             m_PreBuildDependencyPreprocessorOptions;
+	Array< AString >    m_PreBuildDependencyNames;
 
     // Internal State
     bool                m_UsingPrecompiledHeader            = false;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -79,7 +79,8 @@ public:
 
     CompilerNode * GetCompiler() const;
     inline Node * GetSourceFile() const { return m_StaticDependencies[ 1 ].GetNode(); }
-    CompilerNode * GetDedicatedPreprocessor() const;
+	CompilerNode * GetPreBuildPreprocessor() const;
+	CompilerNode * GetDedicatedPreprocessor() const;
     #if defined( __WINDOWS__ )
         inline Node * GetPrecompiledHeaderCPPFile() const { ASSERT( GetFlag( FLAG_CREATING_PCH ) ); return m_StaticDependencies[ 1 ].GetNode(); }
     #endif
@@ -90,8 +91,11 @@ public:
     const char * GetObjExtension() const;
 private:
     virtual bool DoDynamicDependencies( NodeGraph & nodeGraph, bool forceClean ) override;
+	virtual bool DeterminePreBuildDynamicDependenciesNeedToBuild( bool forceClean ) const override;
+	virtual BuildResult DoPreBuildDynamicDependencies( Job * job ) override;
     virtual BuildResult DoBuild( Job * job ) override;
     virtual BuildResult DoBuild2( Job * job, bool racingRemoteJob ) override;
+	virtual bool PreBuildDynamicDependenciesFinalize(NodeGraph & nodeGraph) override;
     virtual bool Finalize( NodeGraph & nodeGraph ) override;
 
     BuildResult DoBuildMSCL_NoCache( Job * job, bool useDeoptimization );
@@ -187,13 +191,16 @@ private:
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
     Array< AString >    m_PreBuildDependencyNames;
+	AString             m_PreBuildDependencyPreprocessor;
+	AString             m_PreBuildDependencyPreprocessorOptions;
+	Array< AString >    m_PreBuildDynamicDependencyNames;
 
     // Internal State
     AString             m_PrecompiledHeader;
     uint32_t            m_Flags                             = 0;
     uint32_t            m_PreprocessorFlags                 = 0;
     uint64_t            m_PCHCacheKey                       = 0;
-
+	
     // Not serialized
     Array< AString >    m_Includes;
     bool                m_Remote                            = false;

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
@@ -72,6 +72,7 @@ private:
     void        WorkerThreadWait( uint32_t maxWaitMS );
     Job *       GetJobToProcess();
     Job *       GetDistributableJobToRace();
+	static Node::BuildResult DoPreBuildDynamicDependencies( Job * job );
     static Node::BuildResult DoBuild( Job * job );
     void        FinishedProcessingJob( Job * job, bool result, bool wasARemoteJob );
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/DependencyProcessorMain.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/DependencyProcessorMain.cpp
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, const char** argv)
+{
+    if ( argc != 3 )
+    {
+        printf("Bad Args!\n");
+        return 1;
+    }
+
+	const char* prefix = argv[1];
+    const char* input = argv[2];
+
+	// Scan source files and find any lines that have "//:" in them. In our imaginary build pipeline these are requires header
+	// file dependencies that need to be built by FASTBuild. The DependencyProcessor outputs these to stdout and fastbuild will
+	// make sure these targets are up to date before finishing the current target.
+	{
+        FILE* f = fopen(input, "rb");
+        if (!f)
+        {
+            printf("Failed to open input file '%s'\n", input);
+            return 2;
+        }
+
+		// Read the file line by line and output any lines that start with "//: "
+		char buffer[4096];
+		while (fgets(buffer, 4096, f) != nullptr)
+		{
+			if (strlen(buffer) > 3)
+			{
+				if (buffer[0] == '/' &&
+					buffer[1] == '/' &&
+					buffer[2] == ':' )
+				{
+					printf("%s%s", prefix, &buffer[3]);
+				}
+			}
+		}
+        fclose(f);
+    }
+	return 0;
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/a.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/a.cpp
@@ -1,0 +1,11 @@
+#include "a.h"
+#include "b.h"
+
+// These special tags cause a.h and b.h to be listed as dependencies by the DependencyProcessor.exe.
+//:a.h
+//:b.h
+
+int main(int, const char**)
+{
+	return 0;
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/dynamicdeps.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/dynamicdeps.bff
@@ -1,0 +1,71 @@
+//
+// Object
+//
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+
+// Common settings
+.UnityOutputPath            = '$Out$/Test/Object/DynamicDeps/'
+.CompilerOutputPath         = '$Out$/Test/Object/DynamicDeps/'
+
+// DependencyProcessor
+// - Create an exe which can parse a file and output dependencies on stdout
+//------------------------------------------------------------------------------
+ObjectList( 'DependencyProcessorCompile' )
+{
+    #if __WINDOWS__
+        .CompilerOptions    + ' /MT'
+    #endif
+    .CompilerInputFiles     = '$Out$/Test/Object/DynamicDeps/DependencyProcessorMain.cpp'
+    .CompilerOuputExtension = '.cpp'
+    .CompilerOutputPath     + 'DependencyProcessor/'
+}
+Executable( 'DependencyProcessor' )
+{
+    .Libraries              = 'DependencyProcessorCompile'
+    .LinkerOutput           = '$Out$/Test/Object/DynamicDeps/DependencyProcessor.exe'
+    #if __WINDOWS__
+        .LinkerOptions      + ' /SUBSYSTEM:CONSOLE'
+                            + ' kernel32.lib'
+                            + .CRTLibs_Static
+    #endif
+}
+Compiler( 'DependencyProcessorCompiler' )
+{
+    .Executable = 'DependencyProcessor'
+    .CompilerFamily = 'custom'
+}
+
+//
+// Generate a list of targets as copy targets
+//------------------------------------------------------------------------------
+Copy()
+{
+	.Source = 
+	{ 
+		'$Out$/Test/Object/DynamicDeps/PossibleDependencies/a.h'
+		'$Out$/Test/Object/DynamicDeps/PossibleDependencies/b.h'
+		'$Out$/Test/Object/DynamicDeps/PossibleDependencies/c.h'
+	}
+	.Dest = '$Out$/Test/Object/DynamicDeps/Dependencies/'
+}
+
+// DependencyProducer will 
+ObjectList( 'DependencyProducer' )
+{
+	.PreBuildDependencyPreprocessor	= 'DependencyProcessorCompiler'
+	.PreBuildDependencyPreprocessorOptions = '"$Out$/Test/Object/DynamicDeps/Dependencies/" %1'
+	.CompilerInputFiles				= 'Tools/FBuild/FBuildTest/Data/TestObject/DynamicDeps/a.cpp'
+	.CompilerOutputPath				+ 'Output/'
+	.CompilerOptions                + ' /I"$Out$/Test/Object/DynamicDeps/Dependencies/"'
+
+	// Set one of our dependencies as a static pre build dependency.
+	.PreBuildDependencies = {'$Out$/Test/Object/DynamicDeps/Dependencies/a.h'}
+}
+
+Alias( 'DynamicDeps' )
+{
+    .Targets                    = { 'DependencyProducer' }
+}


### PR DESCRIPTION
Hi Franta, this pull request adds functionality to allow a user to specify a preprocessor that can scan the input file and list it's dependencies which will be built before being queued for build. This change allows for more complicated asset builds to be compiled using FASTBuild while respecting their dependency chain.

I know it's a rather large and structural pull request and as always I'm happy to make changes and refactor if there is another way you would like this implemented. I think I took the approach you suggested from your comments in issue #365.

