### PR TITLE
Fix logging output from successful remote jobs

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -602,6 +602,12 @@ void Client::Process( const ConnectionInfo * connection, const Protocol::MsgJobR
                 ((FileNode *)job->GetNode())->GetStatFlag( Node::STATS_FAILED );
             }
         }
+
+        // get list of messages during remote work 
+        AStackString<> msgBuffer;
+        job->GetMessagesForLog(msgBuffer);
+        
+        Node::DumpOutput( nullptr, msgBuffer.Get(), msgBuffer.GetLength(), nullptr );
     }
     else
     {

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
@@ -192,9 +192,9 @@ void Job::Deserialize( IOStream & stream )
     OwnData( data, dataSize, compressed );
 }
 
-// GetMessagesForMonitorLog
+// GetMessagesForLog
 //------------------------------------------------------------------------------
-void Job::GetMessagesForMonitorLog( AString & buffer ) const
+void Job::GetMessagesForLog( AString & buffer ) const
 {
     // The common case is that there are no messages
     if ( m_Messages.IsEmpty() )
@@ -216,6 +216,20 @@ void Job::GetMessagesForMonitorLog( AString & buffer ) const
     {
         buffer += msg;
     }
+}
+
+// GetMessagesForMonitorLog
+//------------------------------------------------------------------------------
+void Job::GetMessagesForMonitorLog( AString & buffer ) const
+{
+    // The common case is that there are no messages
+    if ( m_Messages.IsEmpty() )
+    {
+        return;
+    }
+
+    // concat all messages 
+    GetMessagesForLog(buffer);
 
     // Escape some characters to simplify parsing in the log
     // (The monitor will knows how to restore them)

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
@@ -65,6 +65,7 @@ public:
     void Serialize( IOStream & stream );
     void Deserialize( IOStream & stream );
 
+    void                GetMessagesForLog( AString & buffer ) const;
     void                GetMessagesForMonitorLog( AString & buffer ) const;
 
     enum DistributionState


### PR DESCRIPTION
This patch makes log of compilation which contains warnings more determenistic, not relying on what jobs were completed locally and remotely.
Previously if translation unit has compilation warnings and was compiled remotely - you won't see them on master, but you will if compilation job completed locally.
Sometimes users can't fix or disable all warnings, but need to see them (for example on CI), so I made a patch to fix this.