### PR TITLE
Fix inconsistent parsing of function headers

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -19,7 +19,7 @@
 Describes a compiler and specifies how to interact with the compiler process for dependency tracking,
 distribution, caching and more.
       </p>
-<div class='code'>Compiler( 'name' )              // (optional) Alias
+<div class='code'>Compiler( 'name' )              // Alias
 {
   .Executable                   // Primary compiler executable
   .ExtraFiles                   // (optional) Additional files (usually dlls) required by the compiler.

--- a/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/objectlist.html
@@ -18,7 +18,7 @@
       <p>
 Builds a list of objects, typically for later input into a Library, Executable or DLL.
       </p>
-<div class='code'>ObjectList( alias )         ; (optional) Alias
+<div class='code'>ObjectList( alias )         ; Alias
 {
   ; options for compilation
   .Compiler                 ; Compiler to use

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -620,7 +620,6 @@ bool BFFParser::ParseFunction( BFFIterator & iter )
         functionArgsStopToken = iter;
         hasHeader = true;
         iter++; // skip over closing token
-        iter.SkipWhiteSpaceAndComments();
     }
 
     if ( func->NeedsHeader() && ( hasHeader == false ) )
@@ -628,6 +627,8 @@ bool BFFParser::ParseFunction( BFFIterator & iter )
         Error::Error_1023_FunctionRequiresAHeader( iter, func );
         return false;
     }
+
+    iter.SkipWhiteSpaceAndComments();
 
     // some functions have no body
     bool hasBody = false;

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -196,9 +196,10 @@ Function::~Function() = default;
 {
     m_AliasForFunction.Clear();
     if ( AcceptsHeader() &&
-         functionHeaderStartToken && functionHeaderStopToken &&
-         ( functionHeaderStartToken->GetDistTo( *functionHeaderStopToken ) > 1 ) )
+         functionHeaderStartToken && functionHeaderStopToken )
     {
+        ASSERT( *functionHeaderStartToken < *functionHeaderStopToken );
+
         // find opening quote
         BFFIterator start( *functionHeaderStartToken );
         ASSERT( *start == BFFParser::BFF_FUNCTION_ARGS_OPEN );

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/comments.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/comments.bff
@@ -45,13 +45,13 @@
 .Librarian = "l"
 .LibrarianOptions = "%1 %2"
 
-Library; comment after function name
+Library(); comment after function name
 { ; comment after bracket
     ; comment in library
     .LibrarianOutput = "o"
 }; comment after bracket
 
-Library// comment after function name
+Library()// comment after function name
 { // comment after bracket
     // comment in library
     .LibrarianOutput = "ob"

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/comments.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/comments.bff
@@ -45,13 +45,13 @@
 .Librarian = "l"
 .LibrarianOptions = "%1 %2"
 
-Library(); comment after function name
+Library; comment after function name
 { ; comment after bracket
     ; comment in library
     .LibrarianOutput = "o"
 }; comment after bracket
 
-Library()// comment after function name
+Library// comment after function name
 { // comment after bracket
     // comment in library
     .LibrarianOutput = "ob"


### PR DESCRIPTION
Empty function headers (without any characters between parenthesis) were incorrectly accepted for all functions, even for functions that require headers.
For example, this code would correctly produce error #1001:
```
    ObjectList( )
    {
        .Compiler = '/usr/bin/gcc'
        .CompilerOptions = '-c %1 -o %2'
        .CompilerOutputPath = '.'
    }
```
And if the whitespace inside the function header would be removed then there would be no error. Also in Debug build this would lead to a failed assertion in `Function::Commit` because function name would be empty.

This change fixes the problem, but as a side effect specifying empty parenthesis for functions that don't require headers (like `Library`) now results in error #1001. This shouldn't be a problem because these empty parenthesis could be just removed.

Also documentation for `Compiler` and `ObjectList` functions is updated to match code behaviour.