### PR TITLE
"Database has moved" is not an error anymore - it will trigger a recompile

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -1652,7 +1652,8 @@ bool NodeGraph::ReadHeaderAndUsedFiles( IOStream & nodeGraphStream, const char* 
     if ( PathUtils::ArePathsEqual( originalNodeGraphDBFile, nodeGraphDBFileClean ) == false )
     {
         FLOG_WARN( "Database has been moved (originally at '%s', now at '%s').", originalNodeGraphDBFile.Get(), nodeGraphDBFileClean.Get() );
-        return false;
+        compatibleDB = false;
+        return true;
     }
 
     uint32_t numFiles = 0;

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -645,11 +645,10 @@ void TestGraph::DBLocationChanged() const
         TEST_ASSERT( FileIO::FileCopy( dbFile1, dbFile2 ) );
     }
 
-    // Check that the DB in the new location is detected as invalid and the user
-    // is notified appropriately
+    // Check that the DB in the new location doesn't generate any error but verify that the user is notified
     {
         FBuild fBuild( options );
-        TEST_ASSERT( fBuild.Initialize( dbFile2 ) == false );
+        TEST_ASSERT( fBuild.Initialize( dbFile2 ) == true );
         TEST_ASSERT( GetRecordedOutput().Find( "Database has been moved" ) );
     }
 }


### PR DESCRIPTION
Fix unit-test about database move change, now initialize will succeed