### PR TITLE
Added .CompilerOutputKeepBaseExtension to ObjectList

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -35,6 +35,7 @@ REFLECT_NODE_BEGIN( ObjectListNode, Node, MetaNone() )
     REFLECT( m_CompilerOutputPath,                  "CompilerOutputPath",               MetaPath() )
     REFLECT( m_CompilerOutputPrefix,                "CompilerOutputPrefix",             MetaOptional() )
     REFLECT( m_CompilerOutputExtension,             "CompilerOutputExtension",          MetaOptional() )
+    REFLECT( m_CompilerOutputKeepBaseExtension,     "CompilerOutputKeepBaseExtension",  MetaOptional() )
     REFLECT( m_CompilerInputAllowNoFiles,           "CompilerInputAllowNoFiles",        MetaOptional() )
     REFLECT_ARRAY( m_CompilerInputPath,             "CompilerInputPath",                MetaOptional() + MetaPath() )
     REFLECT_ARRAY( m_CompilerInputPattern,          "CompilerInputPattern",             MetaOptional() )
@@ -579,7 +580,7 @@ bool ObjectListNode::CreateDynamicObjectNode( NodeGraph & nodeGraph, Node * inpu
     // get file name only (no path, no ext)
     const char * lastSlash = fileName.FindLast( NATIVE_SLASH );
     lastSlash = lastSlash ? ( lastSlash + 1 ) : fileName.Get();
-    const char * lastDot = fileName.FindLast( '.' );
+    const char * lastDot = m_CompilerOutputKeepBaseExtension ? fileName.GetEnd() : fileName.FindLast( '.' );
     lastDot = lastDot && ( lastDot > lastSlash ) ? lastDot : fileName.GetEnd();
 
     // if source comes from a directory listing, use path relative to dirlist base

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -80,6 +80,7 @@ protected:
     Array< AString >    m_CompilerForceUsing;
     bool                m_CompilerInputAllowNoFiles         = false;
     bool                m_CompilerInputPathRecurse          = true;
+    bool                m_CompilerOutputKeepBaseExtension   = false;
     bool                m_DeoptimizeWritableFiles           = false;
     bool                m_DeoptimizeWritableFilesWithToken  = false;
     bool                m_AllowDistribution                 = true;


### PR DESCRIPTION
I have a few cases where multiple files in the same directory have the same name but different extensions. Normally when such files are in the same ObjectList there is a conflict. For example `file.ext1` and `file.ext2` both produce `file.o`. This option allows to keeps an original extension in output files, so there is no conflict. For example `file.ext1` produces `file.ext1.o`, `file.ext2` produces `file.ext2.o`. 