### PR TITLE
Fix self assignment for arrays

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1739,6 +1739,14 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
             return false;
         }
     }
+    else
+    {
+        // self-assignment?
+        if ( varDst == varSrc )
+        {
+            return true;
+        }
+    }
 
     // if dst exists, types must match
     BFFVariable::VarType srcType = varSrc->GetType();


### PR DESCRIPTION
Previously attempt to assign an array variable to itself in the current scope triggered an assert in `Array::operator=` in Debug builds and cleared the variable in Release builds. This change fixes this surprising behaviour for arrays.