### PR TITLE
Improve lookup time for LightCache hits

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -54,6 +54,10 @@ class IncludedFileHashSet
 public:
     IncludedFileHashSet( const IncludedFileHashSet & ) = delete;
     IncludedFileHashSet &operator=( const IncludedFileHashSet & ) = delete;
+    ~IncludedFileHashSet()
+    {
+        Destruct();
+    }
     IncludedFileHashSet()
     {
         m_Buckets.SetSize( LIGHTCACHE_DEFAULT_BUCKET_SIZE );

--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -66,7 +66,7 @@ public:
             elt = nullptr;
         }
     }
-    IncludedFile *Find( const AString & fileName, uint64_t fileNameHash )
+    const IncludedFile *Find( const AString & fileName, uint64_t fileNameHash )
     {
         IncludedFile ** location = InternalFind( fileName, fileNameHash );
         if( location && *location )
@@ -78,7 +78,7 @@ public:
 
     // If two threads find the same include simultaneously, we delete the new
     // one and return the old one.
-    IncludedFile * Insert( IncludedFile *item )
+    const IncludedFile * Insert( IncludedFile *item )
     {
         if( m_Buckets.GetSize() / 2 <= m_Elts )
         {
@@ -601,7 +601,7 @@ const IncludedFile * LightCache::FileExists( const AString & fileName )
     // Retrieve from shared cache
     {
         MutexHolder mh( bucket.m_Mutex );
-        IncludedFile * location = bucket.m_HashSet.Find( fileName, fileNameHash );
+        const IncludedFile * location = bucket.m_HashSet.Find( fileName, fileNameHash );
         if ( location )
         {
             return location; // File previously handled so we can re-use the result
@@ -610,6 +610,7 @@ const IncludedFile * LightCache::FileExists( const AString & fileName )
 
     // A newly seen file
     IncludedFile * newFile = FNEW( IncludedFile() );
+    const IncludedFile * retval = nullptr;
     newFile->m_FileNameHash = fileNameHash;
     newFile->m_FileName = fileName;
     newFile->m_Exists = false;
@@ -622,9 +623,9 @@ const IncludedFile * LightCache::FileExists( const AString & fileName )
         {
             // Store to shared cache
             MutexHolder mh( bucket.m_Mutex );
-            newFile = bucket.m_HashSet.Insert( newFile );
+            retval = bucket.m_HashSet.Insert( newFile );
         }
-        return newFile;
+        return retval;
     }
 
     // File exists - parse it
@@ -634,10 +635,10 @@ const IncludedFile * LightCache::FileExists( const AString & fileName )
     {
         // Store to shared cache
         MutexHolder mh( bucket.m_Mutex );
-        newFile = bucket.m_HashSet.Insert( newFile );
+        retval = bucket.m_HashSet.Insert( newFile );
     }
 
-    return newFile;
+    return retval;
 }
 
 // SkipWhitepspace


### PR DESCRIPTION
The old implementation used a hash to select a locked shard, then did a
linear search.  Astring::op== dominated those profiles.

We still use shard to reduce lock contention, but we now use an open
addressed, quadratically probed hash map instead of a linear search.

On a clean, but cached build, I was able to reduce my build time from
146 seconds to 51 seconds, with ~18 seconds devoted to linking.