### PR TITLE
Some improvements for Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ install:
   - chmod +x ./${FBUILD}
   # Set up some variables for convenience.
   - |
-  - FBUILD_CMD="../${FBUILD} -noprogress -summary"
+  - FBUILD_CMD="../${FBUILD} -noprogress -nostoponerror -summary"
   - GCC=${GCC:-gcc}
   - GXX=${GCC/gcc/g++}
   - CLANG=${CLANG:-clang}


### PR DESCRIPTION
1. Added option `-nostoponerror` to fbuild invocations to ensure that all tests are run even if one of them fails early.
2. Added workaround for TravisCI timeout based on lack of output from running commands.
    Function `travis_wait` (provided by TravisCI) is not used because its behavior is inferior: it stores all output of the wrapped command in a file and displays it after command finishes.
    Such approach has some problems:
    1. Redirection to the file removes color from the output.
    2. If the wrapped command hangs then its output will not be displayed at all.
3. Option `-summary` is deduplicated and moved into `FBUILD_CMD` variable.