### PR TITLE
Add missing locks around accesses to ClientState

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Protocol/Server.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Server.cpp
@@ -302,6 +302,7 @@ void Server::Process( const ConnectionInfo * connection, const Protocol::MsgConn
 
     // take note of initial status of client
     ClientState * cs = (ClientState *)connection->GetUserData();
+    MutexHolder mh( cs->m_Mutex );
     cs->m_NumJobsAvailable = msg->GetNumJobsAvailable();
     cs->m_HostName = msg->GetHostName();
 }
@@ -312,6 +313,7 @@ void Server::Process( const ConnectionInfo * connection, const Protocol::MsgStat
 {
     // take note of latest status of client
     ClientState * cs = (ClientState *)connection->GetUserData();
+    MutexHolder mh( cs->m_Mutex );
     cs->m_NumJobsAvailable = msg->GetNumJobsAvailable();
 
     // Wake main thread to request jobs


### PR DESCRIPTION
In two places `ClientState` members were modified without grabbing a lock on `ClientState::m_Mutex`. This lead to data race on `m_NumJobsAvailable` between those writes and the reads in `Server::FindNeedyClients`.

This was found by ThreadSanitizer.