### PR TITLE
Check SO_ERROR to determine if connect() was successful on Linux

### DIFF
--- a/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
+++ b/Code/Core/CoreTest/Tests/TestTCPConnectionPool.cpp
@@ -46,6 +46,8 @@ private:
 
     void TestConnectionStuckDuringSend() const;
     static uint32_t TestConnectionStuckDuringSend_ThreadFunc( void * userData );
+
+    void TestConnectionFailure() const;
 };
 
 // Helper Macros
@@ -69,6 +71,7 @@ REGISTER_TESTS_BEGIN( TestTestTCPConnectionPool )
     REGISTER_TEST( TestConnectionCount )
     REGISTER_TEST( TestDataTransfer )
     REGISTER_TEST( TestConnectionStuckDuringSend )
+    REGISTER_TEST( TestConnectionFailure )
 REGISTER_TESTS_END
 
 // TestOneServerMultipleClients
@@ -305,6 +308,20 @@ void TestTestTCPConnectionPool::TestConnectionStuckDuringSend() const
         }
     }
     return 0;
+}
+
+// TestConnectionFailure
+//------------------------------------------------------------------------------
+void TestTestTCPConnectionPool::TestConnectionFailure() const
+{
+    const uint16_t testPort( TEST_PORT );
+
+    TCPConnectionPool client;
+
+    // Check that TCPConnectionPool doesn't create ConnectionInfo when
+    // connection fails after wait for it via select().
+    // To do that we try to connect to our chosen test port without listening on it.
+    TEST_ASSERT( client.Connect( AStackString<>( "127.0.0.1" ), testPort ) == nullptr );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
On Linux `select()` sets a flag in write fd_set both when `connect()` succeeds and when it fails. To determine the result we must get the value of `SO_ERROR` via `getsockopt()`.

Before this change connection attempts to workers that were not running were always treated as successful. For each such attempt a new thread was created and then immediately terminated after a `send()` failure on the non-connected socket.