### PR TITLE
Call NodeGraph::FindNodeExact instead of FindNode when using clean path

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -1178,7 +1178,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     NodeGraph::CleanPath( potentialNodeName, potentialNodeNameClean );
 
     // see if a node already exists
-    Node * node = nodeGraph.FindNode( potentialNodeNameClean );
+    Node * node = nodeGraph.FindNodeExact( potentialNodeNameClean );
     if ( node )
     {
         // aliases not supported - must point to something that provides a file


### PR DESCRIPTION
This is a minor optimization for BFF parsing. `CleanPath` function is somewhat complex and not calling it unnecessarily improves performance slightly (by about 5% in my case).