### PR TITLE
Fixed assert firing with orbis-wave-psslc.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1866,7 +1866,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
         }
         else
         {
-            ASSERT( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isCUDA || isVBCC );
+            ASSERT( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isCUDA || isVBCC || isOrbisWavePsslc );
             fullArgs += "-E"; // run pre-processor only
 
             // Ensure unused defines declared in the PCH but not used


### PR DESCRIPTION
Hello, while working on a different feature, I ran into an assert triggered when compiling using orbis-wave-psslc. I believe this assert is just missing check for this compiler family, as orbis-wave-psslc uses -E as "run pre-processor only" flag.