### PR TITLE
Fix name of the dependency graph file on Linux

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -155,7 +155,7 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
             m_DependencyGraphFile += ".windows.fdb";
         #elif defined( __OSX__ )
             m_DependencyGraphFile += ".osx.fdb";
-        #elif defined( __LINUX )
+        #elif defined( __LINUX__ )
             m_DependencyGraphFile += ".linux.fdb";
         #endif
     }


### PR DESCRIPTION
Macro `__LINUX__` was misspelled and as the result node graph on Linux was stored in the file `fbuild` instead of `fbuild.linux.fdb`.

I also would like to propose a way to prevent such problems (or at least reduce probability) in the future by using function-like macros for platform checks. That way if the name of the macro will be misspelled compiler would produce an error about unknown function-like macro.  
In detail I propose:
1. Replacing checks like `#if defined( __WINDOWS__ )` with `#if __WINDOWS__()` (or even better: `#if FBUILD_WINDOWS()` to stop using reserved identifiers).
2. Replacing compiler flags like `-D__WINDOWS__` with `-D__WINDOWS__()=1 -D__LINUX__()=0 -D__OSX__()=0`.

Existing check of the form `#else` `#error Unknown platform` can prevent such errors, but only if it is inserted in each new place where platform defines are checked.