### PR TITLE
Use offsetof() macro instead of getting offset by dereferencing null pointer

### DIFF
--- a/Code/Core/Reflection/PropertyType.h
+++ b/Code/Core/Reflection/PropertyType.h
@@ -16,6 +16,7 @@ class Mat44;
 class RefObject;
 template< class T > class Ref;
 template< class T > class WeakRef;
+template< class T > class Array;
 
 // PropertyType
 //------------------------------------------------------------------------------
@@ -61,6 +62,11 @@ template < class T >
 inline PropertyType GetPropertyType( const Ref< T > * ) { return PT_REF; }
 template < class T >
 inline PropertyType GetPropertyType( const WeakRef< T > * ) { return PT_WEAKREF; }
+template < class T >
+inline PropertyType GetPropertyArrayType( const Array< T > * )
+{
+    return GetPropertyType( static_cast< T * >( nullptr ) );
+}
 
 PropertyType GetPropertyTypeFromString( const AString & propertyType );
 

--- a/Code/Core/Reflection/ReflectionInfo.cpp
+++ b/Code/Core/Reflection/ReflectionInfo.cpp
@@ -184,27 +184,35 @@ const IMetaData * ReflectionInfo::HasMetaDataInternal( const ReflectionInfo * ri
     return m_SuperClass ? m_SuperClass->HasMetaDataInternal( ri ) : nullptr;
 }
 
+// AddProperty
+//------------------------------------------------------------------------------
+void ReflectionInfo::AddProperty( uint32_t offset, const char * memberName, PropertyType type )
+{
+    ReflectedProperty * r = new ReflectedProperty( memberName, offset, type, false );
+    m_Properties.Append( r );
+}
+
 // AddPropertyStruct
 //------------------------------------------------------------------------------
-void ReflectionInfo::AddPropertyStruct( void * offset, const char * memberName, const ReflectionInfo * structInfo )
+void ReflectionInfo::AddPropertyStruct( uint32_t offset, const char * memberName, const ReflectionInfo * structInfo )
 {
-    ReflectedPropertyStruct * r = new ReflectedPropertyStruct( memberName, (uint32_t)( (size_t)offset ), structInfo );
+    ReflectedPropertyStruct * r = new ReflectedPropertyStruct( memberName, offset, structInfo );
+    m_Properties.Append( r );
+}
+
+// AddPropertyArray
+//------------------------------------------------------------------------------
+void ReflectionInfo::AddPropertyArray( uint32_t offset, const char * memberName, PropertyType type )
+{
+    ReflectedProperty * r = new ReflectedProperty( memberName, offset, type, true );
     m_Properties.Append( r );
 }
 
 // AddPropertyArrayOfStruct
 //------------------------------------------------------------------------------
-void ReflectionInfo::AddPropertyArrayOfStruct( void * memberOffset, const char * memberName, const ReflectionInfo * structInfo )
+void ReflectionInfo::AddPropertyArrayOfStruct( uint32_t offset, const char * memberName, const ReflectionInfo * structInfo )
 {
-    ReflectedPropertyStruct * r = new ReflectedPropertyStruct( memberName, (uint32_t)( (size_t)memberOffset ), structInfo, true );
-    m_Properties.Append( r );
-}
-
-// AddPropertyInternal
-//------------------------------------------------------------------------------
-void ReflectionInfo::AddPropertyInternal( PropertyType type, uint32_t offset, const char * memberName, bool isArray )
-{
-    ReflectedProperty * r = new ReflectedProperty( memberName, offset, type, isArray );
+    ReflectedPropertyStruct * r = new ReflectedPropertyStruct( memberName, offset, structInfo, true );
     m_Properties.Append( r );
 }
 

--- a/Code/Core/Reflection/ReflectionInfo.h
+++ b/Code/Core/Reflection/ReflectionInfo.h
@@ -109,29 +109,16 @@ protected:
     void SetTypeName( const char * typeName );
 
     // basic types
