### PR TITLE
Report error and exit when the intermediate process fails instead of hanging

### DIFF
--- a/Code/Tools/FBuild/FBuildApp/Main.cpp
+++ b/Code/Tools/FBuild/FBuildApp/Main.cpp
@@ -255,7 +255,17 @@ int WrapperMainProcess( const AString & args, const FBuildOptions & options, Sys
 
     // the intermediate process will exit immediately after launching the final
     // process
-    p.WaitForExit();
+    int result = p.WaitForExit();
+    if ( result == FBUILD_FAILED_TO_SPAWN_WRAPPER_FINAL )
+    {
+        OUTPUT( "FBuild: Error: Intermediate process failed to spawn the final process.\n" );
+        return result;
+    }
+    else if ( result != FBUILD_OK )
+    {
+        OUTPUT( "FBuild: Error: Intermediate process failed (%i).\n", result );
+        return result;
+    }
 
     // wait for final process to signal as started
     while ( sd->Started == false )


### PR DESCRIPTION
Intermediate wrapper process may fail to start the final wrapper process. In that case it exits with an appropriate error code but the main process ignores it and waits (indefinitely) for a signal from the final process.

To fix this problem main process now checks the return code of the intermediate process and proceeds to waiting only if it succeeded.

Main process can still hang if the final process crashes/exits before it can set the `Started` flag. But that problem is not so easy to fix.