### PR TITLE
Fixes MSVC compilation with 14.24.28314

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFToken.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFToken.h
@@ -44,6 +44,8 @@ public:
     BFFToken( const BFFFile & file, const char * sourcePos, BFFTokenType type, const AString & stringValue );
     BFFToken( const BFFFile & file, const char * sourcePos, BFFTokenType type, const bool boolValue );
 
+    BFFToken& operator=(const BFFToken&) = delete;
+
     // Convenience wrappers
     bool IsInvalid() const                          { return ( m_Type == BFFTokenType::Invalid ); }
     bool IsIdentifier() const                       { return ( m_Type == BFFTokenType::Identifier ); }

--- a/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFTokenizer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Tokenizer/BFFTokenizer.cpp
@@ -516,7 +516,7 @@ bool BFFTokenizer::HandleDirective( const char * & pos, const char * end, const 
         // fall through to error handling
     }
 
-    const BFFToken error( file, argsStart, BFFTokenType::Invalid, argsStart );
+    const BFFToken error( file, argsStart, BFFTokenType::Invalid, argsStart, argsStart + 1 );
     Error::Error_1030_UnknownDirective( &error, directive );
     return false;
 }


### PR DESCRIPTION
Getting errors when compiling:
- `warning C4626: 'BFFToken': assignment operator was implicitly defined as deleted`
- `warning C5027: 'BFFToken': move assignment operator was implicitly defined as deleted`
- `warning C4800: Implicit conversion from 'const char *' to bool. Possible information loss`