### PR TITLE
Path fixes

### DIFF
--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -26,17 +26,14 @@
     return false;
 }
 
-// IsfullPath
+// IsFullPath
 //------------------------------------------------------------------------------
 /*static*/ bool PathUtils::IsFullPath( const AString & path )
 {
     #if defined( __WINDOWS__ )
-        // full paths on Windows are in X: format
-        if ( path.GetLength() >= 2 )
-        {
-            return ( path[ 1 ] == ':' );
-        }
-        return false;
+        // full paths on Windows have a drive letter and colon, or are unc
+        return ( ( path.GetLength() >= 2 && path[ 1 ] == ':' ) || 
+                       path.BeginsWith( NATIVE_DOUBLE_SLASH ) );
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // full paths on Linux/OSX/IOS begin with a slash
         return path.BeginsWith( NATIVE_SLASH );

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1312,10 +1312,31 @@ void ObjectNode::GetExtraCacheFilePaths( const Job * job, Array< AString > & out
         {
             // .pchast (precompiled headers only)
             AStackString<> pchASTFileName( m_PCHObjectFileName );
-            const char * extPos = pchASTFileName.Find( '.' ); // All extensions removed
-            if ( extPos )
+            size_t newLength = 0;
+            const char * firstExtPos = nullptr;
+            const char * basePathPos = pchASTFileName.FindLast( NATIVE_SLASH );
+            if ( basePathPos )
             {
-                pchASTFileName.SetLength( (uint32_t)( extPos - pchASTFileName.Get() ) );
+                AStackString<> astFilename( basePathPos + 1 );
+                firstExtPos = astFilename.Find( '.' ); // find first, so we remove all extensions
+                if ( firstExtPos )
+                {
+                    // base path + slash + base name of filename
+                    newLength = ( basePathPos - pchASTFileName.Get() ) + 1 + ( firstExtPos - astFilename.Get() );
+                }
+            }
+            else
+            {
+                firstExtPos = pchASTFileName.Find( '.' ); // find first, so we remove all extensions
+                if ( firstExtPos )
+                {
+                    // first ext pos - start of file path
+                    newLength = firstExtPos - pchASTFileName.Get();
+                }
+            }
+            if ( firstExtPos )
+            {
+                pchASTFileName.SetLength( (uint32_t) newLength );
             }
             pchASTFileName += ".pchast";
             outFileNames.Append( pchASTFileName );


### PR DESCRIPTION
1. In IsFullPath(), handle the unc path case
2. In ObjectNode's precompiled headers logic, handle the case where a folder name contains a period. So need to FindLast slash and then find first period. Also, included code to handle the else cases of these find operations.