### PR TITLE
Strip -MF and -MD tokens when compiling preprocessed source

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1563,6 +1563,14 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                 {
                     continue; // skip this token in both cases
                 }
+                if (StripTokenWithArg("-MF", token, i))
+                {
+                    continue; // skip this token in both cases
+                }
+                if (StripTokenWithArg("-MD", token, i))
+                {
+                    continue; // skip this token in both cases
+                }
             }
             if ( isGCC || isClang || isVBCC || isOrbisWavePsslc )
             {


### PR DESCRIPTION
At this point any dependency info produced is bogus, and could stomp on top of valid dependency info produced by the preprocessing pass.

This PR fixes full rebuilds when compiling UE4, due to UE4 using the generated dependency data to figure out when files have changed etc