### PR TITLE
Require header for CopyDir and RemoveDir

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.cpp
@@ -25,6 +25,13 @@ FunctionCopyDir::FunctionCopyDir()
     return true;
 }
 
+// NeedsHeader
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionCopyDir::NeedsHeader() const
+{
+    return true;
+}
+
 // CreateNode
 //------------------------------------------------------------------------------
 /*virtual*/ Node * FunctionCopyDir::CreateNode() const

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopyDir.h
@@ -16,6 +16,7 @@ public:
 
 protected:
     virtual bool AcceptsHeader() const override;
+    virtual bool NeedsHeader() const override;
     virtual Node * CreateNode() const override;
 };
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.cpp
@@ -25,6 +25,13 @@ FunctionRemoveDir::FunctionRemoveDir()
     return true;
 }
 
+// NeedsHeader
+//------------------------------------------------------------------------------
+/*virtual*/ bool FunctionRemoveDir::NeedsHeader() const
+{
+    return true;
+}
+
 // Commit
 //------------------------------------------------------------------------------
 /*virtual*/ bool FunctionRemoveDir::Commit( NodeGraph & nodeGraph, const BFFIterator & funcStartIter ) const

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionRemoveDir.h
@@ -16,6 +16,7 @@ public:
 
 protected:
     virtual bool AcceptsHeader() const override;
+    virtual bool NeedsHeader() const override;
     virtual bool Commit( NodeGraph & nodeGraph, const BFFIterator & funcStartIter ) const override;
     virtual Node * CreateNode() const override;
 };


### PR DESCRIPTION
Header is the only source of the name for these nodes and thus it should be required. Documentation already says that it is required but the code doesn't enforce that.

Without the change this code is silently accepted in Release but triggers assert about non-empty name in `Function::Commit` in Debug:
```
    CopyDir
    {
        .SourcePaths = 'src'
        .Dest = 'dst'
    }
```