### PR TITLE
Fixed segfault when compiling with Apple LLVM 10.0

### DIFF
--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -13,6 +13,7 @@
 #include "Core/Mem/SmallBlockAllocator.h"
 
 #include <stdlib.h>
+#include <cstddef>
 
 // Defines
 //------------------------------------------------------------------------------
@@ -21,7 +22,7 @@
 //------------------------------------------------------------------------------
 void * Alloc( size_t size )
 {
-    return AllocFileLine( size, alignof( max_align_t ), "Unknown", 0 );
+    return AllocFileLine( size, alignof( std::max_align_t ), "Unknown", 0 );
 }
 
 // Alloc
@@ -35,7 +36,7 @@ void * Alloc( size_t size, size_t alignment )
 //------------------------------------------------------------------------------
 void * AllocFileLine( size_t size, const char * file, int line )
 {
-    return AllocFileLine( size, alignof( max_align_t ), file, line );
+    return AllocFileLine( size, alignof( std::max_align_t ), file, line );
 }
 
 // AllocFileLine

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 void * Alloc( size_t size )
 {
-    return AllocFileLine( size, sizeof( void * ), "Unknown", 0 );
+    return AllocFileLine( size, alignof( max_align_t ), "Unknown", 0 );
 }
 
 // Alloc
@@ -35,7 +35,7 @@ void * Alloc( size_t size, size_t alignment )
 //------------------------------------------------------------------------------
 void * AllocFileLine( size_t size, const char * file, int line )
 {
-    return AllocFileLine( size, sizeof( void * ), file, line );
+    return AllocFileLine( size, alignof( max_align_t ), file, line );
 }
 
 // AllocFileLine

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -22,7 +22,11 @@
 //------------------------------------------------------------------------------
 void * Alloc( size_t size )
 {
+#if defined( __clang__ )
     return AllocFileLine( size, alignof( std::max_align_t ), "Unknown", 0 );
+#else
+    return AllocFileLine( size, sizeof( void * ), "Unknown", 0 );
+#endif
 }
 
 // Alloc
@@ -36,7 +40,11 @@ void * Alloc( size_t size, size_t alignment )
 //------------------------------------------------------------------------------
 void * AllocFileLine( size_t size, const char * file, int line )
 {
+#if defined( __clang__ )
     return AllocFileLine( size, alignof( std::max_align_t ), file, line );
+#else
+    return AllocFileLine( size, sizeof( void * ), file, line );
+#endif
 }
 
 // AllocFileLine

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -21,6 +21,7 @@
 //------------------------------------------------------------------------------
 #include "Core/Mem/MemPoolBlock.h"
 #include "Core/Process/Mutex.h"
+#include <cstddef>
 
 // SmallBlockAllocator
 //------------------------------------------------------------------------------
@@ -44,7 +45,7 @@
         static void InitBuckets();
 
         static const size_t BUCKET_MAX_ALLOC_SIZE = 256;
-        static const size_t BUCKET_ALIGNMENT = alignof( max_align_t );
+        static const size_t BUCKET_ALIGNMENT = alignof( std::max_align_t );
         static const size_t BUCKET_NUM_BUCKETS = ( BUCKET_MAX_ALLOC_SIZE / BUCKET_ALIGNMENT );
         static const size_t BUCKET_ADDRESSSPACE_SIZE = ( 200 * 1024 * 1024 );
         static const size_t BUCKET_NUM_PAGES = ( BUCKET_ADDRESSSPACE_SIZE / MemPoolBlock::MEMPOOLBLOCK_PAGE_SIZE );

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -44,7 +44,7 @@
         static void InitBuckets();
 
         static const size_t BUCKET_MAX_ALLOC_SIZE = 256;
-        static const size_t BUCKET_ALIGNMENT = sizeof( void * );
+        static const size_t BUCKET_ALIGNMENT = alignof( max_align_t );
         static const size_t BUCKET_NUM_BUCKETS = ( BUCKET_MAX_ALLOC_SIZE / BUCKET_ALIGNMENT );
         static const size_t BUCKET_ADDRESSSPACE_SIZE = ( 200 * 1024 * 1024 );
         static const size_t BUCKET_NUM_PAGES = ( BUCKET_ADDRESSSPACE_SIZE / MemPoolBlock::MEMPOOLBLOCK_PAGE_SIZE );

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -45,7 +45,11 @@
         static void InitBuckets();
 
         static const size_t BUCKET_MAX_ALLOC_SIZE = 256;
+#if defined( __clang__ )
         static const size_t BUCKET_ALIGNMENT = alignof( std::max_align_t );
+#else
+        static const size_t BUCKET_ALIGNMENT = sizeof( void * );
+#endif
         static const size_t BUCKET_NUM_BUCKETS = ( BUCKET_MAX_ALLOC_SIZE / BUCKET_ALIGNMENT );
         static const size_t BUCKET_ADDRESSSPACE_SIZE = ( 200 * 1024 * 1024 );
         static const size_t BUCKET_NUM_PAGES = ( BUCKET_ADDRESSSPACE_SIZE / MemPoolBlock::MEMPOOLBLOCK_PAGE_SIZE );


### PR DESCRIPTION
When FASTBuild is built using the latest Xcode 10.1 (Apple LLVM version 10.0.0 (clang-1000.11.45.5)), I encounter segfaults EXC_BAD_ACCESS(code=EXC_I386_GPFLT) when some objects are dynamically allocated. For example at `FileIO::FileInfo * fi = FNEW( FileIO::FileInfo() );` inside UnityNode.cpp.
![screen shot 2019-02-04 at 5 02 16 pm](https://user-images.githubusercontent.com/22981756/52216884-efd2ee00-289f-11e9-942b-43b6c8a01c67.png)
I think it is caused by LLVM [bug 35901](https://bugs.llvm.org/show_bug.cgi?id=35901). Clang generates a `movaps` instruction, which expects 16 byte alignment.
Perhaps these changes should be wrapped by `#ifdef __clang__`, since it seems to be a problem only for Clang.
