### PR TITLE
Use GetProcessTimes() in kill process tree, fixes #71

### DIFF
--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -7,6 +7,11 @@
 #include "Core/Env/Types.h"
 #include "Core/Containers/AutoPtr.h"
 
+#if defined( __WINDOWS__ )
+    #include "Core/Containers/Array.h"
+    #include <windows.h>
+#endif
+
 // Process
 //------------------------------------------------------------------------------
 class Process
@@ -49,7 +54,9 @@ public:
     static uint32_t GetCurrentId();
 private:
     #if defined( __WINDOWS__ )
-        void KillProcessTreeInternal( uint32_t processID );
+        bool ConsiderPid( const uint32_t processID );
+        uint64_t GetProcessStartTime( const HANDLE hProc );
+        void KillProcessTreeInternal( uint32_t processID, Array< uint32_t > & pidsSeen );
         void Read( void * handle, AutoPtr< char > & buffer, uint32_t & sizeSoFar, uint32_t & bufferSize );
         char * Read( void * handle, uint32_t * bytesRead );
         uint32_t Read( void * handle, char * outputBuffer, uint32_t outputBufferSize );


### PR DESCRIPTION
Check process start time of children against their parent's start time, before descending in kill process algorithm. This fixes the issue where we could kill ourselves or other old processes that had the same parent pid as a process in our tree, due to Windows pid reuse.
Fixes #71 