### PR TITLE
[wip] Attempting to give more control over the behavior of symlinks when co…

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -15,6 +15,7 @@
 
 // system
 #if defined( __WINDOWS__ )
+    #include <winioctl.h>
     #include "Core/Env/WindowsHeader.h"
     #include "Core/Time/Time.h"
 #endif
@@ -70,6 +71,23 @@
         FuncPtr         m_FuncPtr       = nullptr;
     } gOSXHelper_utimensat;
 #endif
+
+/*static*/ FileIO::SymlinkBehavior FileIO::ParseSymlinkBehavior( const AString& value )
+{
+	if ( value.IsEmpty() || value.CompareI( "FollowSrcAndDest" ) )
+	{
+		return FOLLOW_SRC_AND_DST;
+	}
+	if ( value.CompareI( "FollowSrc" ) )
+	{
+		return FOLLOW_SRC;
+	}
+	if ( value.CompareI( "NoFollow" ) )
+	{
+		return FOLLOW_NEITHER;
+	}
+	return INVALID_SYM_LINK_BEHAVIOR;
+}
 
 // Exists
 //------------------------------------------------------------------------------
@@ -147,12 +165,41 @@
 
 // Copy
 //------------------------------------------------------------------------------
-/*static*/ bool FileIO::FileCopy( const char * srcFileName, const char * dstFileName,
-                              bool allowOverwrite )
+/*static*/ bool FileIO::FileCopy( const char* srcFileName, const char* dstFileName,
+	SymlinkBehavior linkBehavior, bool allowOverwrite )
 {
 #if defined( __WINDOWS__ )
-    DWORD flags = COPY_FILE_COPY_SYMLINK;
-    flags = ( allowOverwrite ? flags : flags | COPY_FILE_FAIL_IF_EXISTS );
+	DWORD flags = ( linkBehavior == FOLLOW_NEITHER ) ? COPY_FILE_COPY_SYMLINK : 0U;
+	flags = ( allowOverwrite ? flags : flags | COPY_FILE_FAIL_IF_EXISTS );
+
+	if ( linkBehavior == FOLLOW_SRC && allowOverwrite )
+	{
+		DWORD dwAttrs = GetFileAttributes( dstFileName );
+		if ( dwAttrs != INVALID_FILE_ATTRIBUTES &&
+			( dwAttrs & FILE_ATTRIBUTE_REPARSE_POINT ) )
+		{
+			HANDLE hFile = CreateFile( dstFileName, 0, FILE_SHARE_READ, 0,
+				OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, 0 );
+			VERIFY( hFile != INVALID_HANDLE_VALUE );
+			char buf[ 4096 ];
+			DWORD bufSize = 0;
+			bool isSymLink = false;
+			if ( DeviceIoControl( hFile, FSCTL_GET_REPARSE_POINT, NULL, 0, buf, sizeof( buf ), &bufSize, NULL ) )
+			{
+				ULONG* pTag = reinterpret_cast<ULONG*>( buf );
+				isSymLink = ( *pTag == IO_REPARSE_TAG_SYMLINK );
+			}
+			CloseHandle( hFile );
+
+			// CopyFileEx only supports FOLLOW_SRC_AND_DST and FOLLOW_NEITHER
+			// based on the COPY_FILE_COPY_SYMLINK flag.  
+			// (and COPY_FILE_COPY_SYMLINK isn't really FOLLOW_NEITHER)
+			if ( isSymLink && DeleteFile( dstFileName ) == 0 )
+			{
+				return false;
+			}
+		}
+	}
 
     BOOL result = CopyFileEx( srcFileName, dstFileName, nullptr, nullptr, nullptr, flags );
     if ( result == FALSE )
@@ -198,7 +245,15 @@
     // then copyfile() and fcopyfile() will use the information from the state
     // object; if it is NULL, then both functions will work normally, but less
     // control will be available to the caller.
-    bool result = ( copyfile( srcFileName, dstFileName, nullptr, COPYFILE_DATA | COPYFILE_XATTR | COPYFILE_NOFOLLOW ) == 0 );
+    copyfile_flags_t flags = COPYFILE_DATA | COPYFILE_XATTR;
+    switch ( linkBehavior )
+    {
+    case FOLLOW_NEITHER:
+        flags |= COPYFILE_NOFOLLOW_SRC;
+    case FOLLOW_SRC:
+        flags |= COPYFILE_NOFOLLOW_DST;
+    }
+    bool result = ( copyfile( srcFileName, dstFileName, nullptr, flags ) == 0 );
     return result;
 #elif defined( __LINUX__ )
     if ( allowOverwrite == false )
@@ -212,17 +267,39 @@
     struct stat stat_source;
     VERIFY( lstat( srcFileName, &stat_source ) == 0 );
 
-    // Special case symlinks.
-    if ( S_ISLNK( stat_source.st_mode ) )
+    if ( linkBehavior == FOLLOW_NEITHER )
     {
-        AString linkPath( stat_source.st_size + 1 );
-        ssize_t length = readlink( srcFileName, linkPath.Get(), linkPath.GetReserved() );
-        if ( length != stat_source.st_size )
+        // Special case symlinks.
+        if ( S_ISLNK( stat_source.st_mode ) )
         {
+            AString linkPath( stat_source.st_size + 1 );
+            ssize_t length = readlink( srcFileName, linkPath.Get(), linkPath.GetReserved() );
+            if ( length != stat_source.st_size )
+            {
+                return false;
+            }
+            linkPath.SetLength( length );
+            if ( symlink( linkPath.Get(), dstFileName ) == 0 )
+            {
+                return true;
+            }
+            // symlink will not clobber.
+            if ( errno == EEXIST )
+            {
+                return
+                    ( unlink( dstFileName ) == 0 ) &&
+                    ( symlink( linkPath.Get(), dstFileName ) == 0 );
+            }
             return false;
         }
-        linkPath.SetLength( length );
-        return symlink( linkPath.Get(), dstFileName ) == 0;
+    }
+
+    // Now that we know we're following the source, update the stats
+    // with the link target.  This also checks for a broken link. 
+    if ( S_ISLNK( stat_source.st_mode ) &&
+        stat( srcFileName, &stat_source ) != 0 )
+    {
+        return false;
     }
 
     int source = open( srcFileName, O_RDONLY, 0 );
@@ -234,11 +311,26 @@
     // Ensure dest file will be writable if it exists
     FileIO::SetReadOnly( dstFileName, false );
 
-    int dest = open( dstFileName, O_WRONLY | O_CREAT | O_TRUNC, 0644 );
+    int dstFlags = O_WRONLY | O_CREAT | O_TRUNC;
+    const bool noDstFollow = ( linkBehavior != FOLLOW_SRC_AND_DST );
+    if ( noDstFollow )
+    {
+        dstFlags |= O_NOFOLLOW;
+    }
+    int dest = open( dstFileName, dstFlags, 0644 );
     if ( dest < 0 )
     {
-        close( source );
-        return false;
+        if ( ( errno == ELOOP && noDstFollow ) &&
+            ( unlink( dstFileName ) == 0 ) &&
+            ( dest = open( dstFileName, dstFlags, 0644 ) ) )
+        {
+            // dest was a link, but unlink was able to remove it so open would work.
+        }
+        else
+        {
+            close( source );
+            return false;
+        }
     }
 
     // set permissions to match the source file's

--- a/Code/Core/FileIO/FileIO.h
+++ b/Code/Core/FileIO/FileIO.h
@@ -17,10 +17,19 @@
 class FileIO
 {
 public:
+	enum SymlinkBehavior
+	{
+		INVALID_SYM_LINK_BEHAVIOR,
+		FOLLOW_SRC_AND_DST,       // The pre-0.96 behavior, and behavior of cp
+		FOLLOW_SRC,
+		FOLLOW_NEITHER,           // The 0.96 behavior
+		DEFAULT_SYM_LINK_BEHAVIOR = FOLLOW_SRC_AND_DST,
+	};
+	static SymlinkBehavior ParseSymlinkBehavior( const AString& value );
     static bool FileExists( const char * fileName );
     static bool FileDelete( const char * fileName );
-    static bool FileCopy( const char * srcFileName, const char * dstFileName, bool allowOverwrite = true );
-    static bool FileMove( const AString & srcFileName, const AString & dstFileName );
+	static bool FileCopy( const char* srcFileName, const char* dstFileName, SymlinkBehavior linkBehavior = DEFAULT_SYM_LINK_BEHAVIOR, bool allowOverwrite = true );
+	static bool FileMove( const AString & srcFileName, const AString & dstFileName );
     static bool DirectoryDelete( const AString & path );
 
     // directory listing

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.h
@@ -35,6 +35,7 @@ private:
     AString             m_Source;
     AString             m_Dest;
     Array< AString >    m_PreBuildDependencyNames;
+    AString             m_SymlinkBehavior;
 };
 
 //------------------------------------------------------------------------------

--- a/External/SDK/VisualStudio/VisualStudio.bff
+++ b/External/SDK/VisualStudio/VisualStudio.bff
@@ -4,8 +4,8 @@
 // Select desired Visual Studio version
 //------------------------------------------------------------------------------
 //#define USING_VS2015
-#define USING_VS2017
-//#define USING_VS2019
+//#define USING_VS2017
+#define USING_VS2019
 
 // Activate
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR supercedes https://github.com/fastbuild/fastbuild/pull/628

I have an sdk with libfoo.so, and libfoo.so.10, with libfoo.so as a symlink to libfoo.so.10.  My build rules from 0.94 had a CopyFile from libfoo.so to a distribution folder which housed all the files needed to run the build result.  This now just creates a broken link in that distribution folder instead of a usable .so file.  From the point of view of my build, the current behavior is buggy.

My previous attempt to fix this had numerous flaws, not the least of which is that the build can't run twice because it can't overwrite the link (I think this is a problem with the current implementation as well!)  So, another reason why the current behavior is buggy?

I've attempted to make good on our discussion in the previous PR, and have added some options to CopyFile.  There's still some work to do to finish this up (documentation, more testing), but I wanted to get your thoughts on it before working on it more.

In this PR, I've set the default behavior back to the 0.94 behavior, which is the same as the behavior of `copy` or `cp`, as I think those define what will be "least surprise".
