### PR TITLE
Fixed migration of cached PCH nodes

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/MetaData/Meta_IgnoreForComparison.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/MetaData/Meta_IgnoreForComparison.cpp
@@ -1,0 +1,22 @@
+// Meta_IgnoreForComparison
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Tools/FBuild/FBuildCore/PrecompiledHeader.h"
+#include "Meta_IgnoreForComparison.h"
+
+// Reflection
+//------------------------------------------------------------------------------
+REFLECT_BEGIN( Meta_IgnoreForComparison, IMetaData, MetaNone() )
+REFLECT_END( Meta_IgnoreForComparison )
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+Meta_IgnoreForComparison::Meta_IgnoreForComparison() = default;
+
+// DESTRUCTOR
+//------------------------------------------------------------------------------
+Meta_IgnoreForComparison::~Meta_IgnoreForComparison() = default;
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/MetaData/Meta_IgnoreForComparison.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/MetaData/Meta_IgnoreForComparison.h
@@ -1,0 +1,19 @@
+// Meta_IgnoreForComparison
+//------------------------------------------------------------------------------
+#pragma once
+
+// Includes
+//------------------------------------------------------------------------------
+#include "Core/Reflection/MetaData/MetaDataInterface.h"
+
+// Meta_InheritFromOwner
+//------------------------------------------------------------------------------
+class Meta_IgnoreForComparison : public IMetaData
+{
+    REFLECT_DECLARE( Meta_IgnoreForComparison )
+public:
+    explicit Meta_IgnoreForComparison();
+    virtual ~Meta_IgnoreForComparison();
+};
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -37,6 +37,7 @@
 #include "Tools/FBuild/FBuildCore/Graph/MetaData/Meta_EmbedMembers.h"
 #include "Tools/FBuild/FBuildCore/Graph/MetaData/Meta_InheritFromOwner.h"
 #include "Tools/FBuild/FBuildCore/Graph/MetaData/Meta_Name.h"
+#include "Tools/FBuild/FBuildCore/Graph/MetaData/Meta_IgnoreForComparison.h"
 #include "Tools/FBuild/FBuildCore/WorkerPool/Job.h"
 
 // Core
@@ -100,6 +101,10 @@ IMetaData & MetaEmbedMembers()
 IMetaData & MetaInheritFromOwner()
 {
     return *FNEW( Meta_InheritFromOwner() );
+}
+IMetaData & MetaIgnoreForComparison()
+{
+    return *FNEW( Meta_IgnoreForComparison() );
 }
 
 // Reflection

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -278,5 +278,6 @@ IMetaData & MetaAllowNonFile();
 IMetaData & MetaAllowNonFile( const Node::Type limitToType );
 IMetaData & MetaEmbedMembers();
 IMetaData & MetaInheritFromOwner();
+IMetaData & MetaIgnoreForComparison();
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -51,6 +51,8 @@
 #include "Core/Strings/LevenshteinDistance.h"
 #include "Core/Tracing/Tracing.h"
 
+#include "MetaData/Meta_IgnoreForComparison.h"
+
 #include <string.h>
 
 // Defines
@@ -1989,6 +1991,10 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
 //------------------------------------------------------------------------------
 /*static*/ bool NodeGraph::AreNodesTheSame( const void * baseA, const void * baseB, const ReflectedProperty & property )
 {
+    if( property.HasMetaData< Meta_IgnoreForComparison >() )
+    {
+      return true;
+    }
     switch ( property.GetType() )
     {
         case PropertyType::PT_ASTRING:

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -69,7 +69,7 @@ REFLECT_NODE_BEGIN( ObjectNode, Node, MetaNone() )
     REFLECT( m_PrecompiledHeader,                   "PrecompiledHeader",                MetaHidden() )
     REFLECT( m_Flags,                               "Flags",                            MetaHidden() )
     REFLECT( m_PreprocessorFlags,                   "PreprocessorFlags",                MetaHidden() )
-    REFLECT( m_PCHCacheKey,                         "PCHCacheKey",                      MetaHidden() )
+    REFLECT( m_PCHCacheKey,                         "PCHCacheKey",                      MetaHidden() + MetaIgnoreForComparison() )
 REFLECT_END( ObjectNode )
 
 // CONSTRUCTOR


### PR DESCRIPTION
Fix migration of cached PCH nodes by ignoring PCHCacheKey property during nodes comparison. Related issue #530 