### PR TITLE
Disable offsetof warning for Windows Clang builds

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
@@ -47,6 +47,7 @@
     .CompilerOptions    = '-c -g %1 -o "%2" -integrated-as'
                         + ' -Wall -Werror -Wfatal-errors'   // warnings as errors
                         + ' -Wextra'                        // additional warnings
+                        + ' -Wno-invalid-offsetof'          // allow offset of members in non-POD types
 ]
 
 //==============================================================================

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -256,6 +256,9 @@ Compiler( 'Compiler-x64Clang-LinuxOSX' )
                                 + ' -Wno-implicit-exception-spec-mismatch'
                             #endif
 
+                            // Disabled warnings
+                            + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+
                             // Extra warnings
                             + ' -Wshadow'
 


### PR DESCRIPTION
I copied the entries from the Linux .bff sections, so that the Windows builds would pass.