### PR TITLE
Fix memory leak on node creation error

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -289,6 +289,7 @@ Function::~Function() = default;
     AStackString<> nameFromMetaData;
     if ( GetNameForNode( nodeGraph, funcStartIter, node->GetReflectionInfoV(), nameFromMetaData ) == false )
     {
+        FDELETE node;
         return false; // GetNameForNode will have emitted an error
     }
     const bool aliasUsedForName = nameFromMetaData.IsEmpty();
@@ -299,6 +300,7 @@ Function::~Function() = default;
     if ( nodeGraph.FindNode( name ) )
     {
         Error::Error_1100_AlreadyDefined( funcStartIter, this, name );
+        FDELETE node;
         return false;
     }
 


### PR DESCRIPTION
This was found with BFFFuzzer and AddresSanitizer.

This leak isn't serious, but it is still sad to see that FASTBuild uses explicit memory management, especially since there is already a smart pointer - `AutoPtr`. With that in mind, would you be interested in patches that will try to fix this by:
1. Enhancing `AutoPtr` to be more "object friendly" (adding `operator->`, etc.).
2. Replacing usage of explicit `FDELETE` with usage of `AutoPtr` to store pointers.
3. Improving ownership transfer semantics by using `AutoPtr` and move semantics. For example `NodeGraph::RegisterNode` would accept `AutoPtr<Node, DeleteDeletor>` as an argument instead of `Node *`.

Or such changes are undesired?