### PR TITLE
Support for forcably isolating files in Unity nodes

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -138,7 +138,7 @@ UnityNode::~UnityNode()
         return NODE_RESULT_FAILED; // GetFiles will have emitted an error
     }
 
-	FilterForceIsolated( files, m_IsolatedFiles );
+    FilterForceIsolated( files, m_IsolatedFiles );
 
     // TODO:A Sort files for consistent ordering across file systems/platforms
 
@@ -454,43 +454,43 @@ bool UnityNode::GetFiles( Array< FileAndOrigin > & files )
 //------------------------------------------------------------------------------
 void UnityNode::FilterForceIsolated( Array< FileAndOrigin > & files, Array< FileAndOrigin > & isolatedFiles )
 {
-	if ( m_FilesToIsolate.GetSize() == 0 )
-	{
-		return;
-	}
+    if ( m_FilesToIsolate.GetSize() == 0 )
+    {
+        return;
+    }
 
-	const FileAndOrigin * readIt = files.Begin();
-	FileAndOrigin * writeIt = files.Begin();
+    const FileAndOrigin * readIt = files.Begin();
+    FileAndOrigin * writeIt = files.Begin();
 
-	for( ; readIt != files.End(); ++readIt )
-	{
-		bool isolate = false;
-		for ( const AString& filename : m_FilesToIsolate )
-		{
-			if ( PathUtils::PathEndsWithFile( readIt->GetName(), filename ) )
-			{
-				isolate = true;
-				break;
-			}
-		}
+    for( ; readIt != files.End(); ++readIt )
+    {
+        bool isolate = false;
+        for ( const AString& filename : m_FilesToIsolate )
+        {
+            if ( PathUtils::PathEndsWithFile( readIt->GetName(), filename ) )
+            {
+                isolate = true;
+                break;
+            }
+        }
 
-		if ( isolate )
-		{
-			isolatedFiles.Append( *readIt );
-		}
-		else if ( writeIt != readIt )
-		{
-			ASSERT( writeIt < readIt );
-			*writeIt = *readIt;
-			writeIt++;
-		}
-		else
-		{
-			writeIt++;
-		}
-	}
+        if ( isolate )
+        {
+            isolatedFiles.Append( *readIt );
+        }
+        else if ( writeIt != readIt )
+        {
+            ASSERT( writeIt < readIt );
+            *writeIt = *readIt;
+            writeIt++;
+        }
+        else
+        {
+            writeIt++;
+        }
+    }
 
-	files.SetSize( writeIt - files.Begin() );
+    files.SetSize( writeIt - files.Begin() );
 }
 
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -35,6 +35,11 @@ public:
     class FileAndOrigin
     {
     public:
+		FileAndOrigin()
+		 : m_Info( nullptr )
+		 , m_DirListOrigin( nullptr )
+		{}
+
         FileAndOrigin( FileIO::FileInfo * info, DirectoryListNode * dirListOrigin )
          : m_Info( info )
          , m_DirListOrigin( dirListOrigin )
@@ -58,6 +63,7 @@ private:
     virtual bool IsAFile() const override { return false; }
 
     bool GetFiles( Array< FileAndOrigin > & files );
+	void FilterForceIsolated( Array< FileAndOrigin > & files, Array< FileAndOrigin > & isolatedFiles );
 
     // Exposed properties
     Array< AString > m_InputPaths;
@@ -71,6 +77,7 @@ private:
     AString m_PrecompiledHeader;
     Array< AString > m_PathsToExclude;
     Array< AString > m_FilesToExclude;
+    Array< AString > m_FilesToIsolate;
     bool m_IsolateWritableFiles;
     uint32_t m_MaxIsolatedFiles;
     Array< AString > m_ExcludePatterns;

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -35,10 +35,10 @@ public:
     class FileAndOrigin
     {
     public:
-		FileAndOrigin()
-		 : m_Info( nullptr )
-		 , m_DirListOrigin( nullptr )
-		{}
+        FileAndOrigin()
+         : m_Info( nullptr )
+         , m_DirListOrigin( nullptr )
+        {}
 
         FileAndOrigin( FileIO::FileInfo * info, DirectoryListNode * dirListOrigin )
          : m_Info( info )
@@ -63,7 +63,7 @@ private:
     virtual bool IsAFile() const override { return false; }
 
     bool GetFiles( Array< FileAndOrigin > & files );
-	void FilterForceIsolated( Array< FileAndOrigin > & files, Array< FileAndOrigin > & isolatedFiles );
+    void FilterForceIsolated( Array< FileAndOrigin > & files, Array< FileAndOrigin > & isolatedFiles );
 
     // Exposed properties
     Array< AString > m_InputPaths;


### PR DESCRIPTION
A common case I am running into while trying to get unity compilation working is that a directory will mostly work fine compiled as a unity file expect for one or two problematic files. I want the management of those problematic files to remain part of the Unity node, rather than having to manage it in both the Unity node and ObjectList node(s). So:
```
Unity( 'Unity-foo' )
{
    .UnityInputPath = 'src\foo'
    .UnityInputExcludedFiles = { 'problematic_file.cpp' }
}

ObjectList()
{
    .CompilerInputUnity = 'Unity-foo'
    .CompilerInputFiles = { 'src\foo\problematic_file.cpp' }
}
```
Can become:
```
Unity( 'Unity-foo' )
{
    .UnityInputPath = 'src\foo'
    .UnityInputIsolatedFiles = { 'problematic_file.cpp' }
}

ObjectList()
{
    .CompilerInputUnity = 'Unity-foo'
}
```
