### PR TITLE
Allow targets to be hidden from -showtargets list

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -182,7 +182,7 @@ int Main(int argc, char * argv[])
 
     if ( options.m_DisplayTargetList )
     {
-        fBuild.DisplayTargetList();
+        fBuild.DisplayTargetList( options.m_ShowHiddenTargets );
         ctrlCHandler.DeregisterHandler(); // Ensure this happens before FBuild is destroyed
         return FBUILD_OK;
     }

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -16,6 +16,9 @@
 #include "Graph/NodeGraph.h"
 #include "Graph/NodeProxy.h"
 #include "Graph/SettingsNode.h"
+#include "Graph/AliasNode.h"
+#include "Graph/ObjectListNode.h"
+#include "Graph/UnityNode.h"
 #include "Helpers/Report.h"
 #include "Protocol/Client.h"
 #include "Protocol/Protocol.h"
@@ -666,7 +669,7 @@ void FBuild::UpdateBuildStatus( const Node * node )
 
 // DisplayTargetList
 //------------------------------------------------------------------------------
-void FBuild::DisplayTargetList() const
+void FBuild::DisplayTargetList( bool showHidden ) const
 {
     OUTPUT( "FBuild: List of available targets\n" );
     const size_t totalNodes = m_DependencyGraph->GetNodeCount();
@@ -674,6 +677,7 @@ void FBuild::DisplayTargetList() const
     {
         Node * node = m_DependencyGraph->GetNodeByIndex( i );
         bool displayName = false;
+        bool hidden      = false;
         switch ( node->GetType() )
         {
             case Node::PROXY_NODE:          ASSERT( false ); break;
@@ -683,15 +687,15 @@ void FBuild::DisplayTargetList() const
             case Node::FILE_NODE:           break;
             case Node::LIBRARY_NODE:        break;
             case Node::OBJECT_NODE:         break;
-            case Node::ALIAS_NODE:          displayName = true; break;
+            case Node::ALIAS_NODE:          displayName = true; hidden = static_cast<AliasNode*>( node )->IsHidden(); break;
             case Node::EXE_NODE:            break;
             case Node::CS_NODE:             break;
-            case Node::UNITY_NODE:          displayName = true; break;
+            case Node::UNITY_NODE:          displayName = true; hidden = static_cast<UnityNode*>( node )->IsHidden(); break;
             case Node::TEST_NODE:           break;
             case Node::COMPILER_NODE:       break;
             case Node::DLL_NODE:            break;
             case Node::VCXPROJECT_NODE:     break;
-            case Node::OBJECT_LIST_NODE:    displayName = true; break;
+            case Node::OBJECT_LIST_NODE:    displayName = true; hidden = static_cast<ObjectListNode*>( node )->IsHidden(); break;
             case Node::COPY_DIR_NODE:       break;
             case Node::SLN_NODE:            break;
             case Node::REMOVE_DIR_NODE:     break;
@@ -699,7 +703,7 @@ void FBuild::DisplayTargetList() const
             case Node::SETTINGS_NODE:       break;
             case Node::NUM_NODE_TYPES:      ASSERT( false );                        break;
         }
-        if ( displayName )
+        if ( displayName && ( !hidden || ( hidden && showHidden ) ) )
         {
             OUTPUT( "\t%s\n", node->GetName().Get() );
         }

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -59,7 +59,7 @@ public:
     inline const char * GetEnvironmentString() const            { return m_EnvironmentString; }
     inline uint32_t     GetEnvironmentStringSize() const        { return m_EnvironmentStringSize; }
 
-    void DisplayTargetList() const;
+    void DisplayTargetList( bool showHidden ) const;
     bool DisplayDependencyDB( const Array< AString > & targets ) const;
 
     class EnvironmentVarAndHash

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -266,6 +266,11 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
                 m_DisplayTargetList = true;
                 continue;
             }
+            else if ( thisArg == "-showhidden" )
+            {
+                m_ShowHiddenTargets = true;
+                continue;
+            }
             else if ( thisArg == "-summary" )
             {
                 m_ShowSummary = true;
@@ -499,7 +504,8 @@ void FBuildOptions::DisplayHelp( const AString & programName ) const
             "                This will lengthen the total build time.\n"
             " -showcmds      Show command lines used to launch external processes.\n"
             " -showdeps      Show known dependency tree for specified targets.\n"
-            " -showtargets   Display list of primary build targets.\n"
+            " -showtargets   Display list of primary build targets. Doesn't show hidden targets by default.\n"
+            " -showhidden    Show hidden targets. Should be used with -showtargets switch. No-op otherwise.\n"
             " -summary       Show a summary at the end of the build.\n"
             " -verbose       Show detailed diagnostic information. This will slow\n"
             "                down building.\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -53,6 +53,7 @@ public:
     bool        m_FastCancel                        = false;
     bool        m_WaitMode                          = false;
     bool        m_DisplayTargetList                 = false;
+    bool        m_ShowHiddenTargets                 = false;
     bool        m_DisplayDependencyDB               = false;
     bool        m_NoUnity                           = false;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
@@ -16,12 +16,14 @@
 //------------------------------------------------------------------------------
 REFLECT_NODE_BEGIN( AliasNode, Node, MetaNone() )
     REFLECT_ARRAY( m_Targets,   "Targets",          MetaFile() + MetaAllowNonFile() )
+    REFLECT( m_IsHidden,        "Hidden",           MetaOptional() )
 REFLECT_END( AliasNode )
 
 // CONSTRUCTOR
 //------------------------------------------------------------------------------
 AliasNode::AliasNode()
 : Node( AString::GetEmpty(), Node::ALIAS_NODE, Node::FLAG_TRIVIAL_BUILD )
+, m_IsHidden( false )
 {
     m_LastBuildTimeMs = 1; // almost no work is done for this node
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.h
@@ -28,11 +28,13 @@ public:
 
     inline const Dependencies & GetAliasedNodes() const { return m_StaticDependencies; }
 
+    bool IsHidden() const { return m_IsHidden; }
 private:
     virtual bool DetermineNeedToBuild( bool forceClean ) const override;
     virtual BuildResult DoBuild( Job * job ) override;
 
     Array< AString > m_Targets;
+    bool m_IsHidden;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -128,7 +128,6 @@ Node::Node( const AString & name, Type type, uint32_t controlFlags )
     , m_ProcessingTime( 0 )
     , m_ProgressAccumulator( 0 )
     , m_Index( INVALID_NODE_INDEX )
-    , m_Hidden( false )
 {
     SetName( name );
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -48,6 +48,7 @@ REFLECT_NODE_BEGIN( ObjectListNode, Node, MetaNone() )
     REFLECT( m_DeoptimizeWritableFilesWithToken,    "DeoptimizeWritableFilesWithToken", MetaOptional() )
     REFLECT( m_AllowDistribution,                   "AllowDistribution",                MetaOptional() )
     REFLECT( m_AllowCaching,                        "AllowCaching",                     MetaOptional() )
+    REFLECT( m_IsHidden,                            "Hidden",                           MetaOptional() )
     // Precompiled Headers
     REFLECT( m_PCHInputFile,                        "PCHInputFile",                     MetaOptional() + MetaFile() )
     REFLECT( m_PCHOutputFile,                       "PCHOutputFile",                    MetaOptional() + MetaFile() )
@@ -71,6 +72,7 @@ REFLECT_END( ObjectListNode )
 //------------------------------------------------------------------------------
 ObjectListNode::ObjectListNode()
 : Node( AString::GetEmpty(), Node::OBJECT_LIST_NODE, Node::FLAG_NONE )
+, m_IsHidden( false )
 {
     m_LastBuildTimeMs = 10000;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -39,6 +39,8 @@ public:
     CompilerNode * GetPreprocessor() const;
 
     inline const AString & GetCompilerOptions() const { return m_CompilerOptions; }
+
+    bool IsHidden() const { return m_IsHidden; }
 protected:
     friend class FunctionObjectList;
 
@@ -90,6 +92,7 @@ protected:
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
     Array< AString >    m_PreBuildDependencyNames;
+    bool                m_IsHidden;
 
     // Internal State
     bool                m_UsingPrecompiledHeader            = false;

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -38,6 +38,7 @@ REFLECT_NODE_BEGIN( UnityNode, Node, MetaNone() )
     REFLECT( m_IsolateWritableFiles,    "UnityInputIsolateWritableFiles",       MetaOptional() )
     REFLECT( m_PrecompiledHeader,       "UnityPCH",                             MetaOptional() + MetaFile( true ) ) // relative
     REFLECT_ARRAY( m_PreBuildDependencyNames,   "PreBuildDependencies",         MetaOptional() + MetaFile() + MetaAllowNonFile() )
+    REFLECT( m_IsHidden,                "Hidden",                               MetaOptional() )
 REFLECT_END( UnityNode )
 
 // CONSTRUCTOR
@@ -58,6 +59,7 @@ UnityNode::UnityNode()
 , m_ExcludePatterns( 0, true )
 , m_IsolatedFiles( 0, true )
 , m_UnityFileNames( 0, true )
+, m_IsHidden( false )
 {
     m_InputPattern.Append( AStackString<>( "*.cpp" ) );
     m_LastBuildTimeMs = 100; // higher default than a file node

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -50,6 +50,8 @@ public:
     };
     inline const Array< FileAndOrigin > & GetIsolatedFileNames() const { return m_IsolatedFiles; }
 
+    bool IsHidden() const { return m_IsHidden; }
+
 private:
     virtual BuildResult DoBuild( Job * job ) override;
 
@@ -78,6 +80,8 @@ private:
     // Temporary data
     Array< AString > m_UnityFileNames;
     Array< FileIO::FileInfo* > m_FilesInfo;
+
+    bool m_IsHidden;
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
It's useful to hide some targets from -showtargets list. 
For example, here is list of targets:
- Foo-Bar-c
- Foo-Bar-cpp
- Foo-Bar-asm
- Foo-Bar-exe

I don't need information about anything except Foo-Bar-exe, so now I can hide other targets from
default output, but when I need full list of targets, I can specify -showhidden flag and see full list of targets.

This commit changes:
- Added .Hidden option to Alias, Unity and ObjectList. Default == false
- Disabled showing hidden targets in -showtargets output by default
- Added -showhidden option to allow displaying hidden targets.