### PR TITLE
Fix remote build failures, when the user kills cl.exe

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -481,9 +481,16 @@ void Client::Process( const ConnectionInfo * connection, const Protocol::MsgJobR
         VERIFY( ss->m_Jobs.FindDerefAndErase( jobId ) );
     }
 
+    // was it a system error?
+    if (systemError)
+    {
+        // blacklist misbehaving worker
+        ss->m_Blacklisted = true;
+    }
+
     // Has the job been cancelled in the interim?
     // (Due to a Race by the main thread for example)
-    Job * job = JobQueue::Get().OnReturnRemoteJob( jobId );
+    Job * job = JobQueue::Get().OnReturnRemoteJob( jobId, systemError );
     if ( job == nullptr )
     {
         // don't save result as we were cancelled
@@ -564,9 +571,6 @@ void Client::Process( const ConnectionInfo * connection, const Protocol::MsgJobR
         // was it a system error?
         if ( systemError )
         {
-            // blacklist misbehaving worker
-            ss->m_Blacklisted = true;
-
             // take note of failure of job
             job->OnSystemError();
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
@@ -80,7 +80,7 @@ private:
     // client side of protocol consumes jobs via this interface
     friend class Client;
     Job *       GetDistributableJobToProcess( bool remote );
-    Job *       OnReturnRemoteJob( uint32_t jobId );
+    Job *       OnReturnRemoteJob( uint32_t jobId, const bool systemError = false );
     void        ReturnUnfinishedDistributableJob( Job * job );
 
     // Semaphore to manage work


### PR DESCRIPTION
- Retry fix for remote builds that fail when the remote user kills the compilation

When a compilation process (cl.exe or orbis-clang++.exe) is spawned by the
FBuildWorker, sometimes that can make the machine unresponsible, and as a result
it can happen that the users are killing the compilation process manually.

When that happens the process terminates with code 1, as documented here:
https://stackoverflow.com/questions/4344923/process-exit-code-when-process-is-killed-forcibly
In that case the remote worker (FBuildWorker) will tag that job as a
"system failure", which will force the client to re-spawn the job on a different
worker. The client will also "blacklist" that worker as a result, which prevents
from spawning subsequent jobs on that client (as long as the client runs).

The change is a bit tricker when clang is used, because clang uses 1 as a exit
code when the compilation fails. We consequently check if the log contains
"error: ", and if not we consider the exit code as a call to TerminateProcess()
initiated by the remote user.

First issue is described here: https://github.com/fastbuild/fastbuild/issues/411