### PR TITLE
vs2019 build fix when warning C4365 is treated as error

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -1840,7 +1840,7 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
     // - since everything matches, we only need to migrate the stamps
     for ( Dependency & dep : newNode.m_StaticDependencies )
     {
-        const size_t index = ( &dep - newNode.m_StaticDependencies.Begin() );
+        const size_t index = size_t( &dep - newNode.m_StaticDependencies.Begin() );
         const Dependency & oldDep = oldNode->m_StaticDependencies[ index ];
         dep.Stamp( oldDep.GetNodeStamp() );
     }


### PR DESCRIPTION
warning C4365: 'initializing': conversion from '__int64' to 'size_t', signed/unsigned mismatch" is treated as error