### PR TITLE
Don't define nullptr

### DIFF
--- a/Code/Core/Env/Types.h
+++ b/Code/Core/Env/Types.h
@@ -103,12 +103,6 @@ typedef signed int          int32_t;
     #define __w64
 #endif
 
-#if !defined( __WINDOWS__ ) || defined( __clang__ )
-    #ifndef nullptr
-        #define nullptr (0)
-    #endif
-#endif
-
 // Versions of Visual Studio prior to 2017 don't manage noexcept properly
 #if defined( _MSC_VER ) && ( _MSC_VER < 1910 ) && !defined( __clang__ )
     #define NOEXCEPT

--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -135,6 +135,7 @@ public:
                                    0,               // DWORD dwCreationFlags
                                    nullptr      // LPDWORD lpThreadId
                                  );
+        ASSERT( h != nullptr );
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         #if __has_feature( address_sanitizer ) || defined( __SANITIZE_ADDRESS__ )
             // AddressSanitizer instruments objects created on the stack by inserting redzones around them.
@@ -142,17 +143,16 @@ public:
             // To account for that double the requested stack size for the thread.
             stackSize *= 2;
         #endif
-        pthread_t h;
+        pthread_t h( 0 );
         pthread_attr_t threadAttr;
         VERIFY( pthread_attr_init( &threadAttr ) == 0 );
         VERIFY( pthread_attr_setstacksize( &threadAttr, stackSize ) == 0 );
         VERIFY( pthread_attr_setdetachstate( &threadAttr, PTHREAD_CREATE_JOINABLE ) == 0 );
         VERIFY( pthread_create( &h, &threadAttr, ThreadStartInfo::ThreadStartFunction, &info ) == 0 );
+        ASSERT( h != (pthread_t)0 );
     #else
         #error Unknown platform
     #endif
-
-    ASSERT( h != nullptr );
 
     return (Thread::ThreadHandle)h;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -613,7 +613,7 @@ bool Node::Deserialize( NodeGraph & nodeGraph, IOStream & stream )
          ( m_StaticDependencies.Load( nodeGraph, stream ) == false ) ||
          ( m_DynamicDependencies.Load( nodeGraph, stream ) == false ) )
     {
-        return nullptr;
+        return false;
     }
 
     // Properties

--- a/Code/Tools/FBuild/FBuildCore/Graph/SLNNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/SLNNode.cpp
@@ -380,14 +380,14 @@ bool SLNNode::GatherProject( NodeGraph & nodeGraph,
     if ( node == nullptr )
     {
         Error::Error_1104_TargetNotDefined( iter, function, propertyName, projectName );
-        return nullptr;
+        return false;
     }
     if ( ( node->GetType() != Node::VCXPROJECT_NODE ) &&
          ( node->GetType() != Node::VSPROJEXTERNAL_NODE ) )
     {
         // don't know how to handle this type of node
         Error::Error_1005_UnsupportedNodeType( iter, function, propertyName, node->GetName(), node->GetType() );
-        return nullptr;
+        return false;
     }
     VSProjectBaseNode * projectNode = ( node->GetType() == Node::VCXPROJECT_NODE )
                                     ? static_cast< VSProjectBaseNode * >( node->CastTo< VCXProjectNode >() )


### PR DESCRIPTION
# Description:
All supported compilers support `nullptr` natively.
Avoiding custom definition helps to find some unintended type conversions.

# Checklist:

The PR:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on all platforms**
- [ ] **Has accompanying tests** - This if a refactoring/cleanup, so no new tests.
- [x] **Passes tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** - This if a refactoring/cleanup, so no documentation required.