-    template< class T >
-    NO_INLINE void AddProperty( T * memberOffset,   const char * memberName )
-    {
-        PropertyType type = GetPropertyType( memberOffset );
-        AddPropertyInternal( type, (uint32_t)( (size_t)memberOffset ), memberName, false );
-    }
+    void AddProperty( uint32_t offset, const char * memberName, PropertyType type );
 
     // struct
-    void AddPropertyStruct( void * memberOffset, const char * memberName, const ReflectionInfo * structInfo );
+    void AddPropertyStruct( uint32_t offset, const char * memberName, const ReflectionInfo * structInfo );
 
     // array
-    template< class T >
-    NO_INLINE void AddPropertyArray( Array< T > * memberOffset, const char * memberName )
-    {
-        T * fakeElement( nullptr );
-        PropertyType type = GetPropertyType( fakeElement );
-        AddPropertyInternal( type, (uint32_t)( (size_t)memberOffset ), memberName, true );
-    }
+    void AddPropertyArray( uint32_t offset, const char * memberName, PropertyType type );
 
     // array of struct
-    void AddPropertyArrayOfStruct( void * memberOffset, const char * memberName, const ReflectionInfo * structInfo );
-
-    void AddPropertyInternal( PropertyType type, uint32_t offset, const char * memberName, bool isArray );
+    void AddPropertyArrayOfStruct( uint32_t offset, const char * memberName, const ReflectionInfo * structInfo );
 
     void AddMetaData( IMetaData & metaDataChain );
     void AddPropertyMetaData( IMetaData & metaDataChain );

--- a/Code/Core/Reflection/ReflectionMacros.h
+++ b/Code/Core/Reflection/ReflectionMacros.h
@@ -4,8 +4,11 @@
 
 // Includes
 //------------------------------------------------------------------------------
+#include "Core/Reflection/PropertyType.h"
 #include "Core/Reflection/ReflectionInfo.h"
 #include "Core/Reflection/MetaData/MetaData.h"
+
+#include <stddef.h>
 
 // Forward Declarations
 //------------------------------------------------------------------------------
@@ -132,19 +135,19 @@ class ReflectionInfo;
 // MEMBERS
 //------------------------------------------------------------------------------
 #define REFLECT( member, memberName, metaData ) \
-            AddProperty( &((objectType *)0)->member, memberName ); \
+            AddProperty( offsetof( objectType, member ), memberName, GetPropertyType( static_cast< decltype( objectType::member ) * >( nullptr ) ) ); \
             ADD_PROPERTY_METADATA( metaData )
 
 #define REFLECT_ARRAY( member, memberName, metaData ) \
-            AddPropertyArray( &((objectType *)0)->member, memberName ); \
+            AddPropertyArray( offsetof( objectType, member ), memberName, GetPropertyArrayType( static_cast< decltype( objectType::member ) * >( nullptr ) ) ); \
             ADD_PROPERTY_METADATA( metaData )
 
 #define REFLECT_STRUCT( member, memberName, structType, metaData ) \
-            AddPropertyStruct( &((objectType *)0)->member, memberName, structType::GetReflectionInfoS() ); \
+            AddPropertyStruct( offsetof( objectType, member ), memberName, structType::GetReflectionInfoS() ); \
             ADD_PROPERTY_METADATA( metaData )
 
 #define REFLECT_ARRAY_OF_STRUCT( member, memberName, structType, metaData ) \
-            AddPropertyArrayOfStruct( &((objectType *)0)->member, memberName, structType::GetReflectionInfoS() ); \
+            AddPropertyArrayOfStruct( offsetof( objectType, member ), memberName, structType::GetReflectionInfoS() ); \
             ADD_PROPERTY_METADATA( metaData )
 
 // END


### PR DESCRIPTION
New code still has a UB - `offsetof()` can be use only with standard layout types and `ReflectionInfo` is not a standard layout type. But there are some technical benefits to this change:
1. This fixes `-Winvalid-offsetof` warnings in old GCC versions.
2. This fixes UBSan warnings about dereferencing a null pointer, which helps to spot other problems in the output.
3. Since C++17 using `offsetof()` with non-standard layout types is "conditionally-supported", so there is a chance that on some compilers this will become legal eventually.