### PR TITLE
VS2019 build fixes for build tools v. 14.23.28105

### DIFF
--- a/Code/OSUI/OSWindow.cpp
+++ b/Code/OSUI/OSWindow.cpp
@@ -242,7 +242,7 @@ void OSWindow::SetMinimized( bool minimized )
 /*sttaic*/ uint32_t OSWindow::GetPrimaryScreenWidth()
 {
     #if defined( __WINDOWS__ )
-        return GetSystemMetrics( SM_CXSCREEN );
+        return uint32_t(GetSystemMetrics( SM_CXSCREEN ));
     #elif defined( __OSX__ )
         return WindowOSX_GetPrimaryScreenWidth();
     #else

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -353,6 +353,8 @@ void TestProjectGeneration::TestFunction_Speed() const
 //------------------------------------------------------------------------------
 void TestProjectGeneration::FindExecutableTarget() const
 {
+#pragma warning( push )
+#pragma warning (disable : 6011)
     // Parse bff
     FBuildTestOptions options;
     options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestProjectGeneration/FindExecutableTarget/fbuild.bff";
@@ -380,6 +382,7 @@ void TestProjectGeneration::FindExecutableTarget() const
         TEST_ASSERT( copy );
         TEST_ASSERT( copy->GetType() == Node::COPY_FILE_NODE );
     }
+#pragma warning( pop )
 }
 
 // IntellisenseAndCodeSense


### PR DESCRIPTION
Hello, I was only able to successfully build FASTBuild under VS2019 Enterprise with the latest build tools 14.23.28105 after this explicit cast and disabling a warning.