### PR TITLE
Added missing support for the CopyDir node in libraries.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -1359,6 +1359,14 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
         return true;
     }
 
+    // a directory copy?
+    if (node->GetType() == Node::COPY_DIR_NODE)
+    {
+        // depend on copy - will use input at build time
+        nodes.Append(Dependency(node));
+        return true;
+    }
+
     // an external executable?
     if ( node->GetType() == Node::EXEC_NODE )
     {


### PR DESCRIPTION
This should make it possible to have a dependency on another project which has a `CopyDir` in its targets.

For example:
ProjectA.bff
```
DLL( 'Project_A_DLL' )
{
    .Libraries = {
                    // This will now cause "Error #1005 - DLL() - Unsupported node type in 'Libraries'." (Node: 'Copy_Directory', Type: 'CopyDir')
                    'Project_B'
                 }
}
```

ProjectB.bff
```
DLL( 'Project_B_DLL' )
{
    [...]
}

CopyDir( 'Copy_Directory' )
{
    .SourcePaths = 'folder\source\'
    .Dest        = 'folder\destination\'
}

Alias( 'Project_B' )
{
    .Targets =  {
                    'Copy_Directory'
                    'Project_B_DLL'
                }
}
```