### PR TITLE
Print can now search for what to print based on a pattern and options

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/print.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/print.html
@@ -29,9 +29,26 @@
 <div id='print' class='newsitemheader'>Summary</div>
 <div class='newsitembody'>
   <p>
-  Prints some text during BFF parsing.
+  Prints some text or variable state during BFF parsing.
   </p>
-  <div class='code'>Print( "String or $VarName$" )</div>
+  <div class='code'>Print( "String with optional $VarName$" )     // (1)
+Print( .VarName )                             // (2)
+Print( /String with optional $VarName$/opts ) // (3)</div>
+<ol>
+  <li>Prints a string, embedding any scalar variables included.  To print a $, escape it with a ^.  
+      Arrays and structs cannot be printed this way.</li>
+  <li>Prints a variable.  If the variable is an array or struct, it will recursively print the members.</li>
+  <li>(0.99)Prints all variables in the current scope that match the given pattern.  The pattern string may include variables, 
+      as in variant 1. The pattern is a wildcard, not a regex.  Note that variables names start with a period.  
+	  After the closing slash, a set of characters may be included to enable certain options.  The following options are supported:
+      <table>
+        <tr><td valign=top><b>P</b></td><td>: Includes the entire chain of parent scopes.  Output starts with the global variables and then then 
+		                  first child scope in the chain is indented, and so on until the current scope is reached, which 
+						  will be the most indented.  Without P, only variables declared in the current scope will be printed,
+						  and there will be no extra indenting.</td></tr>
+        <tr><td valign=top><b>+</b></td><td>: Recurses into array and struct variables.  Without the +, just the variable name and type are printed.</td></tr>
+      </table></li>
+</ol>
 </div>
 	
 <div id='print' class='newsitemheader'>Details</div>
@@ -56,9 +73,17 @@
 .X64_Debug     = [ .Config = 'Debug'   .Platform = 'X64' ]
 .X64_Release   = [ .Config = 'Release' .Platform = 'X64' ]
 .Configs       = { .X86_Debug, .X86_Release, .X64_Debug, .X64_Release }
+{
+  .X64Configs = { ^X64_Debug, ^X64_Release }
+  .X86Configs = { .X86_Release }
   
+  Print(/.X64*/P)
+  Print(/.X86*/+)
+  Print('----------')
+}
 ForEach( .Config in .Configs )
 {
+  Print( .Config )
   Using( .Config )
   .TargetName = '$Platform$-$Config$'
 	
@@ -67,9 +92,41 @@ ForEach( .Config in .Configs )
   <p>
   Will generate the following output:
   </p>
-  <div class='output'>TargetName = X86-Debug
+  <div class='output'>.X64_Debug = // Struct
+.X64_Release = // Struct
+    .X64Configs = // ArrayOfStructs, size: 2
+.X86Configs = // ArrayOfStructs, size: 1
+{
+    .X86_Release = // Struct
+    [
+        .Config = 'Release'
+        .Platform = 'X86'
+    ]
+}
+----------
+.Config = // Struct
+[
+    .Config = 'Debug'
+    .Platform = 'X86'
+]
+TargetName = X86-Debug
+.Config = // Struct
+[
+    .Config = 'Release'
+    .Platform = 'X86'
+]
 TargetName = X86-Release
+.Config = // Struct
+[
+    .Config = 'Debug'
+    .Platform = 'X64'
+]
 TargetName = X64-Debug
+.Config = // Struct
+[
+    .Config = 'Release'
+    .Platform = 'X64'
+]
 TargetName = X64-Release</div>
 </div>
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionPrint.h
@@ -26,7 +26,8 @@ protected:
                                 const BFFIterator * functionHeaderStartToken,
                                 const BFFIterator * functionHeaderStopToken ) const override;
 
-    static void PrintVarRecurse( const BFFVariable & var, uint32_t indent );
+    static void PrintVarRecurse( const BFFVariable& var, uint32_t indent, uint32_t maxIndent );
+    static void PrintStackVars( const AString &pattern, bool iterateParents, bool expandStructs );
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Feature:
  If given a // string instead of a '' or "" string, it will treat the string as a pattern and print the variables that match the wildcard pattern.  Two options are currently provided, to print what's declared in the current scope or to print everything in scope; and to expand arrays/structs or not.

Rationale:
  I was tasked with adding a feature to an existing (large) build system, and figuring out where I was supposed to get certain state from was nigh impossible without a feature like this.  I expect it will almost always be used with the 'P' option (iterate parent scopes), since you usually don't know where you're looking when you invoke this form of Print.

  I had added a setting to a bff, but didn't know what, if any, struct that setting had been stored in to.  By dumping everything in scope, I was able to find it quickly.

Notes:
  I added the pattern matching because it was easy to add, but I always used it with just /*/P+

  The // syntax is borrowed from a variety of sources, but most notably perl.  However, in those uses the pattern is always a regex.  I didn't see an existing regex in fbuild, and I didn't need regex powers, so it's not a regex.  But a future option could enable regex or something; the optons add a lot of power.  'i' would be an obvious option to add; there's even already a MatchI to call.

  I went with 'P' and '+' because they aren't used by the other existing // search precedents out there, and thus shouldn't confuse people.

branches print_pattern, mkujawa/print_pattern, origin/print_pattern