### PR TITLE
Fix null deference in MetaNone

### DIFF
--- a/Code/Core/Reflection/MetaData/MetaData.cpp
+++ b/Code/Core/Reflection/MetaData/MetaData.cpp
@@ -37,19 +37,6 @@ IMetaData & operator + ( IMetaData & a, IMetaData & b )
     return a;
 }
 
-// No MetaData
-//------------------------------------------------------------------------------
-IMetaData & MetaNone()
-{
-    // We have to return by reference to be able to implement the chainign + operator
-    // but everything is managed as a ptr internally so this is ok
-    IMetaData * md = nullptr;
-    PRAGMA_DISABLE_PUSH_MSVC( 6011 ); // null deref is deliberate
-    IMetaData& mdRef = *md;
-    PRAGMA_DISABLE_POP_MSVC
-    return mdRef;
-}
-
 // Basic MetaData Types
 //------------------------------------------------------------------------------
 

--- a/Code/Core/Reflection/MetaData/MetaData.h
+++ b/Code/Core/Reflection/MetaData/MetaData.h
@@ -16,7 +16,7 @@ IMetaData & operator + ( IMetaData & a, IMetaData & b );
 
 // No MetaData
 //------------------------------------------------------------------------------
-IMetaData & MetaNone();
+class MetaNone {};
 
 // Basic MetaData Types
 //------------------------------------------------------------------------------

--- a/Code/Core/Reflection/ReflectionInfo.cpp
+++ b/Code/Core/Reflection/ReflectionInfo.cpp
@@ -210,10 +210,24 @@ void ReflectionInfo::AddPropertyInternal( PropertyType type, uint32_t offset, co
 
 // AddMetaData
 //------------------------------------------------------------------------------
+void ReflectionInfo::AddMetaData( MetaNone )
+{
+    ASSERT( m_MetaDataChain == nullptr );
+}
+
+// AddMetaData
+//------------------------------------------------------------------------------
 void ReflectionInfo::AddMetaData( IMetaData & metaDataChain )
 {
     ASSERT( m_MetaDataChain == nullptr );
     m_MetaDataChain = &metaDataChain;
+}
+
+// AddPropertyMetaData
+//------------------------------------------------------------------------------
+void ReflectionInfo::AddPropertyMetaData( MetaNone )
+{
+    m_Properties.Top()->AddMetaData( nullptr );
 }
 
 // AddPropertyMetaData

--- a/Code/Core/Reflection/ReflectionInfo.h
+++ b/Code/Core/Reflection/ReflectionInfo.h
@@ -17,6 +17,7 @@
 class AString;
 class IMetaData;
 class Mat44;
+class MetaNone;
 class Object;
 class ReflectionInfo;
 class ReflectedProperty;
@@ -133,7 +134,9 @@ protected:
 
     void AddPropertyInternal( PropertyType type, uint32_t offset, const char * memberName, bool isArray );
 
+    void AddMetaData( MetaNone );
     void AddMetaData( IMetaData & metaDataChain );
+    void AddPropertyMetaData( MetaNone );
     void AddPropertyMetaData( IMetaData & metaDataChain );
 
     const ReflectedProperty * FindProperty( const char * name ) const;


### PR DESCRIPTION
This is small refactor to get rid of null pointer derefence in `MetaNone` function. Albeit that dereference is harmless (at least for now) it's still ugly.

`MetaNone` function is replaced with `MetaNone` type, this allows us to keepthe current syntax and specialize functions that take `IMetaData&` for this new type. New overloads produce the same results as the old ones did for a reference-to-null argument.
Despite the comment in the old `MetaNone()` implementation `MetaNone()` wasn't used with `operator+`, so it doesn't need overloads for `MetaNone` type.