### PR TITLE
Fix GetRelativePath case sensitivity

### DIFF
--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -220,7 +220,7 @@
 
     #if defined( __WINDOWS__ ) || defined( __OSX__ )
         // Windows & OSX: Case insensitive
-        if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
+        if ( ( compA >= 'A' ) && ( compA <= 'Z' ) )
         {
             compA = 'a' + ( compA - 'A' );
         }

--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -242,7 +242,7 @@
             pathA = itA;
             pathB = itB;
         }
-        
+
         #if defined( __WINDOWS__ ) || defined( __OSX__ )
             // Windows & OSX: Case insensitive
             if ( ( compA >= 'A' ) && ( compA <= 'Z' ) )

--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -245,7 +245,7 @@
         
         #if defined( __WINDOWS__ ) || defined( __OSX__ )
             // Windows & OSX: Case insensitive
-            if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
+            if ( ( compA >= 'A' ) && ( compA <= 'Z' ) )
             {
                 compA = 'a' + ( compA - 'A' );
             }

--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -218,7 +218,7 @@
     char compA = *itA;
     char compB = *itB;
 
-    #if !defined( __LINUX__ )
+    #if defined( __WINDOWS__ ) || defined( __OSX__ )
         // Windows & OSX: Case insensitive
         if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
         {
@@ -243,7 +243,7 @@
             pathB = itB;
         }
         
-        #if !defined( __LINUX__ )
+        #if defined( __WINDOWS__ ) || defined( __OSX__ )
             // Windows & OSX: Case insensitive
             if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
             {

--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -215,17 +215,47 @@
     const char * pathB = fileName.Get();
     const char * itA = pathA;
     const char * itB = pathB;
-    while ( ( *itA == *itB ) && ( *itA != '\0' ) )
+    char compA = *itA;
+    char compB = *itB;
+
+    #if !defined( __LINUX__ )
+        // Windows & OSX: Case insensitive
+        if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
+        {
+            compA = 'a' + ( compA - 'A' );
+        }
+        if ( ( compB >= 'A' ) && ( compB <= 'Z' ) )
+        {
+            compB = 'a' + ( compB - 'A' );
+        }
+    #endif
+
+    while ( ( compA == compB ) && ( compA != '\0' ) )
     {
         const bool dirToken = ( ( *itA == '/' ) || ( *itA == '\\' ) );
         itA++;
+        compA = *itA;
         itB++;
+        compB = *itB;
         if ( dirToken )
         {
             pathA = itA;
             pathB = itB;
         }
+        
+        #if !defined( __LINUX__ )
+            // Windows & OSX: Case insensitive
+            if ( ( compA >= 'A' ) && ( compB <= 'Z' ) )
+            {
+                compA = 'a' + ( compA - 'A' );
+            }
+            if ( ( compB >= 'A' ) && ( compB <= 'Z' ) )
+            {
+                compB = 'a' + ( compB - 'A' );
+            }
+        #endif
     }
+
     const bool hasCommonSubPath = ( pathA != basePath.Get() );
     if ( hasCommonSubPath == false )
     {


### PR DESCRIPTION
GetRelativePath is currently case sensitive on all systems.  As per the other code in PathUtils, change GetRelativePath to assume case insensitivity on windows and macosx.  This can solve issues when using. say, file paths which are using different cases for the drive letter on windows.
Due to the requirements of some of the current tests, preserves case in the output relative file path.