### PR TITLE
Fix build in GCC 7

### DIFF
--- a/Code/Core/Mem/MemDebug.cpp
+++ b/Code/Core/Mem/MemDebug.cpp
@@ -42,9 +42,9 @@ void MemDebug::FillMem( void * ptr, const size_t size, const uint32_t pattern )
         char * cit = static_cast< char * >( static_cast< void * >( it ) );
         switch( remainder )
         {
-            case 3: *cit = *b; ++cit; ++b;
-            case 2: *cit = *b; ++cit; ++b;
-            case 1: *cit = *b;
+            case 3: *cit++ = *b++; *cit++ = *b++; *cit++ = *b++; break;
+            case 2: *cit++ = *b++; *cit++ = *b++; break;
+            case 1: *cit++ = *b++; break;
         }
     }
 }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionIf.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionIf.cpp
@@ -335,6 +335,7 @@ bool FunctionIf::HandleSimpleCompare( NodeGraph & nodeGraph,
             case Operator::OP_GREATER_THAN_OR_EQUAL:
             {
                 Error::Error_1034_OperationNotSupported( rhsVarIter, lhsVar->GetType(), rhsVar->GetType(), operatorIter );
+                return false;
             }
 
             // Logic error


### PR DESCRIPTION
This fixes places that trigger new `-Wimplicit-fallthrough` warning from GCC 7.

I am opening a new PR for this because similar fixes from #430 doesn't fix all problematic places that are currently in the code.