### PR TITLE
Make the dir creation thread safe

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -534,7 +534,10 @@
             // create this level
             if ( DirectoryCreate( pathCopy ) == false )
             {
-                return false; // something went wrong
+                // something went wrong, but continue
+                // so we handle the case where
+                // multiple processes or threads are racing
+                // to create the same dir
             }
         }
         *slash = NATIVE_SLASH; // put back the slash


### PR DESCRIPTION
Handle the case where multiple processes or threads are racing
to create the same dir