### PR TITLE
Cuda nvcc not parsing dependencies

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -790,11 +790,11 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
         bool msvcStyle;
         if ( GetDedicatedPreprocessor() != nullptr )
         {
-            msvcStyle = GetPreprocessorFlag( FLAG_MSVC ) || GetPreprocessorFlag( FLAG_CUDA_NVCC );
+            msvcStyle = GetPreprocessorFlag( FLAG_MSVC );
         }
         else
         {
-            msvcStyle = GetFlag( FLAG_MSVC ) || GetFlag( FLAG_CUDA_NVCC );
+            msvcStyle = GetFlag( FLAG_MSVC );
         }
         bool result = msvcStyle ? parser.ParseMSCL_Preprocessed( output, outputSize )
                                 : parser.ParseGCC_Preprocessed( output, outputSize );

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -237,7 +237,7 @@ ObjectNode::~ObjectNode()
     bool useCache = ShouldUseCache();
     bool useDist = GetFlag( FLAG_CAN_BE_DISTRIBUTED ) && m_AllowDistribution && FBuild::Get().GetOptions().m_AllowDistributed;
     bool useSimpleDist = GetCompiler()->SimpleDistributionMode();
-    bool usePreProcessor = !useSimpleDist && ( useCache || useDist || GetFlag( FLAG_GCC ) || GetFlag( FLAG_SNC ) || GetFlag( FLAG_CLANG ) || GetFlag( CODEWARRIOR_WII ) || GetFlag( GREENHILLS_WIIU ) || GetFlag( ObjectNode::FLAG_VBCC ) || GetFlag( FLAG_ORBIS_WAVE_PSSLC ) );
+    bool usePreProcessor = !useSimpleDist && ( useCache || useDist || GetFlag( FLAG_GCC ) || GetFlag(FLAG_CUDA_NVCC) || GetFlag( FLAG_SNC ) || GetFlag( FLAG_CLANG ) || GetFlag( CODEWARRIOR_WII ) || GetFlag( GREENHILLS_WIIU ) || GetFlag( ObjectNode::FLAG_VBCC ) || GetFlag( FLAG_ORBIS_WAVE_PSSLC ) );
     if ( GetDedicatedPreprocessor() )
     {
         usePreProcessor = true;
@@ -1589,7 +1589,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
         // -o removal for preprocessor
         if ( pass == PASS_PREPROCESSOR_ONLY )
         {
-            if ( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isCUDA || isVBCC || isOrbisWavePsslc )
+            if ( isGCC || isSNC || isClang || isCWWii || isGHWiiU || isVBCC || isOrbisWavePsslc )
             {
                 if ( StripTokenWithArg( "-o", token, i ) )
                 {
@@ -1604,7 +1604,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                     }
                 }
             }
-            else if ( isQtRCC )
+            else if ( isQtRCC || isCUDA )
             {
                 // remove --output (or alias -o) so dependency list goes to stdout
                 if ( StripTokenWithArg( "--output", token, i ) ||

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1604,7 +1604,7 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                     }
                 }
             }
-            else if ( isQtRCC || isCUDA )
+            else if ( isQtRCC )
             {
                 // remove --output (or alias -o) so dependency list goes to stdout
                 if ( StripTokenWithArg( "--output", token, i ) ||
@@ -1613,6 +1613,18 @@ bool ObjectNode::BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool us
                     continue;
                 }
             }
+			else if (isCUDA)
+			{
+				// remove --output-file (or alias -o) so preprocessor output goes to stdout
+				// remove --compile (or alias -c) when using preprocessor only
+				if (StripTokenWithArg("--output-file", token, i) ||
+					StripTokenWithArg("-o", token, i) ||
+					StripToken("--compile", token) || 
+					StripToken("-c", token))
+				{
+					continue;
+				}
+			}
         }
 
         if ( isClang || isGCC ) // Also check when invoked via gcc sym link


### PR DESCRIPTION
#540 
Tested on Windows 10 - Visual Studio 2017 - Cuda 10.1
Dependencies are now correctly parsed during pre-processing step for nvcc (*.cu).