### PR TITLE
Prettify the DirectoryListNodes display in the stats summary, to avoid the very long unreadable lines

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
@@ -194,6 +194,8 @@ DirectoryListNode::~DirectoryListNode() = default;
         }
     }
 
+    MakePrettyName( files.GetSize() );
+
     if ( FLog::ShowInfo() )
     {
         const size_t numFiles = m_Files.GetSize();
@@ -207,6 +209,20 @@ DirectoryListNode::~DirectoryListNode() = default;
     }
 
     return NODE_RESULT_OK;
+}
+
+// MakePrettyName
+//------------------------------------------------------------------------------
+void DirectoryListNode::MakePrettyName( const size_t totalFiles )
+{
+    AStackString<> prettyName(m_Path);
+    if (m_Recursive)
+        prettyName += " (recursive)";
+
+    const size_t numFiles = m_Files.GetSize();
+    prettyName.AppendFormat(", files kept: %zu / %zu", numFiles, totalFiles);
+
+    m_PrettyName = prettyName;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h
@@ -26,6 +26,8 @@ public:
 
     virtual bool IsAFile() const override { return false; }
 
+    virtual const AString & GetPrettyName() const override { return m_PrettyName.IsEmpty() ? m_Name : m_PrettyName; }
+
     static void FormatName( const AString & path,
                             const Array< AString > * patterns,
                             bool recursive,
@@ -36,6 +38,8 @@ public:
 
 private:
     virtual BuildResult DoBuild( Job * job ) override;
+
+    void MakePrettyName( const size_t totalFiles );
 
     friend class CompilationDatabase; // For DoBuild - TODO:C This is not ideal
 
@@ -51,6 +55,7 @@ private:
 
     // Internal State
     Array< FileIO::FileInfo > m_Files;
+    AString m_PrettyName;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -170,6 +170,8 @@ public:
 
     const AString & GetName() const { return m_Name; }
 
+    virtual const AString & GetPrettyName() const { return GetName(); }
+
     bool IsHidden() const { return m_Hidden; }
 
     #if defined( DEBUG )

--- a/Code/Tools/FBuild/FBuildCore/Helpers/FBuildStats.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/FBuildStats.cpp
@@ -128,7 +128,7 @@ void FBuildStats::OutputSummary() const
         for ( size_t i=0; i<itemsToDisplay; ++i )
         {
             const Node * n = m_NodesByTime[ i ];
-            output.AppendFormat( "%-9.3f %s\n", (double)( (float)n->GetProcessingTime() / 1000.0f ), n->GetName().Get() );
+            output.AppendFormat( "%-9.3f %s\n", (double)( (float)n->GetProcessingTime() / 1000.0f ), n->GetPrettyName().Get() );
         }
         output += "\n";
     }


### PR DESCRIPTION
- Add a GetPrettyName virtual to Node class, that can be overriden in derived classes if needed
- If not overriden, the pretty will be the name
- Override GetPretttyName in DirectoryListNode