### PR TITLE
Support operators of the If function in Error_1034

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Error.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Error.cpp
@@ -300,12 +300,18 @@
                                                          BFFVariable::VarType rhs,
                                                          const  BFFIterator & operatorIter )
 {
+    BFFIterator operatorIterNext( operatorIter );
+    operatorIterNext++;
+
     const char * operation  = "???"; // should never be used
     switch ( *operatorIter )
     {
-        case BFFParser::BFF_VARIABLE_ASSIGNMENT:    operation = "="; break;
+        case BFFParser::BFF_VARIABLE_ASSIGNMENT:    operation = ( *operatorIterNext == '=' ) ? "==" : "="; break;
         case BFFParser::BFF_VARIABLE_CONCATENATION: operation = "+"; break;
         case BFFParser::BFF_VARIABLE_SUBTRACTION:   operation = "-"; break;
+        case '>':                                   operation = ( *operatorIterNext == '=' ) ? ">=" : ">"; break;
+        case '<':                                   operation = ( *operatorIterNext == '=' ) ? "<=" : "<"; break;
+        case '!':                                   operation = "!="; ASSERT( *operatorIterNext == '=' ); break;
         default:                                    ASSERT( false ); break;
     }
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestIf/usageerror_unsupportedoperation.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestIf/usageerror_unsupportedoperation.bff
@@ -1,0 +1,7 @@
+//
+// Make sure the error correctly reports unsupported operator
+//
+.Bool = true
+If(.Bool >= .Bool)
+{
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
@@ -33,6 +33,7 @@ private:
     void IfFunctionStringCompare() const;
     void UsageError_ExtraTokensAfterExpression() const;
     void UsageError_UnsupportedTypeForIn() const;
+    void UsageError_UnsupportedOperation() const;
 
     void Parse( const char * fileName, bool expectFailure = false ) const;
 };
@@ -53,6 +54,7 @@ REGISTER_TESTS_BEGIN( TestIf )
     REGISTER_TEST( IfFunctionStringCompare )
     REGISTER_TEST( UsageError_ExtraTokensAfterExpression )
     REGISTER_TEST( UsageError_UnsupportedTypeForIn )
+    REGISTER_TEST( UsageError_UnsupportedOperation )
 REGISTER_TESTS_END
 
 // IfFunctionTrue
@@ -160,6 +162,14 @@ void TestIf::UsageError_UnsupportedTypeForIn() const
 {
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/usageerror_unsupportedtypeforin.bff", true ); // Expect failure
     TEST_ASSERT( GetRecordedOutput().Find( "Property '.Int' must be of type <ArrayOfStrings> or <String> (found <Int>" ) );
+}
+
+// UsageError_UnsupportedOperation
+//------------------------------------------------------------------------------
+void TestIf::UsageError_UnsupportedOperation() const
+{
+    Parse( "Tools/FBuild/FBuildTest/Data/TestIf/usageerror_unsupportedoperation.bff", true ); // Expect failure
+    TEST_ASSERT( GetRecordedOutput().Find( "Operation not supported: 'Bool' >= 'Bool'" ) );
 }
 
 // Parse


### PR DESCRIPTION
Previously code like this:
```
    .Bool = true
    If (.Bool >= .Bool) {}
```
triggered an assert in Error_1034 function and produced strange looking results in Release: "Operation not supported: 'Bool' ??? 'Bool'".