### PR TITLE
Fixes for shared memory test

### DIFF
--- a/Code/Core/CoreTest/Tests/TestSharedMemory.cpp
+++ b/Code/Core/CoreTest/Tests/TestSharedMemory.cpp
@@ -18,6 +18,10 @@
     #include <unistd.h>
 #endif
 
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+
 // TestSharedMemory
 //------------------------------------------------------------------------------
 class TestSharedMemory : public UnitTest
@@ -43,8 +47,15 @@ void TestSharedMemory::CreateAccessDestroy() const
     // TODO:WINDOWS Test SharedMemory (without fork, so).
 #elif defined(__LINUX__) || defined(__APPLE__)
     AStackString<> sharedMemoryName( "FBuild_SHM_Test_" );
+    #if defined( __clang__ )
+        sharedMemoryName += "Clang";
+    #endif
     sharedMemoryName += (sizeof(void*) == 8) ? "64_" : "32_";
-    #if defined( DEBUG )
+    #if __has_feature( address_sanitizer ) || defined( __SANITIZE_ADDRESS__ )
+        sharedMemoryName += "ASan";
+    #elif __has_feature( memory_sanitizer )
+        sharedMemoryName += "MSan";
+    #elif defined( DEBUG )
         sharedMemoryName += "Debug";
     #elif defined( RELEASE )
         #if defined( PROFILING_ENABLED )

--- a/Code/Core/CoreTest/Tests/TestSharedMemory.cpp
+++ b/Code/Core/CoreTest/Tests/TestSharedMemory.cpp
@@ -54,6 +54,11 @@ void TestSharedMemory::CreateAccessDestroy() const
         #endif
     #endif
 
+    // Create shared memory before forking to ensure that it will exist by the time forked process will try to open it.
+    SharedMemory shmHolder;
+    shmHolder.Create( sharedMemoryName.Get(), sizeof(uint32_t) );
+    shmHolder.Unmap();
+
     int pid = fork();
     if(pid == 0)
     {
@@ -95,7 +100,7 @@ void TestSharedMemory::CreateAccessDestroy() const
         t.Start();
 
         SharedMemory shm;
-        shm.Create( sharedMemoryName.Get(), sizeof(uint32_t) );
+        shm.Open( sharedMemoryName.Get(), sizeof(uint32_t) );
         volatile uint32_t * magic = static_cast<volatile uint32_t *>( shm.GetPtr() );
         TEST_ASSERT( magic );
 

--- a/Code/Core/CoreTest/Tests/TestSystemMutex.cpp
+++ b/Code/Core/CoreTest/Tests/TestSystemMutex.cpp
@@ -8,6 +8,10 @@
 #include "Core/Process/SystemMutex.h"
 #include "Core/Strings/AStackString.h"
 
+#if !defined( __has_feature )
+    #define __has_feature( ... ) 0
+#endif
+
 // TestMutex
 //------------------------------------------------------------------------------
 class TestSystemMutex : public UnitTest
@@ -33,8 +37,15 @@ void TestSystemMutex::LeakRegression() const
     // Create a unique name based on architecture/config to avoid
     // collisions when tests can run in parallel
     AStackString<> mutexName( "SysMutexName_" );
+    #if defined( __clang__ )
+        mutexName += "Clang";
+    #endif
     mutexName += (sizeof(void*) == 8) ? "64_" : "32_";
-    #if defined( DEBUG )
+    #if __has_feature( address_sanitizer ) || defined( __SANITIZE_ADDRESS__ )
+        mutexName += "ASan";
+    #elif __has_feature( memory_sanitizer )
+        mutexName += "MSan";
+    #elif defined( DEBUG )
         mutexName += "Debug";
     #elif defined( RELEASE )
         #if defined( PROFILING_ENABLED )

--- a/Code/Core/Process/SharedMemory.cpp
+++ b/Code/Core/Process/SharedMemory.cpp
@@ -74,21 +74,13 @@ SharedMemory::SharedMemory()
 //------------------------------------------------------------------------------
 SharedMemory::~SharedMemory()
 {
+    Unmap();
     #if defined( __WINDOWS__ )
-        if ( m_Memory )
-        {
-            UnmapViewOfFile( m_Memory );
-        }
         if ( m_MapFile )
         {
             CloseHandle( m_MapFile );
         }
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
-        if( m_Memory )
-        {
-            ASSERT( m_Length > 0 );
-            munmap( m_Memory, m_Length );
-        }
         if( m_MapFile != -1 )
         {
             close( m_MapFile );
@@ -149,6 +141,28 @@ void SharedMemory::Open( const char * name, unsigned int size )
         m_Length = size;
     #else
         #error
+    #endif
+}
+
+// Unmap
+//------------------------------------------------------------------------------
+void SharedMemory::Unmap()
+{
+    #if defined( __WINDOWS__ )
+        if ( m_Memory )
+        {
+            UnmapViewOfFile( m_Memory );
+            m_Memory = nullptr;
+        }
+    #elif defined( __LINUX__ ) || defined( __APPLE__ )
+        if ( m_Memory )
+        {
+            ASSERT( m_Length > 0 );
+            munmap( m_Memory, m_Length );
+            m_Memory = nullptr;
+        }
+    #else
+        #error Unknown Platform
     #endif
 }
 

--- a/Code/Core/Process/SharedMemory.h
+++ b/Code/Core/Process/SharedMemory.h
@@ -22,6 +22,9 @@ public:
 
     void * GetPtr() const { return m_Memory; }
 private:
+    friend class TestSharedMemory;
+    void Unmap(); // Used in unit tests
+
     void * m_Memory;
     #if defined( __WINDOWS__)
         void * m_MapFile;


### PR DESCRIPTION
This is a series of fixes for TestSharedMemory test:
1. Improvement for failure handling in the test.
2. Fix for sporadic failures of the test on Travis caused by a race between main process and the fork.
3. Support of ASan/MSan and Clang configurations in the chain of ifdefs that produce unique names for global objects in test.

More info in the corresponding commit messages.