### PR TITLE
Use correct extension for temporary files with preprocessed output

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2148,7 +2148,63 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
     AStackString<> fileName( sourceFile->GetName().FindLast( NATIVE_SLASH ) + 1 );
     if ( GetFlag( FLAG_GCC ) )
     {
-        fileName += ".i";
+        // Add extension to the name of the temporary file that corresponds to
+        // a preprocessed variant of the original extension.
+        // That way GCC will be able to deduce the same language from the name
+        // of temporary file as it would do from the original name.
+        const char * lastDot = fileName.FindLast( '.' );
+        if ( lastDot != nullptr && lastDot[1] != '\0' )
+        {
+            AStackString<> extension( lastDot + 1 );
+            if ( extension == "c" )
+            {
+                fileName += ".i";
+            }
+            else if ( extension == "cpp" || extension == "cc" || extension == "cxx" || extension == "c++" || extension == "cp" || extension == "CPP" || extension == "C" )
+            {
+                fileName += ".ii";
+            }
+            else if ( extension == "m" )
+            {
+                fileName += ".mi";
+            }
+            else if ( extension == "mm" || extension == "M" )
+            {
+                fileName += ".mii";
+            }
+            else if ( extension == "F" || extension == "fpp" || extension == "FPP" )
+            {
+                fileName += ".f";
+            }
+            else if ( extension == "FOR" )
+            {
+                fileName += ".for";
+            }
+            else if ( extension == "FTN" )
+            {
+                fileName += ".ftn";
+            }
+            else if ( extension == "F90" )
+            {
+                fileName += ".f90";
+            }
+            else if ( extension == "F95" )
+            {
+                fileName += ".f95";
+            }
+            else if ( extension == "F03" )
+            {
+                fileName += ".f03";
+            }
+            else if ( extension == "F08" )
+            {
+                fileName += ".f08";
+            }
+            else if ( extension == "S" || extension == "sx" )
+            {
+                fileName += ".s";
+            }
+        }
     }
 
     void const * dataToWrite = job->GetData();


### PR DESCRIPTION
GCC decides how to interpret input files by looking at file's extensions, in particular it determines the language of the input and the fact whether input was already preprocessed or not. This applies to `gcc` binary itself (not to `g++`, `g++` "upgrades" `.c` files to C++).

The problem was that we always used `.i` extension for the temporary files in which output of the preprocessor was stored, and that extension tell GCC that the file is a preprocessed C program.
So if a C++ source was compiled with separate preprocessing step and `.Compiler` referenced to a `gcc` binary then GCC interpreted that source as C code and failed to compile it.

To fix that `ObjectNode::WriteTmpFile` now selects proper extension for the temporary file based on the extension of the original file.

Change to `.Executable` value in the GCC configuration file allows us to check that we can now use `gcc` binary as the compiler. Before this change it wasn't possible – GCC reported that `-Wno-invalid-offsetof` is not a valid option for compiling C code.