### PR TITLE
Detect #import directives in light cache

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -223,6 +223,12 @@ void LightCache::Hash( IncludedFile * file, FileStream & f )
 				SkipLineEnd( pos );
 				continue;
 			}
+            else if ( AString::StrNCmp( pos, "import", 6 ) == 0 )
+            {
+                // We encountered an import directive, we can't handle them.
+                m_ProblemParsing = true;
+                return;
+            }
 		}
 
 		// block comments

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_ImportDirective/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_ImportDirective/fbuild.bff
@@ -1,0 +1,16 @@
+//
+// LightCache does not support #import directives.
+// But it should detect this case and safely fall back to regular cache.
+//
+//------------------------------------------------------------------------------
+#define ENABLE_LIGHT_CACHE // Shared compiler config will check this
+
+#include "..\..\testcommon.bff"
+Using( .StandardEnvironment )
+Settings {} // use Standard Environment
+
+ObjectList( 'ObjectList' )
+{
+    .CompilerInputFiles = { '$TestRoot$/Data/TestCache/LightCache_ImportDirective/file.cpp' }
+    .CompilerOutputPath = '$Out$/Test/Cache/LightCache_ImportDirective/'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_ImportDirective/file.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_ImportDirective/file.cpp
@@ -1,0 +1,8 @@
+//
+// LightCache does not support #import directives.
+// But it should detect this case and safely fall back to regular cache.
+//
+//------------------------------------------------------------------------------
+#if 0 // We don't want to actually compile an #import directive. Compilation can fail for multiple unrelated reasons and we don't want false positives in tests.
+    #import <C:\Windows\system32\stdole32.tlb>
+#endif

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
@@ -22,6 +22,7 @@ private:
 
     void LightCache_IncludeUsingMacro() const;
     void LightCache_CyclicInclude() const;
+    void LightCache_ImportDirective() const;
 };
 
 // Register Tests
@@ -33,6 +34,7 @@ REGISTER_TESTS_BEGIN( TestCache )
     #if defined( __WINDOWS__ )
         REGISTER_TEST( LightCache_IncludeUsingMacro )
         REGISTER_TEST( LightCache_CyclicInclude )
+        REGISTER_TEST( LightCache_ImportDirective )
     #endif
 REGISTER_TESTS_END
 
@@ -272,6 +274,29 @@ void TestCache::LightCache_CyclicInclude() const
         TEST_ASSERT( objStats.m_NumCacheHits == objStats.m_NumProcessed );
         TEST_ASSERT( objStats.m_NumBuilt == 0 );
     }
+}
+
+// LightCache_ImportDirective
+//------------------------------------------------------------------------------
+void TestCache::LightCache_ImportDirective() const
+{
+    FBuildTestOptions options;
+    options.m_ForceCleanBuild = true;
+    options.m_UseCacheWrite = true;
+    options.m_CacheVerbose = true;
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestCache/LightCache_ImportDirective/fbuild.bff";
+
+    FBuildForTest fBuild( options );
+    TEST_ASSERT( fBuild.Initialize() );
+
+    TEST_ASSERT( fBuild.Build( AStackString<>( "ObjectList" ) ) );
+
+    // Ensure we detected that we could not use the LightCache
+    TEST_ASSERT( GetRecordedOutput().Find( "Light cache cannot be used for" ) );
+
+    // Ensure cache we fell back to normal caching
+    const FBuildStats::Stats & objStats = fBuild.GetStats().GetStatsFor( Node::OBJECT_NODE );
+    TEST_ASSERT( objStats.m_NumCacheStores == 1 );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I went ahead and added a check for `#import` directives to `LightCache`, as proposed in #562.

Note: LightCache.cpp have mixed indentation (tabs+spaces) that is why indentation looks wrong on GitHub.