### PR TITLE
Microsoft Direct3D shader compiler (fxc.exe) support

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -137,6 +137,7 @@ Compiler( 'Test' )
         <tr><td>qt-rcc</td><td>Qt's resource compiler</td></tr>
         <tr><td>vbcc</td><td>vbcc compiler</td></tr>
         <tr><td>orbis-wave-psslc</td><td>orbis wave psslc shader compiler</td></tr>
+        <tr><td>fxc</td><td>Microsoft Direct3D shader compiler</td></tr>
         <tr><td>&nbsp;</td><td></td></tr>
         <tr><th>Value</th><th>Notes</th></tr>
         <tr><td>custom</td><td>Any custom compiler. <font color=red>NOTE:</font> Only primary input and output dependencies will be tracked. No additional

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -253,6 +253,14 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
             return true;
         }
 
+        // Microsoft Direct3D Shader Compiler
+        if ( compiler.EndsWithI( "fxc.exe" ) ||
+             compiler.EndsWithI( "fxc" ) )
+        {
+            m_CompilerFamilyEnum = FXC;
+            return true;
+        }
+
         // Auto-detect failed
         Error::Error_1500_CompilerDetectionFailed( iter, function, compiler );
         return false;
@@ -312,6 +320,11 @@ bool CompilerNode::InitializeCompilerFamily( const BFFIterator & iter, const Fun
     if ( m_CompilerFamilyString.EqualsI( "orbis-wave-psslc" ) )
     {
         m_CompilerFamilyEnum = ORBIS_WAVE_PSSLC;
+        return true;
+    }
+    if ( m_CompilerFamilyString.EqualsI( "fxc" ) )
+    {
+        m_CompilerFamilyEnum = FXC;
         return true;
     }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -49,6 +49,7 @@ public:
         QT_RCC          = 8,
         VBCC            = 9,
         ORBIS_WAVE_PSSLC= 10,
+        FXC             = 11,
     };
     CompilerFamily GetCompilerFamily() const { return static_cast<CompilerFamily>( m_CompilerFamilyEnum ); }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -63,6 +63,7 @@ public:
         FLAG_ORBIS_WAVE_PSSLC   =   0x400000,
         FLAG_DIAGNOSTICS_COLOR_AUTO = 0x800000,
         FLAG_WARNINGS_AS_ERRORS_CLANGGCC = 0x1000000,
+        FLAG_FXC                =   0x2000000,
     };
     static uint32_t DetermineFlags( const CompilerNode * compilerNode,
                                     const AString & args,
@@ -146,6 +147,7 @@ private:
     bool ShouldUseCache() const;
     bool CanUseResponseFile() const;
     bool GetVBCCPreprocessedOutput( ConstMemoryStream & outStream ) const;
+    bool GetFXCPreprocessedOutput( ConstMemoryStream & outStream ) const;
 
     friend class FunctionObjectList;
 

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
@@ -346,6 +346,95 @@ bool CIncludeParser::ParseGCC_Preprocessed( const char * compilerOutput,
     return true;
 }
 
+// Parse
+//------------------------------------------------------------------------------
+bool CIncludeParser::ParseFXC_Output( const char * compilerOutput,
+                                      size_t compilerOutputSize )
+{
+    // we require null terminated input
+    ASSERT( compilerOutput[ compilerOutputSize ] == 0 );
+    (void)compilerOutputSize;
+
+    const char * pos = compilerOutput;
+    for (;;)
+    {
+        const char * lineStart = pos;
+
+        // find end of the line
+        pos = strchr( pos, '\n' );
+        if ( !pos )
+        {
+            break; // end of output
+        }
+
+        const char * lineEnd = ( lineStart < pos && pos[-1] == '\r' ) ? pos - 1 : pos;
+
+        ASSERT( *pos == '\n' );
+        ++pos; // skip \r for next line
+
+        // We only care about lines like 'Resolved to [{path}]'
+        if ( lineEnd - lineStart <= 14 )
+            continue;
+
+        if ( strncmp( lineStart, "Resolved to [", 13 ) != 0 )
+            continue;
+
+        if ( lineEnd[ -1 ] != ']' )
+            continue;
+
+        const char * includeStart = lineStart + 13;
+        const char * includeEnd = lineEnd - 1;
+
+        const char * ch = includeStart;
+
+        // validates the windows path
+        bool validated = ( includeStart < includeEnd );
+        size_t colonCount( 0 );
+        for ( ; validated && ( ch < includeEnd ); ++ch )
+        {
+            switch ( *ch )
+            {
+                // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+                case '<':
+                case '>':
+                case '"':
+                case '|':
+                case '?':
+                case '*':
+                {
+                    validated = false;
+                    break;
+                }
+                case ':':
+                {
+                    // This logic handles warnings which might otherwise appear as valid paths
+                    ++colonCount;
+                    if ( colonCount > 1 )
+                    {
+                        validated = false;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        if ( validated )
+        {
+            const char c1 = includeStart[ 0 ];
+            const bool driveLetter = ( ( ( c1 >= 'A' ) && ( c1 <= 'Z' ) ) || ( ( c1 >= 'a' ) && ( c1 <= 'z' ) ) );
+            const bool validPath = driveLetter && ( includeStart[ 1 ] == ':' );
+            if ( validPath )
+            {
+                AddInclude( includeStart, includeEnd );
+            }
+        }
+    }
+
+    return true;
+}
+
 // SwapIncludes
 //------------------------------------------------------------------------------
 void CIncludeParser::SwapIncludes( Array< AString > & includes )

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.h
@@ -19,6 +19,7 @@ public:
     bool ParseMSCL_Output( const char * compilerOutput, size_t compilerOutputSize );
     bool ParseMSCL_Preprocessed( const char * compilerOutput, size_t compilerOutputSize );
     bool ParseGCC_Preprocessed( const char * compilerOutput, size_t compilerOutputSize );
+    bool ParseFXC_Output( const char * compilerOutput, size_t compilerOutputSize );
 
     const Array< AString > & GetIncludes() const { return m_Includes; }
 


### PR DESCRIPTION
This change adds support for new compiler family based on Microsoft Direct3D shader compiler fxc.exe . Majority of code is similar to other compiler families. One major difference compared to other families is the way dependencies are obtained.

When compiling a shader, compiler writes results of preprocessing to a file and writes include information to stdout. Includes and dependency information are determined based on stdout, as preprocessed file has paths always in form in which they were written in original code, which means they can be always relative to different directory and I couldn't figure out a way to reconstruct correct paths in all cases.

There are 2 outstanding issues I know of, though there might be more after reviewing changes:
1. Preprocessing output path is compilation output path with .i suffix appended and some places assume that is where the file is located when they begin final compilation. I suspect this would run into issues with distributing build, but I haven't been able to test it.
2. Job data is probably not set correctly. Again, this might cause issues with distributed build.

I am primarily looking for feedback whether there is interest in this change. We definitely needed it for our work, and it would simplify things to have it be part of main fastbuild distribution. I welcome any information on what should be fixed/changed/tested.