### PR TITLE
Set the vs version for the generated fastbuild sln to the matching one

### DIFF
--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -458,6 +458,8 @@ Alias( 'All+Tests' )
         .SolutionBuildProject = 'All-proj'
         .SolutionConfigs    = .ProjectConfigs
 
+        .SolutionVisualStudioVersion = '$VS_SolutionVersion$'
+
         // Work around for Visual Studio F5 behaviour up-to-date check
         .Deps               = [
                                 .Projects = { 'CoreTest-proj', 'FBuildTest-proj', 'FBuildApp-proj', 'FBuildWorker-proj' }

--- a/External/SDK/VisualStudio/VisualStudio.bff
+++ b/External/SDK/VisualStudio/VisualStudio.bff
@@ -16,6 +16,7 @@
     .ToolChain_VS_Windows_X64           = .ToolChain_VS2013_Windows_X64
     .VS_PATH                            = .VS_2013_PATH
     .VS_PlatformToolset                 = .VS_2013_PlatformToolset
+    .VS_SolutionVersion                 = '2013'
 #endif
 #if USING_VS2015
     #include "VS2015.bff"
@@ -23,6 +24,7 @@
     .ToolChain_VS_Windows_X64           = .ToolChain_VS2015_Windows_X64
     .VS_PATH                            = .VS_2015_PATH
     .VS_PlatformToolset                 = .VS_2015_PlatformToolset
+    .VS_SolutionVersion                 = '14'
 #endif
 #if USING_VS2017
     #include "VS2017.bff"
@@ -30,6 +32,7 @@
     .ToolChain_VS_Windows_X64           = .ToolChain_VS2017_Windows_X64
     .VS_PATH                            = .VS_2017_PATH
     .VS_PlatformToolset                 = .VS_2017_PlatformToolset
+    .VS_SolutionVersion                 = '15'
 #endif
 #if USING_VS2019
     #include "VS2019.bff"
@@ -37,6 +40,7 @@
     .ToolChain_VS_Windows_X64           = .ToolChain_VS2019_Windows_X64
     .VS_PATH                            = .VS_2019_PATH
     .VS_PlatformToolset                 = .VS_2019_PlatformToolset
+    .VS_SolutionVersion                 = '16'
 #endif
 
 // Projects


### PR DESCRIPTION
That way, opening the sln with vs selector (default) will open it in the correct ide version