### PR TITLE
Add support for building with ThreadSanitizer and fix minor related issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,22 @@ matrix:
           packages:
             - clang-8
             - llvm-8 # for llvm-symbolizer
+    # Linux, ThreadSanitizer
+    - os: linux
+      env: CFG=tsan CLANG=clang-8
+      # Use latest clang when building with sanitizers.
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-8
+          packages:
+            - clang-8
+            - llvm-8 # for llvm-symbolizer
   allow_failures:
     - env: CFG=asan CLANG=clang-8
     - env: CFG=msan CLANG=clang-8
+    - env: CFG=tsan CLANG=clang-8
   fast_finish: true
 
 install:
@@ -150,6 +163,9 @@ script:
         ;;
       linux:msan)
         ${FBUILD_CMD} {CoreTest,FBuildTest}-RunTest-x64ClangLinux-MSan
+        ;;
+      linux:tsan)
+        ${FBUILD_CMD} {CoreTest,FBuildTest}-RunTest-x64ClangLinux-TSan
         ;;
     esac
   # Check non-unity build.

--- a/Code/Core/CoreTest/Tests/TestAtomic.cpp
+++ b/Code/Core/CoreTest/Tests/TestAtomic.cpp
@@ -72,11 +72,15 @@ private:
 
     // Add
     void Add32() const;
+    void AddU32() const;
     void Add64() const;
+    void AddU64() const;
 
     // Sub
     void Sub32() const;
+    void SubU32() const;
     void Sub64() const;
+    void SubU64() const;
 };
 
 // Register Tests
@@ -109,7 +113,16 @@ void TestAtomic::Add32() const
 {
     // Ensure return result is post-add
     int32_t i32 = 0;
-    TEST_ASSERT( AtomicAdd32( &i32, 999 ) == 999 );
+    TEST_ASSERT( AtomicAdd32( &i32, -999 ) == -999 );
+}
+
+// AddU32
+//------------------------------------------------------------------------------
+void TestAtomic::AddU32() const
+{
+    // Ensure return result is post-add
+    uint32_t u32 = 0;
+    TEST_ASSERT( AtomicAddU32( &u32, 999 ) == 999 );
 }
 
 // Add64
@@ -118,7 +131,16 @@ void TestAtomic::Add64() const
 {
     // Ensure return result is post-add
     int64_t i64 = 0;
-    TEST_ASSERT( AtomicAdd64( &i64, 999 ) == 999 );
+    TEST_ASSERT( AtomicAdd64( &i64, -9876543210 ) == -9876543210 );
+}
+
+// AddU64
+//------------------------------------------------------------------------------
+void TestAtomic::AddU64() const
+{
+    // Ensure return result is post-add
+    uint64_t u64 = 0;
+    TEST_ASSERT( AtomicAddU64( &u64, 9876543210 ) == 9876543210 );
 }
 
 // Sub32
@@ -126,8 +148,17 @@ void TestAtomic::Add64() const
 void TestAtomic::Sub32() const
 {
     // Ensure return result is post-sub
-    int32_t i32 = 999;
-    TEST_ASSERT( AtomicSub32( &i32, 999 ) == 0 );
+    int32_t i32 = 0;
+    TEST_ASSERT( AtomicSub32( &i32, 999 ) == -999 );
+}
+
+// SubU32
+//------------------------------------------------------------------------------
+void TestAtomic::SubU32() const
+{
+    // Ensure return result is post-sub
+    uint32_t u32 = 999;
+    TEST_ASSERT( AtomicSubU32( &u32, 999 ) == 0 );
 }
 
 // Sub64
