### PR TITLE
Crash fixes

### DIFF
--- a/Code/Core/Mem/SmallBlockAllocator.cpp
+++ b/Code/Core/Mem/SmallBlockAllocator.cpp
@@ -108,16 +108,16 @@ NO_INLINE void SmallBlockAllocator::InitBuckets()
 //------------------------------------------------------------------------------
 void * SmallBlockAllocator::Alloc( size_t size, size_t align )
 {
-    // Check we can support allocation of this size
-    if ( size > BUCKET_MAX_ALLOC_SIZE )
-    {
-        return nullptr; // Too big
-    }
-
     // Lazy initialization of buckets to support static allocations
     if ( s_BucketMemoryStart == nullptr )
     {
         InitBuckets();
+    }
+
+    // Check we can support allocation of this size
+    if ( size > BUCKET_MAX_ALLOC_SIZE )
+    {
+        return nullptr; // Too big
     }
 
     // Handle 0 byte allocations

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -790,7 +790,12 @@ bool BFFParser::ParseIncludeDirective( BFFIterator & iter )
     AStackString<> includeToUse;
     if (PathUtils::IsFullPath(include) == false)
     {
-        AStackString<> fileName( iter.GetFileName() );
+        AStackString<> fileName;
+        const char * iterName = iter.GetFileName();
+        if ( iterName )
+        {
+            fileName += iterName;
+        }
         const char * lastSlash = fileName.FindLast( NATIVE_SLASH );
         lastSlash = lastSlash ? lastSlash : fileName.FindLast( OTHER_SLASH );
         lastSlash = lastSlash ? ( lastSlash + 1 ): fileName.Get(); // file only, truncate to empty

--- a/Code/Tools/FBuild/FBuildCore/Error.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Error.cpp
@@ -641,7 +641,12 @@ void Error::FormatError( const BFFIterator & iter,
     iter.GetPosInfo( line, column, lineStart );
 
     // convert to full path and '/'->'\' cleanup
-    const AStackString<> fileName( iter.GetFileName() );
+    AStackString<> fileName;
+    const char * iterName = iter.GetFileName();
+    if ( iterName )
+    {
+        fileName += iterName;
+    }
     AStackString<> fullPath;
     NodeGraph::CleanPath( fileName, fullPath );
 

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -237,6 +237,11 @@ bool FBuild::GetTargets( const Array< AString > & targets, Dependencies & outDep
 {
     ASSERT( !targets.IsEmpty() );
 
+    if ( m_DependencyGraph == nullptr )
+    {
+        return false;
+    }
+
     // Get the nodes for all the targets
     const size_t numTargets = targets.GetSize();
     for ( size_t i=0; i<numTargets; ++i )
@@ -311,6 +316,11 @@ bool FBuild::SaveDependencyGraph( const char * nodeGraphDBFile ) const
 
     PROFILE_FUNCTION
 
+    if ( m_DependencyGraph == nullptr )
+    {
+        return false;
+    }
+
     FLOG_INFO( "Saving DepGraph '%s'", nodeGraphDBFile );
 
     Timer t;
@@ -368,7 +378,10 @@ bool FBuild::SaveDependencyGraph( const char * nodeGraphDBFile ) const
 //------------------------------------------------------------------------------
 void FBuild::SaveDependencyGraph( IOStream & stream, const char* nodeGraphDBFile ) const
 {
-    m_DependencyGraph->Save( stream, nodeGraphDBFile );
+    if ( m_DependencyGraph != nullptr )
+    {
+        m_DependencyGraph->Save( stream, nodeGraphDBFile );
+    }
 }
 
 // Build
@@ -388,6 +401,7 @@ bool FBuild::Build( Node * nodeToBuild )
     m_LastProgressCalcTime = 0.0f;
     m_SmoothedProgressCurrent = 0.0f;
     m_SmoothedProgressTarget = 0.0f;
+
     FLog::StartBuild();
 
     // create worker dir for main thread build case
@@ -402,12 +416,12 @@ bool FBuild::Build( Node * nodeToBuild )
     for ( ;; )
     {
         // process completed jobs
-        m_JobQueue->FinalizeCompletedJobs( *m_DependencyGraph );
+        m_JobQueue->FinalizeCompletedJobs( m_DependencyGraph );
 
         if ( !stopping )
         {
             // do a sweep of the graph to create more jobs
-            m_DependencyGraph->DoBuildPass( nodeToBuild );
+            NodeGraph::DoBuildPass( m_DependencyGraph, nodeToBuild );
         }
 
         if ( m_Options.m_NumWorkerThreads == 0 )
@@ -467,7 +481,7 @@ bool FBuild::Build( Node * nodeToBuild )
     }
 
     // wrap up/free any jobs that come from the last build pass
-    m_JobQueue->FinalizeCompletedJobs( *m_DependencyGraph );
+    m_JobQueue->FinalizeCompletedJobs( m_DependencyGraph );
 
     FDELETE m_JobQueue;
     m_JobQueue = nullptr;
@@ -625,6 +639,12 @@ void FBuild::UpdateBuildStatus( const Node * node )
         FBuildStats & bs = m_BuildStats;
         bs.m_NodeTimeProgressms = 0;
         bs.m_NodeTimeTotalms = 0;
+
+        if ( m_DependencyGraph == nullptr )
+        {
+            return;
+        }
+
         m_DependencyGraph->UpdateBuildStatus( node, bs.m_NodeTimeProgressms, bs.m_NodeTimeTotalms );
         m_LastProgressCalcTime = m_Timer.GetElapsed();
 
@@ -682,6 +702,11 @@ void FBuild::GetCacheFileName( uint64_t keyA, uint32_t keyB, uint64_t keyC, uint
 //------------------------------------------------------------------------------
 void FBuild::DisplayTargetList() const
 {
+    if ( m_DependencyGraph == nullptr )
+    {
+        return;
+    }
+
     OUTPUT( "FBuild: List of available targets\n" );
     const size_t totalNodes = m_DependencyGraph->GetNodeCount();
     for ( size_t i = 0; i < totalNodes; ++i )
@@ -732,6 +757,11 @@ bool FBuild::DisplayDependencyDB( const Array< AString > & targets ) const
     }
 
     OUTPUT( "FBuild: Dependency database\n" );
+
+    if ( m_DependencyGraph == nullptr )
+    {
+        return false;
+    }
 
     m_DependencyGraph->Display( deps );
     return true;

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -282,7 +282,7 @@ bool Node::DetermineNeedToBuild( bool forceClean ) const
 
 // Finalize
 //------------------------------------------------------------------------------
-/*virtual*/ bool Node::Finalize( NodeGraph & )
+/*virtual*/ bool Node::Finalize( NodeGraph * )
 {
     // most nodes have nothing to do
     return true;

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -207,7 +207,7 @@ protected:
     virtual bool DetermineNeedToBuild( bool forceClean ) const;
     virtual BuildResult DoBuild( Job * job );
     virtual BuildResult DoBuild2( Job * job, bool racingRemoteJob );
-    virtual bool Finalize( NodeGraph & nodeGraph );
+    virtual bool Finalize( NodeGraph * nodeGraph );
 
     inline void     SetLastBuildTime( uint32_t ms ) { m_LastBuildTimeMs = ms; }
     inline void     AddProcessingTime( uint32_t ms ){ m_ProcessingTime += ms; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -120,7 +120,7 @@ public:
     XCodeProjectNode * CreateXCodeProjectNode( const AString & name );
     SettingsNode * CreateSettingsNode( const AString & name );
 
-    void DoBuildPass( Node * nodeToBuild );
+    static void DoBuildPass( NodeGraph * ng, Node * nodeToBuild );
 
     static void CleanPath( AString & name, bool makeFullPath = true );
     static void CleanPath( const AString & name, AString & cleanPath, bool makeFullPath = true );
@@ -143,8 +143,8 @@ private:
 
     void AddNode( Node * node );
 
-    void BuildRecurse( Node * nodeToBuild, uint32_t cost );
-    bool CheckDependencies( Node * nodeToBuild, const Dependencies & dependencies, uint32_t cost );
+    static void BuildRecurse( NodeGraph * ng, Node * nodeToBuild, uint32_t cost );
+    static bool CheckDependencies( NodeGraph * ng, Node * nodeToBuild, const Dependencies & dependencies, uint32_t cost );
     static void UpdateBuildStatusRecurse( const Node * node,
                                           uint32_t & nodesBuiltTime,
                                           uint32_t & totalNodeTime );

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -92,7 +92,7 @@ private:
     virtual bool DoDynamicDependencies( NodeGraph & nodeGraph, bool forceClean ) override;
     virtual BuildResult DoBuild( Job * job ) override;
     virtual BuildResult DoBuild2( Job * job, bool racingRemoteJob ) override;
-    virtual bool Finalize( NodeGraph & nodeGraph ) override;
+    virtual bool Finalize( NodeGraph * nodeGraph ) override;
 
     BuildResult DoBuildMSCL_NoCache( Job * job, bool useDeoptimization );
     BuildResult DoBuildWithPreProcessor( Job * job, bool useDeoptimization, bool useCache, bool useSimpleDist );

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
@@ -98,26 +98,28 @@ Job * JobSubQueue::RemoveJob()
         return nullptr;
     }
 
-    ASSERT( m_Count );
-    --m_Count;
+    Job * retJob = m_Jobs.Top();
+    if ( retJob )
+    {
+        ASSERT( m_Count );
+        --m_Count;
 
-    Job * job = m_Jobs.Top();
-    m_Jobs.Pop();
-
-    return job;
+        m_Jobs.Pop();
+    }
+    return retJob;
 }
 
 // CONSTRUCTOR
 //------------------------------------------------------------------------------
 JobQueue::JobQueue( uint32_t numWorkerThreads ) :
-    m_NumLocalJobsActive( 0 ),
-    m_DistributableJobs_Available( 1024, true ),
-    m_DistributableJobs_InProgress( 1024, true ),
-    m_CompletedJobs( 1024, true ),
-    m_CompletedJobsFailed( 1024, true ),
-    m_CompletedJobs2( 1024, true ),
-    m_CompletedJobsFailed2( 1024, true ),
-    m_Workers( numWorkerThreads, false )
+m_NumLocalJobsActive( 0 ),
+m_DistributableJobs_Available( 1024, true ),
+m_DistributableJobs_InProgress( 1024, true ),
+m_CompletedJobs( 1024, true ),
+m_CompletedJobsFailed( 1024, true ),
+m_CompletedJobs2( 1024, true ),
+m_CompletedJobsFailed2( 1024, true ),
+m_Workers( numWorkerThreads, false )
 {
     PROFILE_FUNCTION
 
@@ -440,7 +442,7 @@ void JobQueue::ReturnUnfinishedDistributableJob( Job * job )
 
 // FinalizeCompletedJobs (Main Thread)
 //------------------------------------------------------------------------------
-void JobQueue::FinalizeCompletedJobs( NodeGraph & nodeGraph )
+void JobQueue::FinalizeCompletedJobs( NodeGraph * nodeGraph )
 {
     PROFILE_FUNCTION
 
@@ -546,7 +548,10 @@ void JobQueue::MainThreadWait( uint32_t maxWaitMS )
 void JobQueue::WorkerThreadWait( uint32_t maxWaitMS )
 {
     ASSERT( Thread::IsMainThread() == false );
-    ASSERT( FBuild::Get().GetOptions().m_NumWorkerThreads > 0 );
+    if (FBuild::IsValid())
+    {
+        ASSERT( FBuild::Get().GetOptions().m_NumWorkerThreads > 0 );
+    }
     m_WorkerThreadSemaphore.Wait( maxWaitMS );
 }
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
@@ -33,9 +33,10 @@ public:
 
     // jobs consumed by workers
     Job * RemoveJob();
+    
 private:
-    uint32_t    m_Count;    // access the current count
-    Mutex       m_Mutex;    // lock to add/remove jobs
+    uint32_t       m_Count;    // access the current count
+    Mutex          m_Mutex;    // lock to add/remove jobs
     Array< Job * > m_Jobs;  // Sorted, most expensive at end
 };
 
@@ -50,7 +51,7 @@ public:
     // main thread calls these
     void AddJobToBatch( Node * node );  // Add new job to the staging queue
     void FlushJobBatch();               // Sort and flush the staging queue
-    void FinalizeCompletedJobs( NodeGraph & nodeGraph );
+    void FinalizeCompletedJobs( NodeGraph * nodeGraph );
     void MainThreadWait( uint32_t maxWaitMS );
 
     // main thread can be signalled


### PR DESCRIPTION
1. Call InitBuckets() in SmallBlockAllocator::Alloc() even if size too big, to avoid later crash if only too big allocs exist in a run.
2. Added some nullptr checks to avoid nullptr dereference crashes.
3. Set some ptrs to nullptr during cleanup steps, to avoid later deference crashes.
4. Changed some methods to pass NodeGraph by pointer instead of by reference, since the DoBuild part of the logic in the methods still needs to run. So, I have it check for nullptr in lower methods.