### PR TITLE
Some improvements to kill process logic

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -18,7 +18,6 @@
 #include "Core/Tracing/Tracing.h"
 
 #if defined( __WINDOWS__ )
-    #include <windows.h>
     #include <TlHelp32.h>
 #endif
 
@@ -75,14 +74,14 @@ Process::~Process()
 // KillProcessTreeInternal
 //------------------------------------------------------------------------------
 #if defined( __WINDOWS__ )
-    void Process::KillProcessTreeInternal( uint32_t processID, uint64_t processCreationTime )
+    void Process::KillProcessTreeInternal( const HANDLE hProc, const uint32_t processID, const uint64_t processCreationTime )
     {
         PROCESSENTRY32 pe;
 
         memset( &pe, 0, sizeof( PROCESSENTRY32) );
         pe.dwSize = sizeof( PROCESSENTRY32 );
 
-        HANDLE hSnap = ::CreateToolhelp32Snapshot( TH32CS_SNAPPROCESS, processID );
+        const HANDLE hSnap = ::CreateToolhelp32Snapshot( TH32CS_SNAPPROCESS, 0 );
 
         if ( ::Process32First( hSnap, &pe ) )
         {
@@ -97,48 +96,47 @@ Process::~Process()
 
                 // Handle pid re-use by ensuring process started after parent
                 const uint32_t childProcessId = pe.th32ProcessID;
-                uint64_t childProcessCreationTime = GetProcessCreationTime( childProcessId );
-                if ( childProcessCreationTime < processCreationTime )
+                const HANDLE hChildProc = ::OpenProcess( PROCESS_ALL_ACCESS, FALSE, childProcessId );
+                if ( hChildProc )
                 {
-                    continue; // Cannot be a child because it was created before the parent
+                    const uint64_t childProcessCreationTime = GetProcessCreationTime( hChildProc );
+                    if ( childProcessCreationTime < processCreationTime )
+                    {
+                        continue; // Cannot be a child because it was created before the parent
+                    }
+
+                    // We should never see the main process because that's handled above
+                    ASSERT( childProcessId != GetCurrentProcessId() );
+
+                    // Recursion
+                    KillProcessTreeInternal( hChildProc, childProcessId, childProcessCreationTime );
+
+                    ::CloseHandle( hChildProc );
                 }
-
-                // We should never see the main process because that's handled above
-                ASSERT( childProcessId != GetCurrentProcessId() );
-
-                // Recursion
-                KillProcessTreeInternal( childProcessId, childProcessCreationTime );
             }
             while ( ::Process32Next( hSnap, &pe ) );
         }
 
-        CloseHandle( hSnap );
+        ::CloseHandle( hSnap );
 
         // kill this process on the way back up the recursion
-        HANDLE hProc = ::OpenProcess( PROCESS_ALL_ACCESS, FALSE, processID );
-        if ( hProc )
-        {
-            ::TerminateProcess( hProc, 1 );
-            ::CloseHandle( hProc );
-        }
+        ::TerminateProcess( hProc, 1 );
     }
 #endif
 
 // GetProcessStartTime
 //------------------------------------------------------------------------------
 #if defined( __WINDOWS__ )
