### PR TITLE
Fix array self-assignment when concatenating with an empty array of different type

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFParser.cpp
@@ -1841,7 +1841,12 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
         {
             if ( concat )
             {
-                BFFStackFrame::SetVarArrayOfStrings( dstName, varDst->GetArrayOfStrings(), dstFrame );
+                // Avoid self-assignment by checking that the destination variable is not in destination scope.
+                const BFFVariable * var = (dstFrame ? dstFrame : BFFStackFrame::GetCurrent())->GetLocalVar( dstName );
+                if ( varDst != var )
+                {
+                    BFFStackFrame::SetVarArrayOfStrings( dstName, varDst->GetArrayOfStrings(), dstFrame );
+                }
             }
             else
             {
@@ -1855,7 +1860,12 @@ bool BFFParser::StoreVariableToVariable( const AString & dstName, BFFIterator & 
         {
             if ( concat )
             {
-                BFFStackFrame::SetVarArrayOfStructs( dstName, varDst->GetArrayOfStructs(), dstFrame );
+                // Avoid self-assignment by checking that the destination variable is not in destination scope.
+                const BFFVariable * var = (dstFrame ? dstFrame : BFFStackFrame::GetCurrent())->GetLocalVar( dstName );
+                if ( varDst != var )
+                {
+                    BFFStackFrame::SetVarArrayOfStructs( dstName, varDst->GetArrayOfStructs(), dstFrame );
+                }
             }
             else
             {

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/arrays.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/arrays.bff
@@ -96,6 +96,12 @@
     // assignment of empty array wrapped in inplace array to non-empty
     .T11 = .Array
     .T11 = { .EmptyArray }
+
+    // concatentation of empty array of different type
+    .Struct = []
+    .EmptyArray2 = { .Struct }
+    .EmptyArray2 = {}
+    .T12 = .Array + .EmptyArray2
 }
 
 // Operations with ArrayOfStructs and empty arrays
@@ -133,4 +139,9 @@
     // assignment of empty array wrapped in inplace array to non-empty
     .T11 = .Array
     .T11 = { .EmptyArray }
+
+    // concatentation of empty array of different type
+    .EmptyArray2 = { '' }
+    .EmptyArray2 = {}
+    .T12 = .Array + .EmptyArray2
 }


### PR DESCRIPTION
This code was triggering the assert in `Array::operator=` in Debug and producing wrong results (empty `.B`) in Release:
```
    .S=[]
    .A={.S}
    .A={}
    .B={'foo'}+.A
```