### PR TITLE
Fix intermittent fast cancel test

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestFastCancel.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestFastCancel.cpp
@@ -98,10 +98,13 @@ void TestFastCancel::Cancel() const
     Thread::WaitForThread( h );
     Thread::CloseHandle( h );
 
+    // wait for the OS to release the mutexes
+    Thread::Sleep( 10 );
+
     // Ensure that processes were killed
     for ( SystemMutex & mutex : mutexes )
     {
-        // We should immediately be able to acquire each lock
+        // We should be able to acquire each lock
         TEST_ASSERT( mutex.TryLock() );
     }
 }


### PR DESCRIPTION
This test fails intermittently. To avoid this, I added a sleep to give some time to the OS to release the mutexes.