### PR TITLE
Only add include if preprocessor included it

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CIncludeParser.cpp
@@ -258,6 +258,7 @@ bool CIncludeParser::ParseGCC_Preprocessed( const char * compilerOutput,
     (void)compilerOutputSize;
 
     const char * pos = compilerOutput;
+    bool hasFlags = true;
 
     // special case for include on first line
     // (out of loop to keep loop logic simple)
@@ -283,6 +284,7 @@ bool CIncludeParser::ParseGCC_Preprocessed( const char * compilerOutput,
         }
         if ( strncmp( pos, "line ", 5 ) == 0 )
         {
+            hasFlags = false;
             pos += 5;
             goto foundInclude;
         }
@@ -339,8 +341,16 @@ bool CIncludeParser::ParseGCC_Preprocessed( const char * compilerOutput,
         {
             continue;
         }
+        pos++;
 
-        AddInclude( lineStart, lineEnd );
+        // only add an include if the preprocessor included it (indicated by the `1` flag
+        // https://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html
+        // or if it is coming from -fms-extention which doesn't have flags
+        if ( strncmp( pos, " 1", 2 ) == 0 || !hasFlags )
+        {
+            AddInclude( lineStart, lineEnd );
+        }
+
     }
 
     return true;

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestIncludeParser.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestIncludeParser.cpp
@@ -277,9 +277,9 @@ void TestIncludeParser::TestGCCPreprocessedOutput() const
 
             // check number of includes found to prevent future regressions
             const Array< AString > & includes = parser.GetIncludes();
-            TEST_ASSERT( includes.GetSize() == 222 );
+            TEST_ASSERT( includes.GetSize() == 221 );
             #ifdef DEBUG
-                TEST_ASSERT( parser.GetNonUniqueCount() == 1029 );
+                TEST_ASSERT( parser.GetNonUniqueCount() == 308 );
             #endif
         }
     }
@@ -327,9 +327,9 @@ void TestIncludeParser::TestClangPreprocessedOutput() const
 
             // check number of includes found to prevent future regressions
             const Array< AString > & includes = parser.GetIncludes();
-            TEST_ASSERT( includes.GetSize() == 280 );
+            TEST_ASSERT( includes.GetSize() == 279 );
             #ifdef DEBUG
-                TEST_ASSERT( parser.GetNonUniqueCount() == 1280 );
+                TEST_ASSERT( parser.GetNonUniqueCount() == 427 );
             #endif
         }
     }
@@ -463,9 +463,9 @@ void TestIncludeParser::ClangLineEndings() const
 
     // check number of includes found to prevent future regressions
     const Array< AString > & includes = parser.GetIncludes();
-    TEST_ASSERT( includes.GetSize() == 4 );
+    TEST_ASSERT( includes.GetSize() == 3 );
     #ifdef DEBUG
-        TEST_ASSERT( parser.GetNonUniqueCount() == 8 );
+        TEST_ASSERT( parser.GetNonUniqueCount() == 3 );
     #endif
 }
 


### PR DESCRIPTION
When using tools like bison to generate a cpp file, it will leave `#line`
directives. This can cause fbuild to incorrectly add the file as a
dependency. Instead of always adding the included file, only add it if
the preprocessor included it. This can be detected by flags at the end of the
preprocessor line. Eg

```
cat main.cpp
 #include "found.h"
 #line 1 "notreal.h

touch found.h

g++ -E -c main.cpp
 # 1 "main.cpp"
 # 1 "<built-in>"
 # 1 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
 # 1 "<command-line>" 2
 # 1 "main.cpp"
 # 1 "found.h" 1
 # 2 "main.cpp" 2
 # 1 "notreal.h"
```

Lines which contain at least a ` 1` at the end should be the only files
tracked by fbuild since that is what the preprocessor includes.

https://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html

The reason why `GetSize()` is reduced by 1 is because the actual file
being compiled is in the preprocessed output and it now skipped (because
it does not have a ` 1` and fbuild tracks the file anyway)

Lines starting with `#line` for the clang fms-extension are still always
added

Fixes: https://github.com/fastbuild/fastbuild/issues/228