### PR TITLE
Remove possibility of crash in ShutdownMemoryLeak test

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestDistributed.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestDistributed.cpp
@@ -334,14 +334,18 @@ void TestDistributed::ShutdownMemoryLeak() const
     class Helper
     {
     public:
-        static uint32_t AbortBuild( void * )
+        static uint32_t AbortBuild( void * data )
         {
             // Wait until some distributed jobs are available
             Timer t;
-            while ( Job::GetTotalLocalDataMemoryUsage() == 0 )
+            while ( t.GetElapsed() < 5.0f )
             {
+                if ( Job::GetTotalLocalDataMemoryUsage() != 0 )
+                {
+                    *static_cast< bool * >( data ) = true;
+                    break;
+                }
                 Thread::Sleep( 1 );
-                TEST_ASSERT( t.GetElapsed() < 5.0f ); // Ensure test doesn't hang if broken
             }
 
             // Abort the build
@@ -349,7 +353,8 @@ void TestDistributed::ShutdownMemoryLeak() const
             return 0;
         }
     };
-    Thread::ThreadHandle h = Thread::CreateThread( Helper::AbortBuild );
+    bool detectedDistributedJobs = false;
+    Thread::ThreadHandle h = Thread::CreateThread( Helper::AbortBuild, nullptr, 64 * KILOBYTE, &detectedDistributedJobs );
 
     // Start build and check it was aborted
     TEST_ASSERT( fBuild.Build( AStackString<>( "ShutdownMemoryLeak" ) ) == false );
@@ -357,6 +362,8 @@ void TestDistributed::ShutdownMemoryLeak() const
 
     Thread::WaitForThread( h );
     Thread::CloseHandle( h );
+
+    TEST_ASSERT( detectedDistributedJobs );
 }
 
 // TestZiDebugFormat


### PR DESCRIPTION
`Helper::AbortBuild` waits for distributed jobs to appear and asserts that it happens in a reasonable amount of time. Unfortunately, because that function runs in a separate thread, if that assert fails then the whole process crashes via unhandled exception.

To fix that `AbortBuild` now doesn't perform assertion itself and just sets a flag which is later asserted in the main thread.

This also fixes a highly theoretical race found by ThreadSanitizer:  
Nothing prevents the main thread from sleeping for 5 seconds after it starts the `AbortBuild` thread and then execute `Tracing::AddCallbackOutput` (via `FLog::StartBuild`) while `AbortBuild` thread tries to write output via `TEST_ASSERT`, thus creating a race on `Tracing::s_CallbacksOutput`.