### PR TITLE
Fix crash in light cache

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -464,8 +464,11 @@ void LightCache::ProcessInclude( const AString & include, IncludeType type )
         {
 
             // Find macro - expand each possible value
-            for ( const IncludeDefine * def : m_IncludeDefines )
+            // use index here, since iterators may be invalidated when recursing
+            // get size each iteration, since size could have increased when recursing
+            for ( size_t i=0; i<m_IncludeDefines.GetSize(); ++i )
             {
+                const IncludeDefine * def = m_IncludeDefines[i];
                 if ( def->m_Macro == include )
                 {
                     ProcessInclude( def->m_Include, def->m_Type );


### PR DESCRIPTION
Use index here, since m_IncludeDefines iterators may be invalidated when recursing