### PR TITLE
Fix bug where FBuild uses wrong database filename on Linux

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -155,7 +155,7 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
             m_DependencyGraphFile += ".windows.fdb";
         #elif defined( __OSX__ )
             m_DependencyGraphFile += ".osx.fdb";
-        #elif defined( __LINUX )
+        #elif defined( __LINUX__ )
             m_DependencyGraphFile += ".linux.fdb";
         #endif
     }


### PR DESCRIPTION
FBuild.cpp was incorrectly checking if the __LINUX macro was defined. It should
have instead checked for the __LINUX__ macro. This resulted in a file called
"fbuild" being as the database file on Linux.

We happened to have an existing file with that name (the fbuild binary itself).
FBuild ended up reading our existing file and failng to parse it since it was
not the format it expected.