### PR TITLE
Update value of the "-x" option when compiling preprocessed source

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1670,6 +1670,34 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                 {
                     continue; // skip this token in both cases
                 }
+
+                // To avoid preprocesing code a second time we need to update
+                // arguments of -x option to use the "cpp-output" variant.
+                // We must do this inplace because the argument order matters in this case.
+                if ( token == "-x" && i + 1 < numTokens )
+                {
+                    // Save the "-x" token
+                    fullArgs += token;
+                    fullArgs.AddDelimiter();
+
+                    // Change the argument to its "cpp-output" variant.
+                    const AString & language = tokens[ ++i ];
+                    if ( language == "c" )
+                    {
+                        fullArgs += "cpp-output";
+                    }
+                    else if ( language == "c++" || language == "objective-c" || language == "objective-c++" )
+                    {
+                        fullArgs += language;
+                        fullArgs += "-cpp-output";
+                    }
+                    else
+                    {
+                        fullArgs += language;
+                    }
+                    fullArgs.AddDelimiter();
+                    continue;
+                }
             }
             if ( isGCC || isClang || isVBCC || isOrbisWavePsslc )
             {

--- a/External/LZ4/LZ4.bff
+++ b/External/LZ4/LZ4.bff
@@ -1,7 +1,7 @@
 // LZ4
 //------------------------------------------------------------------------------
 .LZ4BasePath        = '../External/LZ4/lz4-1.9.1/lib'
-.LZ4IncludePaths    = ' "-I$LZ4BasePath$"'
+.LZ4IncludePaths    = ' -I$LZ4BasePath$'
 {
     .ProjectName        = 'LZ4'
     .ProjectPath        = '$LZ4BasePath$'

--- a/External/SDK/Windows/Windows10SDK.bff
+++ b/External/SDK/Windows/Windows10SDK.bff
@@ -21,9 +21,9 @@
 //------------------------------------------------------------------------------
 .Windows10_SDK_X64 =
 [
-    .WindowsSDK_IncludePaths        = ' "-I$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/ucrt"'
-                                    + ' "-I$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/um"'
-                                    + ' "-I$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/shared"'
+    .WindowsSDK_IncludePaths        = ' -I"$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/ucrt"'
+                                    + ' -I"$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/um"'
+                                    + ' -I"$Windows10_SDKBasePath$/Include/$Windows10_SDKVersion$/shared"'
 
     .WindowsDK_WinRTAssemblyPath    = '$Windows10_SDKBasePath$/UnionMetadata/$Windows10_SDKVersion$/'
 


### PR DESCRIPTION
It is possible to explicitly specify the type of an input file to GCC and Clang via `-x` option.
Currently, when we are compiling a preprocessed source we don't touch `-x` options and this forces GCC and Clang to preprocess the source a second time because they are told so by the option.

To fix this problem we now change the value of the `-x` option to a corresponding "cpp-output" variant.

This has 2 benefits:
1. Compilation of the preprocessed source is slightly faster.
2. During distributed compilation GCC running on the remote machine doesn't try to inject contents of `/usr/include/stdc-predef.h` from that machine into preprocessed source.
This avoids potential problems that may arise when that file is different on the remote machine.

Quoting of some `-I` had to be changed in configuration files because currently code in `ObjectNode::BuildArgs` doesn't recognize options that are quoted entirely. This leads to these `-I` options not being removed when compiling preprocessed code in Clang (now Clang actually knows that the input is preprocessed) and Clang producing a warning which breaks the build:
```
clang-8: fatal error: argument unused during compilation: '-I ../External/LZ4/lz4-1.9.1/lib' [-Wunused-command-line-argument]
```