### PR TITLE
Add missing headers

### DIFF
--- a/Code/Core/Process/SystemMutex.cpp
+++ b/Code/Core/Process/SystemMutex.cpp
@@ -14,6 +14,7 @@
 #if defined( __LINUX__ ) || defined( __APPLE__ )
     #include <errno.h>
     #include <sys/file.h>
+    #include <fcntl.h>
     #include <unistd.h>
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.cpp
@@ -10,6 +10,8 @@
 #include "Core/FileIO/MemoryStream.h"
 #include "Core/Network/TCPConnectionPool.h"
 
+// system
+#include <memory.h> // for memset
 #if defined( __APPLE__ ) || defined( __LINUX__ )
     #include <unistd.h> // for ::gethostname
 #endif


### PR DESCRIPTION
* `memory.h` is needed for `memset`, without it non-unity build fails on Linux.
* `fcntl.h` is needed for `open`, without it non-unity build fails on Linux when musl is used.