### PR TITLE
Add ability to manually specify workers via an environment variable.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -373,9 +373,21 @@ bool FBuild::Build( Node * nodeToBuild )
         Array< AString > workers;
         if ( settings->GetWorkerList().IsEmpty() )
         {
-            // check for workers through brokerage
-            // TODO:C This could be moved out of the main code path
-            m_WorkerBrokerage.FindWorkers( workers );
+            // Check for workers for the FASTBUILD_WORKERS environment variable
+            // which is a list of worker addresses separated by a semi-colon.
+            
+            AString workersEnv;
+            if ( Env::GetEnvVariable("FASTBUILD_WORKERS", workersEnv) )
+            {
+                workersEnv.Tokenize(workers, ';');
+            }
+            
+            if ( workers.IsEmpty() )
+            {
+                // check for workers through brokerage
+                // TODO:C This could be moved out of the main code path
+                m_WorkerBrokerage.FindWorkers(workers);
+            }
         }
         else
         {


### PR DESCRIPTION
E.g FASTBUILD_WORKERS=10.0.0.1;10.0.0.2;10.0.0.3

Useful for managing groups of workers where worker discovery cannot be used (e.g DNS lookup not working).