### PR TITLE
Use wordexp to tokenize argument string on Linux/OSX. 

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -31,6 +31,7 @@
     #include <string.h>
     #include <sys/wait.h>
     #include <unistd.h>
+    #include <wordexp.h>
 #endif
 
 // Static Data
@@ -299,21 +300,25 @@ bool Process::Spawn( const char * executable,
         if ( args )
         {
             // Tokenize
-            AStackString<> argCopy( args );
-            argCopy.Tokenize( splitArgs );
+            wordexp_t expResult;
+            memset(&expResult, 0, sizeof(wordexp_t));
 
-            // Build Vector
-            for ( auto & arg : splitArgs )
+            int wordRes = wordexp( args, &expResult, 0 );
+            if (wordRes != 0)
+                return false;
+
+            char** words = expResult.we_wordv;
+            unsigned int wordCount = expResult.we_wordc;
+            for ( unsigned int wordIndex = 0; wordIndex < wordCount; ++wordIndex )
             {
-                if ( arg.BeginsWith( '"' ) && arg.EndsWith( '"' ) )
-                {
-                    // strip quotes
-                    arg.SetLength( arg.GetLength() - 1 ); // trim end quote
-                    argVector.Append( arg.Get() + 1 ); // skip start quote
-                    continue;
-                }
-                argVector.Append( arg.Get() ); // leave arg as-is
+                // Make a copy of the string and stick it in splitArgs, as the strings allocated
+                // by wordexp will be freed when we leave this scope.
+                splitArgs.Append( AString( words[wordIndex] ) );
+                AString& argString = splitArgs.Top();
+                argVector.Append( argString.Get() );
             }
+
+            wordfree( &expResult );
         }
         argVector.Append( nullptr ); // argv must have be nullptr terminated
 

--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -309,13 +309,17 @@ bool Process::Spawn( const char * executable,
 
             char** words = expResult.we_wordv;
             unsigned int wordCount = expResult.we_wordc;
+
+            // Set capacity here to avoid reallocation while appending
+            splitArgs.SetCapacity(wordCount);
+            argVector.SetCapacity(wordCount + 1); // + 1 for the nullptr terminator
+
             for ( unsigned int wordIndex = 0; wordIndex < wordCount; ++wordIndex )
             {
                 // Make a copy of the string and stick it in splitArgs, as the strings allocated
                 // by wordexp will be freed when we leave this scope.
                 splitArgs.Append( AString( words[wordIndex] ) );
-                AString& argString = splitArgs.Top();
-                argVector.Append( argString.Get() );
+                argVector.Append( splitArgs.Top().Get() );
             }
 
             wordfree( &expResult );


### PR DESCRIPTION
Should perform shell-like expansion of the args string to more reliably produce a correct argv/argc.

Seems to resolve #510, although further testing would be needed to verify this.