-    /*static*/ uint64_t Process::GetProcessCreationTime( uint32_t processId )
+    /*static*/ uint64_t Process::GetProcessCreationTime( const HANDLE hProc )
     {
-        HANDLE processHandle = ::OpenProcess( PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId );
-        if ( processHandle == nullptr )
+        if ( hProc == 0 )
         {
-            return 0; // Likely due to lack of permissions
+            return 0;
         }
 
-        // Get process start time                                                                           : 
+        // Get process start time
         FILETIME creationFileTime, unused;
-        VERIFY( GetProcessTimes( processHandle, &creationFileTime, &unused, &unused, &unused ) );
-        ::CloseHandle( processHandle );
+        VERIFY( GetProcessTimes( hProc, &creationFileTime, &unused, &unused, &unused ) );
 
         // Return start time in a more convenient format
         const uint64_t childProcessCreationTime = ( (uint64_t)creationFileTime.dwHighDateTime << 32 ) | creationFileTime.dwLowDateTime;
@@ -151,7 +149,13 @@ Process::~Process()
 void Process::KillProcessTree()
 {
     #if defined( __WINDOWS__ )
-        KillProcessTreeInternal( GetProcessInfo().dwProcessId, GetProcessCreationTime( GetCurrentProcessId() ) );
+        const uint32_t childProcessId = GetProcessInfo().dwProcessId;
+        const HANDLE hChildProc = ::OpenProcess( PROCESS_ALL_ACCESS, FALSE, childProcessId );
+        if ( hChildProc )
+        {
+            KillProcessTreeInternal( hChildProc, childProcessId, GetProcessCreationTime( hChildProc ) );
+            ::CloseHandle( hChildProc );
+        }
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         // TODO: Kill process tree if necessary?
         kill( m_ChildPID, SIGTERM );

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -7,10 +7,6 @@
 #include "Core/Env/Types.h"
 #include "Core/Containers/AutoPtr.h"
 
-#if defined( __WINDOWS__ )
-    #include <windows.h>
-#endif
-
 // Process
 //------------------------------------------------------------------------------
 class Process
@@ -53,8 +49,11 @@ public:
     static uint32_t GetCurrentId();
 private:
     #if defined( __WINDOWS__ )
-        void KillProcessTreeInternal( const HANDLE hProc, const uint32_t processID, const uint64_t processCreationTime );
-        static uint64_t GetProcessCreationTime( const HANDLE hProc );
+        void KillProcessTreeInternal(
+            const void * hProc,  // HANDLE
+            const uint32_t processID,
+            const uint64_t processCreationTime );
+        static uint64_t GetProcessCreationTime( const void * hProc );  // HANDLE
         void Read( void * handle, AutoPtr< char > & buffer, uint32_t & sizeSoFar, uint32_t & bufferSize );
         char * Read( void * handle, uint32_t * bytesRead );
         uint32_t Read( void * handle, char * outputBuffer, uint32_t outputBufferSize );

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -7,6 +7,10 @@
 #include "Core/Env/Types.h"
 #include "Core/Containers/AutoPtr.h"
 
+#if defined( __WINDOWS__ )
+    #include <windows.h>
+#endif
+
 // Process
 //------------------------------------------------------------------------------
 class Process
@@ -49,8 +53,8 @@ public:
     static uint32_t GetCurrentId();
 private:
     #if defined( __WINDOWS__ )
-        void KillProcessTreeInternal( uint32_t processID, uint64_t processCreationTime );
-        static uint64_t GetProcessCreationTime( uint32_t processId );
+        void KillProcessTreeInternal( const HANDLE hProc, const uint32_t processID, const uint64_t processCreationTime );
+        static uint64_t GetProcessCreationTime( const HANDLE hProc );
         void Read( void * handle, AutoPtr< char > & buffer, uint32_t & sizeSoFar, uint32_t & bufferSize );
         char * Read( void * handle, uint32_t * bytesRead );
         uint32_t Read( void * handle, char * outputBuffer, uint32_t outputBufferSize );


### PR DESCRIPTION
1. Keep process handles open while doing work, so pids don't change between work steps.
2. Pass 0 for CreateToolhelp32Snapshot( TH32CS_SNAPPROCESS, 0 ), since enumerating all processes not a specific one.
3. For the initial call to KillProcessTreeInternal(), use the child process's creation time, instead of FBuild.exe's creation time so it matches the other calls to KillProcessTreeInternal()
4. Remove a stray set of spaces and colon in the // Get process start time  comment
5. Added colon in front of CloseHandle( hSnap ) call, so matches the other calls to CloseHandle()