### PR TITLE
Add more special characters to XCodeProjectGenerator

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/XCodeProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/XCodeProjectGenerator.cpp
@@ -775,6 +775,7 @@ bool XCodeProjectGenerator::ShouldQuoteString( const AString & value ) const
              ( c == '"' ) ||
              ( c == '?' ) ||
              ( c == '-' ) ||
+             ( c == '+' ) ||
              ( c == '=' ) )
         {
             return true;


### PR DESCRIPTION
It looks like Xcode also treats the `+`  sign as a special character that requires quoting.