### PR TITLE
Added a new 'ExecAlwaysShowOutput' option to ExecNode

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -32,6 +32,7 @@ REFLECT_NODE_BEGIN( ExecNode, Node, MetaName( "ExecOutput" ) + MetaFile() )
     REFLECT(        m_ExecArguments,            "ExecArguments",            MetaOptional() )
     REFLECT(        m_ExecWorkingDir,           "ExecWorkingDir",           MetaOptional() + MetaPath() )
     REFLECT(        m_ExecReturnCode,           "ExecReturnCode",           MetaOptional() )
+    REFLECT(        m_ExecAlwaysShowOutput,     "ExecAlwaysShowOutput",     MetaOptional() )
     REFLECT(        m_ExecUseStdOutAsOutput,    "ExecUseStdOutAsOutput",    MetaOptional() )
     REFLECT(        m_ExecAlways,               "ExecAlways",               MetaOptional() )
     REFLECT_ARRAY(  m_PreBuildDependencyNames,  "PreBuildDependencies",     MetaOptional() + MetaFile() + MetaAllowNonFile() )
@@ -45,6 +46,7 @@ REFLECT_END( ExecNode )
 ExecNode::ExecNode()
     : FileNode( AString::GetEmpty(), Node::FLAG_NONE )
     , m_ExecReturnCode( 0 )
+    , m_ExecAlwaysShowOutput( false )
     , m_ExecUseStdOutAsOutput( false )
     , m_ExecAlways( false )
     , m_ExecInputPathRecurse( true )
@@ -218,6 +220,13 @@ ExecNode::~ExecNode() = default;
 
         FLOG_ERROR( "Execution failed. Error: %s Target: '%s'", ERROR_STR( result ), GetName().Get() );
         return NODE_RESULT_FAILED;
+    }
+
+    // If we want to show output anyway, print it now
+    if ( m_ExecAlwaysShowOutput == true )
+    {
+        Node::DumpOutput(job, memOut.Get(), memOutSize);
+        Node::DumpOutput(job, memErr.Get(), memErrSize);
     }
 
     if ( m_ExecUseStdOutAsOutput == true )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -44,6 +44,7 @@ private:
     AString             m_ExecArguments;
     AString             m_ExecWorkingDir;
     int32_t             m_ExecReturnCode;
+    bool                m_ExecAlwaysShowOutput;
     bool                m_ExecUseStdOutAsOutput;
     bool                m_ExecAlways;
     bool                m_ExecInputPathRecurse;


### PR DESCRIPTION
- This option tells fastbuild to print the output of the execution, even
  if no error occured