@@ -135,8 +166,17 @@ void TestAtomic::Sub32() const
 void TestAtomic::Sub64() const
 {
     // Ensure return result is post-sub
-    int64_t i64 = 999;
-    TEST_ASSERT( AtomicSub64( &i64, 999 ) == 0 );
+    int64_t i64 = 0;
+    TEST_ASSERT( AtomicSub64( &i64, 9876543210 ) == -9876543210 );
+}
+
+// SubU64
+//------------------------------------------------------------------------------
+void TestAtomic::SubU64() const
+{
+    // Ensure return result is post-sub
+    uint64_t u64 = 9876543210;
+    TEST_ASSERT( AtomicSubU64( &u64, 9876543210 ) == 0 );
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Core/CoreTest/Tests/TestMutex.cpp
+++ b/Code/Core/CoreTest/Tests/TestMutex.cpp
@@ -6,6 +6,7 @@
 #include "TestFramework/UnitTest.h"
 
 #include "Core/Mem/Mem.h"
+#include "Core/Process/Atomic.h"
 #include "Core/Process/Mutex.h"
 #include "Core/Process/Thread.h"
 
@@ -24,7 +25,8 @@ private:
     struct TestExclusivityUserData
     {
         Mutex m_Mutex;
-        volatile uint32_t m_Count;
+        uint32_t m_Count;
+        volatile uint32_t m_BarrierCounter;
     };
     static uint32_t TestExclusivityThreadEntryFunction( void * userData );
 
@@ -84,21 +86,22 @@ void TestMutex::TestExclusivity() const
 {
     TestExclusivityUserData data;
     data.m_Count = 0;
+    data.m_BarrierCounter = 0;
 
     Thread::ThreadHandle h = Thread::CreateThread( TestExclusivityThreadEntryFunction,
                                                    "TestExclusivity",
                                                    ( 64 * KILOBYTE ),
                                                    static_cast< void * >( &data ) );
 
-    // signal thread
-    volatile uint32_t & sharedVar = data.m_Count;
-    ++sharedVar;
+    // arrive at barrier and wait
+    AtomicIncU32( &data.m_BarrierCounter );
+    while ( AtomicLoadAcquire( &data.m_BarrierCounter ) != 2 ) {}
 
     // increment
     for ( size_t i=0; i<1000000; ++i )
     {
         MutexHolder mh( data.m_Mutex );
-        ++sharedVar;
+        ++data.m_Count;
     }
 
     // wait for other thread to complete
@@ -108,7 +111,7 @@ void TestMutex::TestExclusivity() const
     Thread::CloseHandle( h );
 
     // ensure total is correct
-    TEST_ASSERT( sharedVar == 2000001 );
+    TEST_ASSERT( data.m_Count == 2000000 );
 }
 
 // TestExclusivityThreadEntryFunction
@@ -116,16 +119,16 @@ void TestMutex::TestExclusivity() const
 /*static*/ uint32_t TestMutex::TestExclusivityThreadEntryFunction( void * userData )
 {
     TestExclusivityUserData & data = *( static_cast< TestExclusivityUserData * >( userData ) );
-    volatile uint32_t & sharedVar = data.m_Count;
 
-    // wait for start notification
-    while ( sharedVar == 0 ) {}
+    // arrive at barrier and wait
+    AtomicIncU32( &data.m_BarrierCounter );
+    while ( AtomicLoadAcquire( &data.m_BarrierCounter ) != 2 ) {}
 
     // increment
     for ( size_t i=0; i<1000000; ++i )
     {
         MutexHolder mh( data.m_Mutex );
-        ++sharedVar;
+        ++data.m_Count;
     }
 
     return 0;

--- a/Code/Core/Env/Env.cpp
+++ b/Code/Core/Env/Env.cpp
@@ -8,6 +8,7 @@
 // Core
 #include "Core/Containers/Array.h"
 #include "Core/Strings/AStackString.h"
+#include "Core/Process/Atomic.h"
 
 #if defined( __WINDOWS__ )
     #include "Core/Env/WindowsHeader.h"
@@ -315,17 +316,17 @@ static bool IsStdOutRedirectedInternal()
 /*static*/ bool Env::IsStdOutRedirected( const bool recheck )
 {
     static volatile int32_t sCachedResult = 0; // 0 - not checked, 1 - true, 2 - false
-    const int32_t result = sCachedResult;
+    const int32_t result = AtomicLoadRelaxed( &sCachedResult );
     if ( recheck || ( result == 0 ) )
     {
         if ( IsStdOutRedirectedInternal() )
         {
-            sCachedResult = 1;
+            AtomicStoreRelaxed( &sCachedResult, 1 );
             return true;
         }
         else
         {
-            sCachedResult = 2;
+            AtomicStoreRelaxed( &sCachedResult, 2 );
             return false;
         }
     }

--- a/Code/Core/Mem/Mem.cpp
+++ b/Code/Core/Mem/Mem.cpp
@@ -109,7 +109,7 @@ void Free( void * ptr )
     void operator delete( void * ptr, const char *, int ) { Free( ptr ); }
     void operator delete[]( void * ptr, const char *, int ) { Free( ptr ); }
 #endif
-#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !defined( __SANITIZE_ADDRESS__ )
+#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !__has_feature( thread_sanitizer ) && !defined( __SANITIZE_ADDRESS__ )
 void * operator new( size_t size ) { return Alloc( size ); }
 void * operator new[]( size_t size ) { return Alloc( size ); }
 void operator delete( void * ptr ) NOEXCEPT { Free( ptr ); }

--- a/Code/Core/Mem/Mem.h
+++ b/Code/Core/Mem/Mem.h
@@ -54,7 +54,7 @@ void Free( void * ptr );
 #if !defined( __has_feature )
     #define __has_feature( ... ) 0
 #endif
-#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !defined( __SANITIZE_ADDRESS__ )
+#if !__has_feature( address_sanitizer ) && !__has_feature( memory_sanitizer ) && !__has_feature( thread_sanitizer ) && !defined( __SANITIZE_ADDRESS__ )
 void * operator new( size_t size );
 void * operator new[]( size_t size );
 void operator delete( void * ptr ) NOEXCEPT;

--- a/Code/Core/Mem/SmallBlockAllocator.cpp
+++ b/Code/Core/Mem/SmallBlockAllocator.cpp
@@ -250,7 +250,7 @@ bool SmallBlockAllocator::Free( void * ptr )
 /*virtual*/ void * SmallBlockAllocator::MemBucket::AllocateMemoryForPage()
 {
     // Have we exhausted our page space?
-    if ( SmallBlockAllocator::s_BucketNextFreePageIndex >= BUCKET_NUM_PAGES )
+    if ( AtomicLoadRelaxed( &SmallBlockAllocator::s_BucketNextFreePageIndex ) >= BUCKET_NUM_PAGES )
     {
         return nullptr;
     }

--- a/Code/Core/Network/NetworkStartupHelper.cpp
+++ b/Code/Core/Network/NetworkStartupHelper.cpp
@@ -6,6 +6,7 @@
 #include "NetworkStartupHelper.h"
 
 #include "Core/Env/Assert.h"
+#include "Core/Process/Atomic.h"
 
 //------------------------------------------------------------------------------
 // Static Data
@@ -56,7 +57,7 @@ NetworkStartupHelper::NetworkStartupHelper()
 /*static*/ bool NetworkStartupHelper::IsShuttingDown()
 {
     MutexHolder mh( s_Mutex );
-    return ( s_MasterShutdownFlag ) ? ( *s_MasterShutdownFlag ) : false;
+    return ( s_MasterShutdownFlag ) ? AtomicLoadRelaxed( s_MasterShutdownFlag ) : false;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Network/TCPConnectionPool.cpp
+++ b/Code/Core/Network/TCPConnectionPool.cpp
@@ -10,6 +10,7 @@
 #include "Core/Env/ErrorFormat.h"
 #include "Core/Mem/Mem.h"
 #include "Core/Network/Network.h"
+#include "Core/Process/Atomic.h"
 #include "Core/Strings/AString.h"
 #include "Core/Strings/AStackString.h"
 #include "Core/Profile/Profile.h"
@@ -81,7 +82,7 @@ TCPConnectionPool::~TCPConnectionPool()
     // as virtual callbacks in derived classes make it unsafe to do so here.
     // By enforcing explicit shutdown, even when not strictly needed, we can
     // ensure no unsafe cases exist (and can assert below)
-    ASSERT( m_ShuttingDown && "ShutdownAllConnections not called");
+    ASSERT( AtomicLoadRelaxed( &m_ShuttingDown ) && "ShutdownAllConnections not called");
 }
 
 // ShutdownAllConnections
@@ -90,7 +91,7 @@ void TCPConnectionPool::ShutdownAllConnections()
 {
     PROFILE_FUNCTION
 
-    m_ShuttingDown = true;
+    AtomicStoreRelaxed( &m_ShuttingDown, true );
 
     m_ConnectionsMutex.Lock();
 
@@ -280,7 +281,7 @@ const ConnectionInfo * TCPConnectionPool::Connect( uint32_t hostIP, uint16_t por
         if ( selRet == 0 )
         {
             // are we shutting down?
-            if ( m_ShuttingDown )
+            if ( AtomicLoadRelaxed( &m_ShuttingDown ) )
             {
                 #ifdef TCPCONNECTION_DEBUG
                     AStackString<> host;
@@ -385,20 +386,27 @@ void TCPConnectionPool::Disconnect( const ConnectionInfo * ci )
 
     if ( ci == m_ListenConnection )
     {
-        ci->m_ThreadQuitNotification = true;
+        AtomicStoreRelease( &ci->m_ThreadQuitNotification, true );
         return;
     }
 
     ConnectionInfo ** iter = m_Connections.Find( ci );
     if ( iter != nullptr )
     {
-        ci->m_ThreadQuitNotification = true;
+        AtomicStoreRelease( &ci->m_ThreadQuitNotification, true );
         return;
     }
 
     // connection is no longer valid.... we handle this gracefully
     // as the connection might be lost while trying to disconnect
     // on another thread
+}
+
+// SetShuttingDown
+//------------------------------------------------------------------------------
+void TCPConnectionPool::SetShuttingDown()
+{
+    AtomicStoreRelaxed( &m_ShuttingDown, true );
 }
 
 // GetNumConnections
@@ -462,7 +470,7 @@ bool TCPConnectionPool::SendInternal( const ConnectionInfo * connection, const T
     ASSERT( connection );
 
     // closing connection, possibly from a previous failure
-    if ( connection->m_ThreadQuitNotification || m_ShuttingDown )
+    if ( AtomicLoadAcquire( &connection->m_ThreadQuitNotification ) || AtomicLoadRelaxed( &m_ShuttingDown ) )
     {
         return false;
     }
@@ -534,7 +542,7 @@ bool TCPConnectionPool::SendInternal( const ConnectionInfo * connection, const T
         {
             if ( WouldBlock() )
             {
-                if ( connection->m_ThreadQuitNotification || m_ShuttingDown )
+                if ( AtomicLoadAcquire( &connection->m_ThreadQuitNotification ) || AtomicLoadRelaxed( &m_ShuttingDown ) )
                 {
                     sendOK = false;
                     break;
@@ -613,7 +621,7 @@ bool TCPConnectionPool::HandleRead( ConnectionInfo * ci )
         {
             if ( WouldBlock() )
             {
-                if ( ci->m_ThreadQuitNotification || m_ShuttingDown )
+                if ( AtomicLoadAcquire( &ci->m_ThreadQuitNotification ) || AtomicLoadRelaxed( &m_ShuttingDown ) )
                 {
                     return false;
                 }
@@ -643,7 +651,7 @@ bool TCPConnectionPool::HandleRead( ConnectionInfo * ci )
         {
             if ( WouldBlock() )
             {
-                if ( ci->m_ThreadQuitNotification || m_ShuttingDown )
+                if ( AtomicLoadAcquire( &ci->m_ThreadQuitNotification ) || AtomicLoadRelaxed( &m_ShuttingDown ) )
                 {
                     FreeBuffer( buffer );
                     return false;
@@ -834,7 +842,7 @@ void TCPConnectionPool::ListenThreadFunction( ConnectionInfo * ci )
     struct sockaddr_in remoteAddrInfo;
     int remoteAddrInfoSize = sizeof( remoteAddrInfo );
 
-    while ( ci->m_ThreadQuitNotification == false )
+    while ( AtomicLoadAcquire( &ci->m_ThreadQuitNotification ) == false )
     {
         // timout for select() operations
         // (modified by select, so we must recreate it)
@@ -967,7 +975,7 @@ void TCPConnectionPool::ConnectionThreadFunction( ConnectionInfo * ci )
     OnConnected( ci ); // Do callback
 
     // process socket events
-    while ( ci->m_ThreadQuitNotification == false )
+    while ( AtomicLoadAcquire( &ci->m_ThreadQuitNotification ) == false )
     {
         // timout for select() operations
         // (modified by select, so we must recreate it)
@@ -994,7 +1002,7 @@ void TCPConnectionPool::ConnectionThreadFunction( ConnectionInfo * ci )
             continue;
         }
 
-        if ( ci->m_ThreadQuitNotification == true )
+        if ( AtomicLoadAcquire( &ci->m_ThreadQuitNotification ) )
         {
             break; // don't bother reading any pending data if shutting down
         }

--- a/Code/Core/Network/TCPConnectionPool.h
+++ b/Code/Core/Network/TCPConnectionPool.h
@@ -69,7 +69,7 @@ public:
     const ConnectionInfo * Connect( const AString & host, uint16_t port, uint32_t timeout = 2000, void * userData = nullptr );
     const ConnectionInfo * Connect( uint32_t hostIP, uint16_t port, uint32_t timeout = 2000, void * userData = nullptr );
     void Disconnect( const ConnectionInfo * ci );
-    void SetShuttingDown() { m_ShuttingDown = true; }
+    void SetShuttingDown();
 
     // query connection state
     size_t GetNumConnections() const;

--- a/Code/Core/Process/Atomic.h
+++ b/Code/Core/Process/Atomic.h
@@ -180,7 +180,23 @@ inline int32_t AtomicAdd32( volatile int32_t * i, int32_t value )
         return __sync_add_and_fetch( i, value );
     #endif
 }
+inline uint32_t AtomicAddU32( volatile uint32_t * i, int32_t value )
+{
+    #if defined( __WINDOWS__ )
+        return InterlockedAdd( (volatile long *)i, value );
+    #elif defined( __APPLE__ ) || defined( __LINUX__ )
+        return __sync_add_and_fetch( i, value );
+    #endif
+}
 inline int32_t AtomicSub32( volatile int32_t * i, int32_t value )
+{
+    #if defined( __WINDOWS__ )
+        return InterlockedAdd( (volatile long *)i, -value );
+    #elif defined( __APPLE__ ) || defined( __LINUX__ )
+        return __sync_sub_and_fetch( i, value );
+    #endif
+}
+inline uint32_t AtomicSubU32( volatile uint32_t * i, int32_t value )
 {
     #if defined( __WINDOWS__ )
         return InterlockedAdd( (volatile long *)i, -value );
@@ -299,7 +315,7 @@ inline uint64_t AtomicDecU64( volatile uint64_t * i )
         return __sync_sub_and_fetch( i, 1 );
     #endif
 }
-inline int64_t AtomicAdd64( volatile int64_t * i, int32_t value )
+inline int64_t AtomicAdd64( volatile int64_t * i, int64_t value )
 {
     #if defined( __WINDOWS__ )
         return InterlockedAdd64( (volatile LONG64 *)i, value );
@@ -307,7 +323,23 @@ inline int64_t AtomicAdd64( volatile int64_t * i, int32_t value )
         return __sync_add_and_fetch( i, value );
     #endif
 }
-inline int64_t AtomicSub64( volatile int64_t * i, int32_t value )
+inline uint64_t AtomicAddU64( volatile uint64_t * i, int64_t value )
+{
+    #if defined( __WINDOWS__ )
+        return InterlockedAdd64( (volatile LONG64 *)i, value );
+    #elif defined( __APPLE__ ) || defined( __LINUX__ )
+        return __sync_add_and_fetch( i, value );
+    #endif
+}
+inline int64_t AtomicSub64( volatile int64_t * i, int64_t value )
+{
+    #if defined( __WINDOWS__ )
+        return InterlockedAdd64( (volatile LONG64 *)i, -value );
+    #elif defined( __APPLE__ ) || defined( __LINUX__ )
+        return __sync_sub_and_fetch( i, value );
+    #endif
+}
+inline uint64_t AtomicSubU64( volatile uint64_t * i, int64_t value )
 {
     #if defined( __WINDOWS__ )
         return InterlockedAdd64( (volatile LONG64 *)i, -value );

--- a/Code/Core/Process/Atomic.h
+++ b/Code/Core/Process/Atomic.h
@@ -7,7 +7,136 @@
 #include "Core/Env/Types.h"
 #if defined( __WINDOWS__ )
     #include "Core/Env/WindowsHeader.h"
+    #include <intrin.h>
 #endif
+
+// bool
+//------------------------------------------------------------------------------
+inline bool AtomicLoadRelaxed( const volatile bool * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            return *x;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline bool AtomicLoadAcquire( const volatile bool * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_ACQUIRE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            bool value = *x;
+            _ReadWriteBarrier();
+            return value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelaxed( volatile bool * x, bool value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelease( volatile bool * x, bool value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELEASE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            _ReadWriteBarrier();
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+
+// Pointers
+//------------------------------------------------------------------------------
+template < class T >
+inline T * AtomicLoadRelaxed( T * const volatile * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            return *x;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+template < class T >
+inline T * AtomicLoadAcquire( T * const volatile * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_ACQUIRE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            T * value = *x;
+            _ReadWriteBarrier();
+            return value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+template < class T >
+inline void AtomicStoreRelaxed( T * volatile * x, T * value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+template < class T >
+inline void AtomicStoreRelease( T * volatile * x, T * value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELEASE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            _ReadWriteBarrier();
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
 
 // 32bit
 //------------------------------------------------------------------------------
@@ -60,6 +189,82 @@ inline int32_t AtomicSub32( volatile int32_t * i, int32_t value )
     #endif
 }
 
+inline int32_t AtomicLoadRelaxed( const volatile int32_t * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            return *x;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline uint32_t AtomicLoadRelaxed( const volatile uint32_t * x )
+{
+    return static_cast< uint32_t >( AtomicLoadRelaxed( reinterpret_cast< const volatile int32_t * >( x ) ) );
+}
+inline int32_t AtomicLoadAcquire( const volatile int32_t * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_ACQUIRE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined( _M_IX86 )
+            int32_t value = *x;
+            _ReadWriteBarrier();
+            return value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline uint32_t AtomicLoadAcquire( const volatile uint32_t * x )
+{
+    return static_cast< uint32_t >( AtomicLoadAcquire( reinterpret_cast< const volatile int32_t * >( x ) ) );
+}
+inline void AtomicStoreRelaxed( volatile int32_t * x, int32_t value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelaxed( volatile uint32_t * x, uint32_t value )
+{
+    AtomicStoreRelaxed( reinterpret_cast< volatile int32_t * >( x ), static_cast< int32_t >( value ) );
+}
+inline void AtomicStoreRelease( volatile int32_t * x, int32_t value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELEASE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 ) || defined ( _M_IX86 )
+            _ReadWriteBarrier();
+            *x = value;
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelease( volatile uint32_t * x, uint32_t value )
+{
+    AtomicStoreRelease( reinterpret_cast< volatile int32_t * >( x ), static_cast< int32_t >( value ) );
+}
+
 // 64bit
 //------------------------------------------------------------------------------
 inline int64_t AtomicInc64( volatile int64_t * i )
@@ -109,6 +314,90 @@ inline int64_t AtomicSub64( volatile int64_t * i, int32_t value )
     #elif defined( __APPLE__ ) || defined( __LINUX__ )
         return __sync_sub_and_fetch( i, value );
     #endif
+}
+
+inline int64_t AtomicLoadRelaxed( const volatile int64_t * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 )
+            return *x;
+        #elif defined( _M_IX86 )
+            return _InterlockedOr64( x, 0 );
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline uint64_t AtomicLoadRelaxed( const volatile uint64_t * x )
+{
+    return static_cast< uint64_t >( AtomicLoadRelaxed( reinterpret_cast< const volatile int64_t * >( x ) ) );
+}
+inline int64_t AtomicLoadAcquire( const volatile int64_t * x )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_load_n( x, __ATOMIC_ACQUIRE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 )
+            int64_t value = *x;
+            _ReadWriteBarrier();
+            return value;
+        #elif defined( _M_IX86 )
+            return _InterlockedOr64( x, 0 );
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline uint64_t AtomicLoadAcquire( const volatile uint64_t * x )
+{
+    return static_cast< uint64_t >( AtomicLoadAcquire( reinterpret_cast< const volatile int64_t * >( x ) ) );
+}
+inline void AtomicStoreRelaxed( volatile int64_t * x, int64_t value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELAXED );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 )
+            *x = value;
+        #elif defined ( _M_IX86 )
+            _InterlockedExchange64( x, value );
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelaxed( volatile uint64_t * x, uint64_t value )
+{
+    AtomicStoreRelaxed( reinterpret_cast< volatile int64_t * >( x ), static_cast< int64_t >( value ) );
+}
+inline void AtomicStoreRelease( volatile int64_t * x, int64_t value )
+{
+    #if defined( __GNUC__ ) || defined( __clang__ )
+        __atomic_store_n( x, value, __ATOMIC_RELEASE );
+    #elif defined( _MSC_VER )
+        #if defined( _M_X64 )
+            _ReadWriteBarrier();
+            *x = value;
+        #elif defined ( _M_IX86 )
+            _InterlockedExchange64( x, value );
+        #else
+            #error Unknown architecture
+        #endif
+    #else
+        #error Unknown compiler
+    #endif
+}
+inline void AtomicStoreRelease( volatile uint64_t * x, uint64_t value )
+{
+    AtomicStoreRelease( reinterpret_cast< volatile int64_t * >( x ), static_cast< int64_t >( value ) );
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -8,6 +8,7 @@
 #include "Core/Env/Assert.h"
 #include "Core/FileIO/FileIO.h"
 #include "Core/Math/Conversions.h"
+#include "Core/Process/Atomic.h"
 #include "Core/Process/Thread.h"
 #include "Core/Profile/Profile.h"
 #include "Core/Time/Timer.h"
@@ -176,7 +177,7 @@ bool Process::Spawn( const char * executable,
     ASSERT( !m_Started );
     ASSERT( executable );
 
-    if ( m_MasterAbortFlag && ( *m_MasterAbortFlag ) )
+    if ( m_MasterAbortFlag && AtomicLoadRelaxed( m_MasterAbortFlag ) )
     {
         // Once master process has aborted, we no longer permit spawning sub-processes.
         return false;
@@ -576,8 +577,8 @@ bool Process::ReadAllData( AutoPtr< char > & outMem, uint32_t * outMemSize,
     bool processExited = false;
     for ( ;; )
     {
-        const bool masterAbort = ( m_MasterAbortFlag && ( *m_MasterAbortFlag ) );
-        const bool abort = ( m_AbortFlag && ( *m_AbortFlag ) );
+        const bool masterAbort = ( m_MasterAbortFlag && AtomicLoadRelaxed( m_MasterAbortFlag ) );
+        const bool abort = ( m_AbortFlag && AtomicLoadRelaxed( m_AbortFlag ) );
         if ( abort || masterAbort )
         {
             PROFILE_SECTION( "Abort" )

--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -218,6 +218,11 @@ public:
         ASSERT( false ); // invalid thread handle
         timedOut = false;
         return -1;
+    #elif __has_feature( thread_sanitizer ) || defined( __SANITIZE_THREAD__ )
+        // ThreadSanitizer doesn't support pthread_timedjoin_np yet (as of February 2018)
+        timedOut = false;
+        (void)timeoutMS;
+        return WaitForThread( handle );
     #elif defined( __APPLE__ )
         timedOut = false;
         (void)timeoutMS; // TODO:MAC Implement timeout support

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -33,6 +33,7 @@
 #include "Core/FileIO/MemoryStream.h"
 #include "Core/Math/xxHash.h"
 #include "Core/Mem/SmallBlockAllocator.h"
+#include "Core/Process/Atomic.h"
 #include "Core/Process/SystemMutex.h"
 #include "Core/Profile/Profile.h"
 #include "Core/Strings/AStackString.h"
@@ -361,8 +362,8 @@ bool FBuild::Build( Node * nodeToBuild )
 {
     ASSERT( nodeToBuild );
 
-    s_StopBuild = false; // allow multiple runs in same process
-    s_AbortBuild = false; // allow multiple runs in same process
+    AtomicStoreRelaxed( &s_StopBuild, false ); // allow multiple runs in same process
+    AtomicStoreRelaxed( &s_AbortBuild, false ); // allow multiple runs in same process
 
     // create worker threads
     m_JobQueue = FNEW( JobQueue( m_Options.m_NumWorkerThreads ) );
@@ -433,7 +434,7 @@ bool FBuild::Build( Node * nodeToBuild )
         bool complete = ( nodeToBuild->GetState() == Node::UP_TO_DATE ) ||
                         ( nodeToBuild->GetState() == Node::FAILED );
 
-        if ( s_StopBuild || complete )
+        if ( AtomicLoadRelaxed( &s_StopBuild ) || complete )
         {
             if ( stopping == false )
             {
@@ -449,7 +450,7 @@ bool FBuild::Build( Node * nodeToBuild )
                 if ( m_Options.m_FastCancel )
                 {
                     // Notify the system that the master process has been killed and that it can kill its process.
-                    s_AbortBuild = true;
+                    AtomicStoreRelaxed( &s_AbortBuild, true );
                 }
             }
         }
@@ -588,11 +589,11 @@ void FBuild::GetLibEnvVar( AString & value ) const
 //------------------------------------------------------------------------------
 void FBuild::AbortBuild()
 {
-    s_StopBuild = true;
+    AtomicStoreRelaxed( &s_StopBuild, true );
     if ( FBuild::IsValid() && FBuild::Get().m_Options.m_FastCancel )
     {
         // Notify the system that the master process has been killed and that it can kill its process.
-        s_AbortBuild = true;
+        AtomicStoreRelaxed( &s_AbortBuild, true );
     }
 }
 
@@ -604,6 +605,13 @@ void FBuild::AbortBuild()
     {
         AbortBuild();
     }
+}
+
+// GetStopBuild
+//------------------------------------------------------------------------------
+/*static*/ bool FBuild::GetStopBuild()
+{
+    return AtomicLoadRelaxed( &s_StopBuild );
 }
 
 // UpdateBuildStatus

--- a/Code/Tools/FBuild/FBuildCore/FBuild.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.h
@@ -93,7 +93,7 @@ public:
     // attempt to cleanly stop the build
     static        void AbortBuild();
     static        void OnBuildError();
-    static inline bool GetStopBuild() { return s_StopBuild; }
+    static        bool GetStopBuild();
     static inline volatile bool * GetAbortBuildPointer() { return &s_AbortBuild; }
 
     inline ICache * GetCache() const { return m_Cache; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -45,6 +45,7 @@
 #include "Core/FileIO/IOStream.h"
 #include "Core/FileIO/PathUtils.h"
 #include "Core/Math/CRC32.h"
+#include "Core/Process/Atomic.h"
 #include "Core/Process/Mutex.h"
 #include "Core/Profile/Profile.h"
 #include "Core/Reflection/ReflectedProperty.h"
@@ -332,6 +333,20 @@ bool Node::DetermineNeedToBuild( bool forceClean ) const
     // Couldn't delete the file
     FLOG_ERROR( "Failed to delete file before build '%s'", fileName.Get() );
     return false;
+}
+
+// GetLastBuildTime
+//------------------------------------------------------------------------------
+uint32_t Node::GetLastBuildTime() const
+{
+    return AtomicLoadRelaxed( &m_LastBuildTimeMs );
+}
+
+// SetLastBuildTime
+//------------------------------------------------------------------------------
+void Node::SetLastBuildTime( uint32_t ms )
+{
+    AtomicStoreRelaxed( &m_LastBuildTimeMs, ms );
 }
 
 // CreateNode

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -136,7 +136,7 @@ public:
     inline bool GetStatFlag( StatsFlag flag ) const { return ( ( m_StatsFlags & flag ) != 0 ); }
     inline void SetStatFlag( StatsFlag flag ) const { m_StatsFlags |= flag; }
 
-    inline uint32_t GetLastBuildTime() const    { return m_LastBuildTimeMs; }
+    uint32_t GetLastBuildTime() const;
     inline uint32_t GetProcessingTime() const   { return m_ProcessingTime; }
     inline uint32_t GetCachingTime() const      { return m_CachingTime; }
     inline uint32_t GetRecursiveCost() const    { return m_RecursiveCost; }
@@ -217,7 +217,7 @@ protected:
     virtual BuildResult DoBuild2( Job * job, bool racingRemoteJob );
     virtual bool Finalize( NodeGraph & nodeGraph );
 
-    inline void     SetLastBuildTime( uint32_t ms )   { m_LastBuildTimeMs = ms; }
+    void SetLastBuildTime( uint32_t ms );
     inline void     AddProcessingTime( uint32_t ms )  { m_ProcessingTime += ms; }
     inline void     AddCachingTime( uint32_t ms )     { m_CachingTime += ms; }
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
@@ -58,7 +58,7 @@ void Job::Cancel()
 {
     ASSERT( m_IsLocal ); // Cancellation should only occur locally
     ASSERT( m_Abort == false ); // Job must be not already be cancelled
-    m_Abort = true;
+    AtomicStoreRelaxed( &m_Abort, true );
 }
 
 // OwnData
@@ -235,6 +235,13 @@ void Job::GetMessagesForMonitorLog( AString & buffer ) const
     buffer.Replace( '\n', (char)12 );
     buffer.Replace( '\r', (char)12 );
     buffer.Replace( '\"', '\'' ); // TODO:B The monitor can't differentiate ' and "
+}
+
+// GetTotalLocalDataMemoryUsage
+//------------------------------------------------------------------------------
+/*static*/ uint64_t Job::GetTotalLocalDataMemoryUsage()
+{
+    return (uint64_t)AtomicLoadRelaxed( &s_TotalLocalDataMemoryUsage );
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
@@ -88,7 +88,7 @@ public:
     inline DistributionState    GetDistributionState() const                    { return m_DistributionState; }
 
     // Access total memory usage by job data
-    static inline uint64_t      GetTotalLocalDataMemoryUsage() { return (uint64_t)s_TotalLocalDataMemoryUsage; }
+    static uint64_t             GetTotalLocalDataMemoryUsage();
 
 private:
     uint32_t            m_JobId             = 0;

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
@@ -42,7 +42,14 @@ JobSubQueue::JobSubQueue()
 JobSubQueue::~JobSubQueue()
 {
     ASSERT( m_Jobs.IsEmpty() );
-    ASSERT( m_Count == 0 );
+    ASSERT( AtomicLoadRelaxed( &m_Count ) == 0 );
+}
+
+// GetCount
+//------------------------------------------------------------------------------
+uint32_t JobSubQueue::GetCount() const
+{
+    return AtomicLoadRelaxed( &m_Count );
 }
 
 // JobSubQueue:QueueJobs
@@ -66,7 +73,7 @@ void JobSubQueue::QueueJobs( Array< Node * > & nodes )
     const bool wasEmpty = m_Jobs.IsEmpty();
 
     m_Jobs.Append( jobs );
-    m_Count += (uint32_t)jobs.GetSize();
+    AtomicAddU32( &m_Count, (uint32_t)jobs.GetSize() );
 
     if ( wasEmpty )
     {
@@ -82,7 +89,7 @@ void JobSubQueue::QueueJobs( Array< Node * > & nodes )
 Job * JobSubQueue::RemoveJob()
 {
     // lock-free early out if there are no jobs
-    if ( m_Count == 0 )
+    if ( AtomicLoadRelaxed( &m_Count ) == 0 )
     {
         return nullptr;
     }
@@ -96,8 +103,7 @@ Job * JobSubQueue::RemoveJob()
         return nullptr;
     }
 
-    ASSERT( m_Count );
-    --m_Count;
+    VERIFY( AtomicDecU32( &m_Count ) != static_cast< uint32_t >( -1 ) );
 
     Job * job = m_Jobs.Top();
     m_Jobs.Pop();
@@ -220,7 +226,7 @@ void JobQueue::GetJobStats( uint32_t & numJobs,
 
     numJobs = m_LocalJobs_Available.GetCount();
     numJobsDist = (uint32_t)m_DistributableJobs_Available.GetSize();
-    numJobsActive = m_NumLocalJobsActive;
+    numJobsActive = AtomicLoadRelaxed( &m_NumLocalJobsActive );
     numJobsDistActive = (uint32_t)m_DistributableJobs_InProgress.GetSize();
 }
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.h
@@ -26,7 +26,7 @@ public:
     JobSubQueue();
     ~JobSubQueue();
 
-    inline uint32_t GetCount() const { return m_Count; }
+    uint32_t GetCount() const;
 
     // jobs pushed by the main thread
     void QueueJobs( Array< Node * > & nodes );

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.h
@@ -25,8 +25,8 @@ public:
 
     static void InitTmpDir( bool remote = false );
 
-    inline void Stop()              { m_ShouldExit = true; }
-    inline bool HasExited() const   { return m_Exited; }
+    void Stop();
+    bool HasExited() const;
     void WaitForStop();
 
     static uint32_t GetThreadIndex();

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThreadRemote.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThreadRemote.cpp
@@ -13,6 +13,7 @@
 #include "Tools/FBuild/FBuildCore/Protocol/Server.h"
 #include "Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.h"
 
+#include "Core/Process/Atomic.h"
 #include "Core/Process/Thread.h"
 #include "Core/Time/Timer.h"
 
@@ -37,7 +38,7 @@ WorkerThreadRemote::~WorkerThreadRemote()
 //------------------------------------------------------------------------------
 /*virtual*/ void WorkerThreadRemote::Main()
 {
-    while ( m_ShouldExit == false )
+    while ( AtomicLoadRelaxed( &m_ShouldExit ) == false )
     {
         if ( IsEnabled() == false )
         {
@@ -70,7 +71,7 @@ WorkerThreadRemote::~WorkerThreadRemote()
         }
     }
 
-    m_Exited = true;
+    AtomicStoreRelaxed( &m_Exited, true );
 
     m_MainThreadWaitForExit.Signal();
 }

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -87,6 +87,16 @@ Settings
 
     .BuildConfigName                = 'MSan'
 ]
+.TSan_Config =
+[
+    .CompilerOptions                = ' -DRELEASE'
+                                    + ' -fsanitize=thread'
+    .CompilerOptionsC               = .CompilerOptions
+    .CompilerOptionsPCH             = .CompilerOptions
+    .LinkerOptions                  = ' -fsanitize=thread'
+
+    .BuildConfigName                = 'TSan'
+]
 .Fuzzer_Config =
 [
     #if USING_CLANG_6
@@ -209,6 +219,9 @@ Settings
     .X64ASanConfig_Linux        = .X64BaseConfig_Linux
                                 + .ASan_Config
                                 + .Release_Optimizations
+    .X64TSanConfig_Linux        = .X64BaseConfig_Linux
+                                + .TSan_Config
+                                + .Release_Optimizations
     // Clang
     .X64ClangBaseConfig_Linux   = .LinuxCompatibilityOptions // Must be first
                                 + .ToolChain_Clang_Linux
@@ -228,6 +241,9 @@ Settings
     .X64ClangMSanConfig_Linux   = .X64ClangBaseConfig_Linux
                                 + .MSan_Config
                                 + .Fuzzer_Config
+                                + .Release_Optimizations
+    .X64ClangTSanConfig_Linux   = .X64ClangBaseConfig_Linux
+                                + .TSan_Config
                                 + .Release_Optimizations
 #endif
 
@@ -284,9 +300,9 @@ Settings
 #endif
 #if __LINUX__
     .BuildConfigs               = { .X64DebugConfig_Linux, .X64ProfileConfig_Linux, .X64ReleaseConfig_Linux,
-                                    .X64ASanConfig_Linux,
+                                    .X64ASanConfig_Linux, .X64TSanConfig_Linux,
                                     .X64ClangDebugConfig_Linux, .X64ClangProfileConfig_Linux, .X64ClangReleaseConfig_Linux,
-                                    .X64ClangASanConfig_Linux, .X64ClangMSanConfig_Linux }
+                                    .X64ClangASanConfig_Linux, .X64ClangMSanConfig_Linux, .X64ClangTSanConfig_Linux }
 #endif
 #if __OSX__
     .BuildConfigs               = { .X64DebugConfig_OSX, .X64ProfileConfig_OSX, .X64ReleaseConfig_OSX }
@@ -304,11 +320,13 @@ Settings
 .Targets_x64Linux_Profile = {}
 .Targets_x64Linux_Release = {}
 .Targets_x64Linux_ASan = {}
+.Targets_x64Linux_TSan = {}
 .Targets_x64ClangLinux_Debug = {}
 .Targets_x64ClangLinux_Profile = {}
 .Targets_x64ClangLinux_Release = {}
 .Targets_x64ClangLinux_ASan = {}
 .Targets_x64ClangLinux_MSan = {}
+.Targets_x64ClangLinux_TSan = {}
 
 .Targets_x64OSX_Debug = {}
 .Targets_x64OSX_Profile = {}
@@ -350,10 +368,10 @@ ForEach( .BuildConfig in .BuildConfigs )
 .Platforms = { 'x64', 'x64Clang', 'x64Linux', 'x64ClangLinux', 'x64OSX' }
 .PlatformConfigs_x64           = { 'Debug', 'Analyze', 'Profile', 'Release' }
 .PlatformConfigs_x64Clang      = { 'Debug', 'Profile', 'Release' }
-.PlatformConfigs_x64Linux      = { 'Debug', 'Profile', 'Release', 'ASan' }
+.PlatformConfigs_x64Linux      = { 'Debug', 'Profile', 'Release', 'ASan', 'TSan' }
 .PlatformConfigs_x64ClangLinux = { 'Debug', 'Profile', 'Release' }
 #if USING_CLANG_6
-                               + { 'ASan', 'MSan' }
+                               + { 'ASan', 'MSan', 'TSan' }
 #endif
 .PlatformConfigs_x64OSX        = { 'Debug', 'Profile', 'Release' }
 ForEach( .Platform in .Platforms )

--- a/Code/gen_default_aliases.bff
+++ b/Code/gen_default_aliases.bff
@@ -13,6 +13,7 @@ Alias( '$ProjectName$-Profile' )         { .Targets = { '$ProjectName$-X64Linux-
 Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64Linux-Release', '$ProjectName$-X64ClangLinux-Release' } }
 Alias( '$ProjectName$-ASan' )            { .Targets = { '$ProjectName$-X64Linux-ASan',    '$ProjectName$-X64ClangLinux-ASan' } }
 Alias( '$ProjectName$-MSan' )            { .Targets = { '$ProjectName$-X64ClangLinux-MSan' } }
+Alias( '$ProjectName$-TSan' )            { .Targets = { '$ProjectName$-X64Linux-TSan',    '$ProjectName$-X64ClangLinux-TSan' } }
 #endif
 #if __OSX__
 Alias( '$ProjectName$-Debug' )           { .Targets = { '$ProjectName$-X64OSX-Debug' } }
@@ -23,8 +24,8 @@ Alias( '$ProjectName$-Release' )         { .Targets = { '$ProjectName$-X64OSX-Re
 // Per-Platform
 Alias( '$ProjectName$-X64' )             { .Targets = { '$ProjectName$-X64-Debug', '$ProjectName$-X64-Analyze', '$ProjectName$-X64-Release', '$ProjectName$-X64-Profile' } }
 Alias( '$ProjectName$-X64Clang' )        { .Targets = { '$ProjectName$-X64Clang-Debug', '$ProjectName$-X64Clang-Release', '$ProjectName$-X64Clang-Profile' } }
-Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64Linux-ASan' } }
-Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile', '$ProjectName$-X64ClangLinux-ASan', '$ProjectName$-X64ClangLinux-MSan' } }
+Alias( '$ProjectName$-X64Linux' )        { .Targets = { '$ProjectName$-X64Linux-Debug', '$ProjectName$-X64Linux-Release', '$ProjectName$-X64Linux-Profile', '$ProjectName$-X64Linux-ASan', '$ProjectName$-X64Linux-TSan' } }
+Alias( '$ProjectName$-X64ClangLinux' )   { .Targets = { '$ProjectName$-X64ClangLinux-Debug', '$ProjectName$-X64ClangLinux-Release', '$ProjectName$-X64ClangLinux-Profile', '$ProjectName$-X64ClangLinux-ASan', '$ProjectName$-X64ClangLinux-MSan', '$ProjectName$-X64ClangLinux-TSan' } }
 Alias( '$ProjectName$-X64OSX' )          { .Targets = { '$ProjectName$-X64OSX-Debug', '$ProjectName$-X64OSX-Release', '$ProjectName$-X64OSX-Profile' } }
 
 // All


### PR DESCRIPTION
ThreadSanitizer helped to found some number of issues in FASTBuild, so it be nice to add support for building with it into main repo and to TSan runs to TravisCI to promptly catch any new issues that might come up.

The main problem with TSan integration is different view on what is an atomic operation in TSan and in the FASTBuild code base. FASTBuild uses the fact that it supports only x86 and therefore uses plain reads/writes instead of atomic reads/writes when synchronization is not required. TSan on the other hand strictly follows the standard requiring atomic operations when a variable is accesses from multiple threads without synchronization.

So the main part of this PR is addition of new helper function to `Atomic.h` and replacement of plain reads/writes with relaxed atomic reads/writes for the variables for which TSan otherwise reports races.  
As always, more details in commit messages.

Also this PR includes changes from #604 because they are needed to fix ShutdownMemoryLeak test when it runs under TSan.