### PR TITLE
Use different token type for opening and closing brackets

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFToken.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFToken.h
@@ -18,19 +18,22 @@ class BFFFile;
 //------------------------------------------------------------------------------
 enum class BFFTokenType : uint8_t
 {
-    Invalid,        // Input that can't be reconciled
-    Identifier,     // Unspecified identifier
-    Function,       // ForEach, Compiler etc
-    Variable,       // .Var or ^Var
-    Keyword,        // in etc
-    Number,         // 12, 56, -102 etc
-    Operator,       // = += > ! == etc
-    RoundBracket,   // ( or )
-    CurlyBracket,   // { or }
-    SquareBracket,  // [ or ]
-    String,         // "Hello"
-    Boolean,        // true or false
-    Comma,          // Comma
+    Invalid,               // Input that can't be reconciled
+    Identifier,            // Unspecified identifier
+    Function,              // ForEach, Compiler etc
+    Variable,              // .Var or ^Var
+    Keyword,               // in etc
+    Number,                // 12, 56, -102 etc
+    Operator,              // = += > ! == etc
+    OpeningRoundBracket,   // (
+    ClosingRoundBracket,   // )
+    OpeningCurlyBracket,   // {
+    ClosingCurlyBracket,   // }
+    OpeningSquareBracket,  // [
+    ClosingSquareBracket,  // ]
+    String,                // "Hello"
+    Boolean,               // true or false
+    Comma,                 // Comma
 };
 
 // BFFToken
@@ -53,9 +56,12 @@ public:
     bool IsOperator() const                         { return ( m_Type == BFFTokenType::Operator ); }
     bool IsOperator( const char * op ) const        { return ( m_Type == BFFTokenType::Operator ) && ( m_String == op ); }
     bool IsOperator( const char op ) const          { return ( m_Type == BFFTokenType::Operator ) && ( m_String[ 0 ] == op ); }
-    bool IsRoundBracket() const                     { return ( m_Type == BFFTokenType::RoundBracket ); }
-    bool IsCurlyBracket() const                     { return ( m_Type == BFFTokenType::CurlyBracket ); }
-    bool IsSquareBracket() const                    { return ( m_Type == BFFTokenType::SquareBracket ); }
+    bool IsOpeningRoundBracket() const              { return ( m_Type == BFFTokenType::OpeningRoundBracket ); }
+    bool IsClosingRoundBracket() const              { return ( m_Type == BFFTokenType::ClosingRoundBracket ); }
+    bool IsOpeningCurlyBracket() const              { return ( m_Type == BFFTokenType::OpeningCurlyBracket ); }
+    bool IsClosingCurlyBracket() const              { return ( m_Type == BFFTokenType::ClosingCurlyBracket ); }
+    bool IsOpeningSquareBracket() const             { return ( m_Type == BFFTokenType::OpeningSquareBracket ); }
+    bool IsClosingSquareBracket() const             { return ( m_Type == BFFTokenType::ClosingSquareBracket ); }
     bool IsString() const                           { return ( m_Type == BFFTokenType::String ); }
     bool IsBooelan() const                          { return ( m_Type == BFFTokenType::Boolean ); }
     bool IsVariable() const                         { return ( m_Type == BFFTokenType::Variable ); }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFTokenizer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFTokenizer.cpp
@@ -291,25 +291,46 @@ bool BFFTokenizer::Tokenize( const BFFFile & file, const char * pos, const char 
         }
 
         // Round Brackets?
-        if ( ( c == '(' ) || ( c == ')' ) )
+        if ( c == '(' )
         {
-            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::RoundBracket, pos, pos + 1 ) );
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::OpeningRoundBracket, pos, pos + 1 ) );
+            pos++;
+            continue;
+        }
+
+        if ( c == ')' )
+        {
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::ClosingRoundBracket, pos, pos + 1 ) );
             pos++;
             continue;
         }
 
         // Curly Brackets?
-        if ( ( c == '{' ) || ( c == '}' ) )
+        if ( c == '{' )
         {
-            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::CurlyBracket, pos, pos + 1 ) );
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::OpeningCurlyBracket, pos, pos + 1 ) );
+            pos++;
+            continue;
+        }
+
+        if ( c == '}' )
+        {
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::ClosingCurlyBracket, pos, pos + 1 ) );
             pos++;
             continue;
         }
 
         // Square Brackets?
-        if ( ( c == '[' ) || ( c == ']' ) )
+        if ( c == '[' )
         {
-            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::SquareBracket, pos, pos + 1 ) );
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::OpeningSquareBracket, pos, pos + 1 ) );
+            pos++;
+            continue;
+        }
+
+        if ( c == ']' )
+        {
+            m_Tokens.Append( BFFToken( file, tokenStart, BFFTokenType::ClosingSquareBracket, pos, pos + 1 ) );
             pos++;
             continue;
         }
@@ -678,7 +699,7 @@ bool BFFTokenizer::HandleDirective_If( const BFFFile & file, const char * & pos,
 bool BFFTokenizer::HandleDirective_IfExists( BFFTokenRange & iter, bool & outResult )
 {
     // Expect open bracket
-    if ( ( iter->IsRoundBracket() == false ) || ( iter->GetValueString() != "(" ) )
+    if ( iter->IsOpeningRoundBracket() == false )
     {
         Error::Error_1031_UnexpectedCharFollowingDirectiveName( iter.GetCurrent(), AStackString<>( "exists" ), '(' );
         return false;
@@ -695,8 +716,8 @@ bool BFFTokenizer::HandleDirective_IfExists( BFFTokenRange & iter, bool & outRes
     const AString & varName = iter->GetValueString();
     iter++; // consume string value
 
-    // Expect open bracket
-    if ( ( iter->IsRoundBracket() == false ) || ( iter->GetValueString() != ")" ) )
+    // Expect close bracket
+    if ( iter->IsClosingRoundBracket() == false )
     {
         Error::Error_1031_UnexpectedCharFollowingDirectiveName( iter.GetCurrent(), AStackString<>( "exists" ), ')' );
         return false;


### PR DESCRIPTION
All places in the code that check for a particular bracket type also need to distinguish between opening and closing brackets.

In some places only the bracket type was checked and it resulted in code like this to be parsed without errors:
```
    .Array = } 42 }
    .Struct = ]]
```

To simplify checks and to eliminate possibility of forgetting to check for opening vs closing bracket, opening an closing bracket now use different `BFFTokenType` values.