### PR TITLE
Close handle assert fix

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -540,9 +540,9 @@ void Process::Detach()
 
     #if defined( __WINDOWS__ )
         // cleanup
-        VERIFY( ::CloseHandle( m_StdOutRead ) );
-        VERIFY( ::CloseHandle( m_StdErrRead ) );
-        VERIFY( ::CloseHandle( m_StdInWrite ) );
+        if ( m_StdOutRead != INVALID_HANDLE_VALUE ) { ::CloseHandle( m_StdOutRead ); }
+        if ( m_StdErrRead != INVALID_HANDLE_VALUE ) { ::CloseHandle( m_StdErrRead ); }
+        if ( m_StdInWrite != INVALID_HANDLE_VALUE ) { ::CloseHandle( m_StdInWrite ); }
         VERIFY( ::CloseHandle( GetProcessInfo().hProcess ) );
         VERIFY( ::CloseHandle( GetProcessInfo().hThread ) );
     #elif defined( __APPLE__ )


### PR DESCRIPTION
When running debug FBuildWorker.exe, I noticed some asserts when spawning the FBuildWorker subprocess. To avoid the asserts, added if statements around CloseHandle() calls.