### PR TITLE
Fixes PCH not working properly on MSVC when defining obj file manually

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -482,8 +482,7 @@ void ObjectListNode::GetInputFiles( Args & fullArgs, const AString & pre, const 
                 if ( on->IsMSVC() )
                 {
                     fullArgs += pre;
-                    fullArgs += on->GetName();
-                    fullArgs += on->GetObjExtension();
+                    fullArgs += on->GetPCHObjectName();
                     fullArgs += post;
                     fullArgs.AddDelimiter();
                     continue;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -93,6 +93,8 @@ public:
     void GetNativeAnalysisXMLPath( AString& outXMLFileName ) const;
 
     const char * GetObjExtension() const;
+
+    const AString & GetPCHObjectName() const { return m_PCHObjectFileName; }
 private:
     virtual BuildResult DoBuild( Job * job ) override;
     virtual BuildResult DoBuild2( Job * job, bool racingRemoteJob ) override;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/DifferentObj_MSVC/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/DifferentObj_MSVC/fbuild.bff
@@ -1,0 +1,37 @@
+
+#include "..\testcommon.bff"
+
+// Settings & default ToolChain
+Using( .StandardEnvironment )
+Settings {} // use Standard Environment
+
+//
+// Build an object using precompiled headers
+//
+ObjectList( "PCHTest-lib" )
+{
+    .PCHInputFile               = "Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/PrecompiledHeader.cpp"
+    .PCHOutputFile              = "$Out$/Test/PrecompiledHeaders/DifferentObj_MSVC/PrecompiledHeader.pch"
+
+    // Set a different name for the obj file
+    .PCHOptions - ' /Fo"%3"'
+    .PCHOptions + ' /Fo"$PCHOutputFile$.different.obj"'
+
+    .CompilerInputPath  = "Tools/FBuild/FBuildTest/Data/TestPrecompiledHeaders/"
+    .CompilerInputPathRecurse = false
+    .CompilerOutputPath = "$Out$/Test/PrecompiledHeaders/DifferentObj_MSVC/"
+    .CompilerOptions    + ' /Yu"PrecompiledHeader.h" /Fp"$PCHOutputFile$"'
+                        + ' "/ITools/FBuild/FBuildTest/Data/TestPrecompiledHeaders"'
+    .PCHOptions         + ' "/ITools/FBuild/FBuildTest/Data/TestPrecompiledHeaders"'
+}
+
+//
+// Link objects to ensure no debug info related mismatches
+//
+Executable( "PCHTest" )
+{
+    .LinkerOptions      + ' /ENTRY:main'
+
+    .LinkerOutput       = "$Out$/Test/PrecompiledHeaders/DifferentObj_MSVC/PCHTest.exe"
+    .Libraries          = { "PCHTest-lib" }
+}


### PR DESCRIPTION
It doesn't work when defining PCH obj output filename manually. The problem comes from the duplication of the logic for generating the PCH obj output filename.