### PR TITLE
Implement KillProcessTree for Linux/OSX

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -156,8 +156,8 @@ void Process::KillProcessTree()
             ::CloseHandle( hChildProc );
         }
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
-        // TODO: Kill process tree if necessary?
-        kill( m_ChildPID, SIGTERM );
+        // Kill all processes in the process group of the child process.
+        kill( -m_ChildPID, SIGKILL );
     #else
         #error Unknown platform
     #endif
@@ -353,6 +353,11 @@ bool Process::Spawn( const char * executable,
         const bool isChild = ( childProcessPid == 0 );
         if ( isChild )
         {
+            // Put child process into its own process group.
+            // This will allow as to send signals to the whole group which we use to implement KillProcessTree.
+            // The new process group will have ID equal to the PID of the child process.
+            VERIFY( setpgid( 0, 0 ) == 0 );
+
             VERIFY( dup2( stdOutPipeFDs[ 1 ], STDOUT_FILENO ) != -1 );
             VERIFY( dup2( stdErrPipeFDs[ 1 ], STDERR_FILENO ) != -1 );
 


### PR DESCRIPTION
To do the job we put each spawned process into a new process group. This allows us to send SIGKILL to all processes in that group without any kind of process tree traversal. This also works for processes that were reparented to PID 1 due to their parent dying.

This should fix #595.