### PR TITLE
Copy on a symlink didn't fix the target path

### DIFF
--- a/Code/Core/CoreTest/Tests/TestFileIO.cpp
+++ b/Code/Core/CoreTest/Tests/TestFileIO.cpp
@@ -150,7 +150,7 @@ void TestFileIO::FileCopySymlink() const
         // by the file copy API.  Also on Windows, it would make unit
         // tests require administrator privileges.
     #elif defined ( __LINUX__ )
-        AStackString<> symlinkTarget( "symlink" );
+        AStackString<> symlinkTarget( "/symlink" );
 
         // generate a process unique file path
         AStackString<> path;

--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -24,6 +24,7 @@
     #include <libgen.h>
     #include <limits.h>
     #include <stdio.h>
+    #include <string.h>
     #include <sys/stat.h>
     #include <unistd.h>
 #endif
@@ -222,6 +223,20 @@
             return false;
         }
         linkPath.SetLength( length );
+
+        if (linkPath.Get()[0] != '/' )
+        {
+            // Convert linkPath to a full path in case the relative path
+            // is wrong from dstFileName
+            if ( srcFileName[0] != '/' )
+            {
+                return false;
+            }
+            const char *pLastSlash = strrchr(srcFileName, '/');
+            const size_t lenSrcPath = (pLastSlash - srcFileName) + 1;
+            linkPath.Format("%.*s%s", (int)lenSrcPath, srcFileName, linkPath.Get());
+        }
+
         return symlink( linkPath.Get(), dstFileName ) == 0;
     }
 


### PR DESCRIPTION
Previously, instead of the default behavior of following a link and copying the contents to a new file, CopyFile attempted to make a new link pointing at the same place.

But it did this by copying the link contents without modification, and a link's contents can be a relative path.  So if /a/b/foo was a symlink that contained simply "bar", then copying it to /a/d would result in a broken link (there is no /a/d/bar).

There may be situations where that is the desired behavior, but that really needs not to be the default.  Even with this change, there may be times that following the link is preferable to creating a new link (copying to removable media or a network share, for some examples.)  But I think the "normal" desire is that you can copy a path and the result never a broken link.

This change makes the link target always be an absolute path, starting from /, so that it will work regardless of where the link is copied to.  So a/d/foo would be a link containing "/a/b/bar"

