### PR TITLE
Use Array::EmplaceBack instead of Append where possible

### DIFF
--- a/Code/Core/CoreTest/Tests/TestHash.cpp
+++ b/Code/Core/CoreTest/Tests/TestHash.cpp
@@ -140,11 +140,11 @@ void TestHash::CompareHashTimes_Small() const
 {
     // some different strings to hash
     Array< AString > strings( 32, true );
-    strings.Append( AString( " " ) );
-    strings.Append( AString( "shOrt" ) );
-    strings.Append( AString( "MediumstringMediumstring123456789" ) );
-    strings.Append( AString( "longstring_98274ncoif834JODhiorhmwe8r8wy48on87h8mhwejrijrdIERwurd9j,8chm8hiuorciwriowjri" ) );
-    strings.Append( AString( "c:\\files\\subdir\\project\\thing\\stuff.cpp" ) );
+    strings.EmplaceBack( " " );
+    strings.EmplaceBack( "shOrt" );
+    strings.EmplaceBack( "MediumstringMediumstring123456789" );
+    strings.EmplaceBack( "longstring_98274ncoif834JODhiorhmwe8r8wy48on87h8mhwejrijrdIERwurd9j,8chm8hiuorciwriowjri" );
+    strings.EmplaceBack( "c:\\files\\subdir\\project\\thing\\stuff.cpp" );
     const size_t numStrings = strings.GetSize();
     #if defined( DEBUG )
         const size_t numIterations = 10240;

--- a/Code/OSUI/OSListView.mm
+++ b/Code/OSUI/OSListView.mm
@@ -132,7 +132,7 @@ void ListViewOSX_AddItem( OSListView * owner, const char * itemText )
     // Add item
     {
         MutexHolder mh( table->m_Mutex );
-        table->m_Columns[0]->m_Data.Append(AStackString<>(itemText));
+        table->m_Columns[ 0 ]->m_Data.EmplaceBack( itemText );
     }
     
     [table RefreshUI];

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -524,7 +524,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
             return false;
         }
 
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
     }
     return true;
 }
@@ -623,7 +623,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         return false;
     }
 
-    nodes.Append( Dependency( node ) );
+    nodes.EmplaceBack( node );
     return true;
 }
 
@@ -675,7 +675,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
             return false;
         }
 
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
     }
     return true;
 }
@@ -726,7 +726,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     {
         // not found - create a new file node
         n = nodeGraph.CreateFileNode( nodeName );
-        nodes.Append( Dependency( n ) );
+        nodes.EmplaceBack( n );
         return true;
     }
 
@@ -734,7 +734,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     if ( n->IsAFile() )
     {
         // found file - just use as is
-        nodes.Append( Dependency( n ) );
+        nodes.EmplaceBack( n );
         return true;
     }
 
@@ -742,7 +742,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     if ( n->GetType() == Node::OBJECT_LIST_NODE )
     {
         // use as-is
-        nodes.Append( Dependency( n ) );
+        nodes.EmplaceBack( n );
         return true;
     }
 
@@ -753,7 +753,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::COPY_DIR_NODE )
         {
             // use as-is
-            nodes.Append( Dependency( n ) );
+            nodes.EmplaceBack( n );
             return true;
         }
     }
@@ -763,7 +763,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::REMOVE_DIR_NODE )
         {
             // use as-is
-            nodes.Append( Dependency( n ) );
+            nodes.EmplaceBack( n );
             return true;
         }
     }
@@ -773,7 +773,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::UNITY_NODE )
         {
             // use as-is
-            nodes.Append( Dependency( n ) );
+            nodes.EmplaceBack( n );
             return true;
         }
     }
@@ -783,7 +783,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::COMPILER_NODE )
         {
             // use as-is
-            nodes.Append( Dependency( n ) );
+            nodes.EmplaceBack( n );
             return true;
         }
     }
@@ -847,7 +847,7 @@ bool Function::GetStrings( const BFFToken * iter, Array< AString > & strings, co
 bool Function::ProcessAlias( NodeGraph & nodeGraph, const BFFToken * iter, Node * nodeToAlias ) const
 {
     Dependencies nodesToAlias( 1, false );
-    nodesToAlias.Append( Dependency( nodeToAlias ) );
+    nodesToAlias.EmplaceBack( nodeToAlias );
     return ProcessAlias( nodeGraph, iter, nodesToAlias );
 }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
@@ -163,7 +163,7 @@ FunctionCopy::FunctionCopy()
             return false; // Initialize will have emitted an error
         }
 
-        copyNodes.Append( Dependency( copyFileNode ) );
+        copyNodes.EmplaceBack( copyFileNode );
     }
 
     // handle alias creation

--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -429,7 +429,7 @@ bool LightCache::ParseDirective_Include( IncludedFile & file, const char * & pos
             return false;
         }
 
-        file.m_Includes.Append( IncludedFile::Include{ include, includeType } );
+        file.m_Includes.EmplaceBack( include, includeType );
         return true;
     }
 
@@ -441,7 +441,7 @@ bool LightCache::ParseDirective_Include( IncludedFile & file, const char * & pos
     }
 
     // Store the macro include which will be resolved later
-    file.m_Includes.Append( IncludedFile::Include{ macroName, IncludeType::MACRO } );
+    file.m_Includes.EmplaceBack( macroName, IncludeType::MACRO );
     return true;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -252,7 +252,7 @@ bool FBuild::GetTargets( const Array< AString > & targets, Dependencies & outDep
 
             return false;
         }
-        outDeps.Append( Dependency( node ) );
+        outDeps.EmplaceBack( node );
     }
 
     return true;
@@ -558,8 +558,7 @@ bool FBuild::ImportEnvironmentVar( const char * name, bool optional, AString & v
     }
 
     // import new variable name with its hash value
-    const EnvironmentVarAndHash var( name, hash );
-    m_ImportedEnvironmentVars.Append( var );
+    m_ImportedEnvironmentVars.EmplaceBack( name, hash );
 
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -369,7 +369,7 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
     if ( m_Targets.IsEmpty() )
     {
         FLOG_INFO( "No target specified, defaulting to target 'all'" );
-        m_Targets.Append( AStackString<>( "all" ) );
+        m_Targets.EmplaceBack( "all" );
     }
 
     // When building multiple targets, try to build as much as possible

--- a/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
@@ -47,7 +47,7 @@ CSNode::CSNode()
 , m_NumCompilerInputFiles( 0 )
 , m_NumCompilerReferences( 0 )
 {
-    m_CompilerInputPattern.Append( AStackString<>( "*.cs" ) );
+    m_CompilerInputPattern.EmplaceBack( "*.cs" );
     m_Type = CS_NODE;
     m_LastBuildTimeMs = 5000; // higher default than a file node
 }
@@ -105,7 +105,7 @@ CSNode::CSNode()
 
     // Store dependencies
     m_StaticDependencies.SetCapacity( 1 + m_CompilerInputPath.GetSize() + m_NumCompilerInputFiles + m_NumCompilerReferences );
-    m_StaticDependencies.Append( Dependency( compilerNode ) );
+    m_StaticDependencies.EmplaceBack( compilerNode );
     m_StaticDependencies.Append( compilerInputPath );
     m_StaticDependencies.Append( compilerInputFiles );
     m_StaticDependencies.Append( compilerReferences );
@@ -151,7 +151,7 @@ CSNode::~CSNode() = default;
                 return false;
             }
 
-            m_DynamicDependencies.Append( Dependency( sn ) );
+            m_DynamicDependencies.EmplaceBack( sn );
         }
         continue;
     }

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
@@ -168,7 +168,7 @@ CopyDirNode::~CopyDirNode() = default;
                 }
             }
 
-            m_DynamicDependencies.Append( Dependency( n ) );
+            m_DynamicDependencies.EmplaceBack( n );
         }
     }
     return true;

--- a/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.cpp
@@ -80,7 +80,7 @@ bool Dependencies::Load( NodeGraph & nodeGraph, IOStream & stream )
         }
 
         // Recombine dependency info
-        Append( Dependency( node, stamp, isWeak ) );
+        EmplaceBack( node, stamp, isWeak );
     }
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -54,7 +54,7 @@ ExecNode::ExecNode()
 {
     m_Type = EXEC_NODE;
 
-    m_ExecInputPattern.Append( AStackString<>( "*.*" ) );
+    m_ExecInputPattern.EmplaceBack( "*.*" );
 }
 
 // Initialize
@@ -148,7 +148,7 @@ ExecNode::~ExecNode() = default;
                 return false;
             }
 
-            m_DynamicDependencies.Append( Dependency( sn ) );
+            m_DynamicDependencies.EmplaceBack( sn );
         }
     }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
@@ -92,8 +92,8 @@ void FileNode::DumpOutput( Job * job, const char * data, uint32_t dataSize, cons
     if ( ( data != nullptr ) && ( dataSize > 0 ) )
     {
         Array< AString > exclusions( 2, false );
-        exclusions.Append( AString( "Note: including file:" ) );
-        exclusions.Append( AString( "#line" ) );
+        exclusions.EmplaceBack( "Note: including file:" );
+        exclusions.EmplaceBack( "#line" );
 
         AStackString<> msg;
         msg.Format( "%s: %s\n", treatAsWarnings ? "WARNING" : "PROBLEM", name.Get() );

--- a/Code/Tools/FBuild/FBuildCore/Graph/LibraryNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LibraryNode.cpp
@@ -132,7 +132,7 @@ LibraryNode::~LibraryNode()
     const size_t endIndex = m_StaticDependencies.GetSize();
     for ( size_t i=startIndex; i<endIndex; ++i )
     {
-        m_DynamicDependencies.Append( Dependency( m_StaticDependencies[ i ].GetNode() ) );
+        m_DynamicDependencies.EmplaceBack( m_StaticDependencies[ i ].GetNode() );
     }
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -1191,7 +1191,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
         }
 
         // found existing node
-        libs.Append( Dependency( node ) );
+        libs.EmplaceBack( node );
         found = true;
         return true; // no error
     }
@@ -1200,7 +1200,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( FileIO::FileExists( potentialNodeNameClean.Get() ) )
     {
         node = nodeGraph.CreateFileNode( potentialNodeNameClean );
-        libs.Append( Dependency( node ) );
+        libs.EmplaceBack( node );
         found = true;
         FLOG_INFO( "Additional library '%s' assumed to be '%s'\n", lib.Get(), potentialNodeNameClean.Get() );
         return true; // no error
@@ -1305,7 +1305,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     // node not found - create a new FileNode, assuming we are
     // linking against an externally built library
     node = nodeGraph.CreateFileNode( nodeName );
-    nodes.Append( Dependency( node ) );
+    nodes.EmplaceBack( node );
     return true;
 }
 
@@ -1322,7 +1322,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::LIBRARY_NODE )
     {
         // can link directly to it
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
         return true;
     }
 
@@ -1330,7 +1330,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::OBJECT_LIST_NODE )
     {
         // can link directly to it
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
         return true;
     }
 
@@ -1338,7 +1338,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::DLL_NODE )
     {
         // TODO:B Depend on import lib
-        nodes.Append( Dependency( node, 0, true ) ); // NOTE: Weak dependency
+        nodes.EmplaceBack( node, 0, true ); // NOTE: Weak dependency
         return true;
     }
 
@@ -1346,7 +1346,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::FILE_NODE )
     {
         // can link directy against it
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
         return true;
     }
 
@@ -1354,7 +1354,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::COPY_FILE_NODE )
     {
         // depend on copy - will use input at build time
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
         return true;
     }
 
@@ -1362,7 +1362,7 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     if ( node->GetType() == Node::EXEC_NODE )
     {
         // depend on ndoe - will use exe output at build time
-        nodes.Append( Dependency( node ) );
+        nodes.EmplaceBack( node );
         return true;
     }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -203,7 +203,7 @@ bool NodeGraph::ParseFromRoot( const char * bffFile )
         m_UsedFiles.SetCapacity( usedFiles.GetSize() );
         for ( const BFFFile * file : usedFiles )
         {
-            m_UsedFiles.Append( UsedFile( file->GetFileName(), file->GetTimeStamp(), file->GetHash() ) );
+            m_UsedFiles.EmplaceBack( file->GetFileName(), file->GetTimeStamp(), file->GetHash() );
         }
     }
     return ok;
@@ -1509,7 +1509,7 @@ void NodeGraph::FindNearestNodesInternal( const AString & fullPath, Array< NodeW
 
             if ( nodes.IsEmpty() )
             {
-                nodes.Append( NodeWithDistance( node, d ) );
+                nodes.EmplaceBack( node, d );
                 worstMinDistance = nodes.Top().m_Distance;
             }
             else if ( d >= worstMinDistance )
@@ -1517,7 +1517,7 @@ void NodeGraph::FindNearestNodesInternal( const AString & fullPath, Array< NodeW
                 ASSERT( nodes.IsEmpty() || nodes.Top().m_Distance == worstMinDistance );
                 if ( false == nodes.IsAtCapacity() )
                 {
-                    nodes.Append( NodeWithDistance( node, d ) );
+                    nodes.EmplaceBack( node, d );
                     worstMinDistance = d;
                 }
             }
@@ -1528,7 +1528,7 @@ void NodeGraph::FindNearestNodesInternal( const AString & fullPath, Array< NodeW
 
                 if ( false == nodes.IsAtCapacity() )
                 {
-                    nodes.Append(NodeWithDistance());
+                    nodes.EmplaceBack();
                 }
 
                 size_t pos = count;
@@ -1698,7 +1698,7 @@ bool NodeGraph::ReadHeaderAndUsedFiles( IOStream & nodeGraphStream, const char* 
             return false;
         }
 
-        files.Append( UsedFile( fileName, timeStamp, dataHash ) );
+        files.EmplaceBack( fileName, timeStamp, dataHash );
     }
 
     return true;
@@ -1852,14 +1852,14 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
             }
             if ( newDepNode )
             {
-                newDeps.Append( Dependency( newDepNode, oldDep.GetNodeStamp(), oldDep.IsWeak() ) );
+                newDeps.EmplaceBack( newDepNode, oldDep.GetNodeStamp(), oldDep.IsWeak() );
             }
             else
             {
                 // Create the dependency
                 newDepNode = Node::CreateNode( *this, oldDepNode->GetType(), oldDepNode->GetName() );
                 ASSERT( newDepNode );
-                newDeps.Append( Dependency( newDepNode, oldDep.GetNodeStamp(), oldDep.IsWeak() ) );
+                newDeps.EmplaceBack( newDepNode, oldDep.GetNodeStamp(), oldDep.IsWeak() );
 
                 // Early out for FileNode (no properties and doesn't need Initialization)
                 if ( oldDepNode->GetType() == Node::FILE_NODE )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -76,7 +76,7 @@ ObjectListNode::ObjectListNode()
 {
     m_LastBuildTimeMs = 10000;
 
-    m_CompilerInputPattern.Append( AStackString<>( "*.cpp" ) );
+    m_CompilerInputPattern.EmplaceBack( "*.cpp" );
 }
 
 // Initialize
@@ -191,7 +191,7 @@ ObjectListNode::ObjectListNode()
             Error::Error_1102_UnexpectedType( iter, function, "CompilerInputUnity", unity, n->GetType(), Node::UNITY_NODE );
             return false;
         }
-        compilerInputUnity.Append( Dependency( n ) );
+        compilerInputUnity.EmplaceBack( n );
     }
     m_NumCompilerInputUnity = (uint32_t)compilerInputUnity.GetSize();
 
@@ -226,14 +226,14 @@ ObjectListNode::ObjectListNode()
 
     // Store dependencies
     m_StaticDependencies.SetCapacity( m_StaticDependencies.GetSize() + 1 + ( preprocessorNode ? 1 : 0 ) + ( precompiledHeader ? 1 : 0 ) + compilerInputPath.GetSize() + m_NumCompilerInputUnity + m_NumCompilerInputFiles );
-    m_StaticDependencies.Append( Dependency( compilerNode ) );
+    m_StaticDependencies.EmplaceBack( compilerNode );
     if ( preprocessorNode )
     {
-        m_StaticDependencies.Append( Dependency( preprocessorNode ) );
+        m_StaticDependencies.EmplaceBack( preprocessorNode );
     }
     if ( precompiledHeader )
     {
-        m_StaticDependencies.Append( Dependency( precompiledHeader ) );
+        m_StaticDependencies.EmplaceBack( precompiledHeader );
     }
     m_StaticDependencies.Append( compilerInputPath );
     m_StaticDependencies.Append( compilerInputUnity );
@@ -395,7 +395,7 @@ ObjectListNode::~ObjectListNode() = default;
     // b) a DLL or executable links our .obj files
     if ( m_UsingPrecompiledHeader )
     {
-        m_DynamicDependencies.Append( Dependency( GetPrecompiledHeader() ) );
+        m_DynamicDependencies.EmplaceBack( GetPrecompiledHeader() );
     }
 
     return true;
@@ -680,7 +680,7 @@ bool ObjectListNode::CreateDynamicObjectNode( NodeGraph & nodeGraph, Node * inpu
             return false;
         }
     }
-    m_DynamicDependencies.Append( Dependency( on ) );
+    m_DynamicDependencies.EmplaceBack( on );
     return true;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -137,12 +137,12 @@ ObjectNode::ObjectNode()
 
     // Store Dependencies
     m_StaticDependencies.SetCapacity( 1 + 1 + precompiledHeader.GetSize() + ( preprocessor ? 1 : 0 ) + compilerForceUsing.GetSize() );
-    m_StaticDependencies.Append( Dependency( compiler ) );
+    m_StaticDependencies.EmplaceBack( compiler );
     m_StaticDependencies.Append( compilerInputFile );
     m_StaticDependencies.Append( precompiledHeader );
     if ( preprocessor )
     {
-        m_StaticDependencies.Append( Dependency( preprocessor ) );
+        m_StaticDependencies.EmplaceBack( preprocessor );
     }
     m_StaticDependencies.Append( compilerForceUsing );
 
@@ -164,8 +164,8 @@ ObjectNode::ObjectNode( const AString & objectName,
     m_LastBuildTimeMs = 5000; // higher default than a file node
 
     m_StaticDependencies.SetCapacity( 2 );
-    m_StaticDependencies.Append( Dependency( nullptr ) );
-    m_StaticDependencies.Append( Dependency( srcFile ) );
+    m_StaticDependencies.EmplaceBack( nullptr );
+    m_StaticDependencies.EmplaceBack( srcFile );
 }
 
 // DESTRUCTOR
@@ -285,7 +285,7 @@ ObjectNode::~ObjectNode()
             fn->CastTo< FileNode >()->DoBuild( nullptr );
         }
 
-        m_DynamicDependencies.Append( Dependency( fn ) );
+        m_DynamicDependencies.EmplaceBack( fn );
     }
 
     Node::Finalize( nodeGraph );

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
@@ -30,7 +30,7 @@ RemoveDirNode::RemoveDirNode()
     : Node( AString::GetEmpty(), Node::REMOVE_DIR_NODE, Node::FLAG_ALWAYS_BUILD )
     , m_RemovePathsRecurse( true )
 {
-    m_RemovePatterns.Append( AStackString<>( "*" ) );
+    m_RemovePatterns.EmplaceBack( "*" );
 }
 
 // Initialize

--- a/Code/Tools/FBuild/FBuildCore/Graph/SLNNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/SLNNode.cpp
@@ -166,7 +166,7 @@ SLNNode::SLNNode()
         else
         {
             // Add new entry
-            collapsedFolders.Append( SolutionFolder( folder ) );
+            collapsedFolders.EmplaceBack( folder );
         }
     }
     m_SolutionFolders.Swap( collapsedFolders );
@@ -253,7 +253,7 @@ SLNNode::SLNNode()
     m_StaticDependencies.SetCapacity( projects.GetSize() );
     for ( VSProjectBaseNode * project : projects )
     {
-        m_StaticDependencies.Append( Dependency( project ) );
+        m_StaticDependencies.EmplaceBack( project );
     }
 
     return true;

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
@@ -157,7 +157,7 @@ const char * TestNode::GetEnvironmentString() const
                 return false;
             }
 
-            m_DynamicDependencies.Append( Dependency( sn ) );
+            m_DynamicDependencies.EmplaceBack( sn );
         }
         continue;
     }

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -62,7 +62,7 @@ UnityNode::UnityNode()
 , m_IsolatedFiles( 0, true )
 , m_UnityFileNames( 0, true )
 {
-    m_InputPattern.Append( AStackString<>( "*.cpp" ) );
+    m_InputPattern.EmplaceBack( "*.cpp" );
     m_LastBuildTimeMs = 100; // higher default than a file node
 }
 
@@ -409,7 +409,7 @@ bool UnityNode::GetFiles( Array< FileAndOrigin > & files )
 
                 if ( keep )
                 {
-                    files.Append( FileAndOrigin( filesIt, dirNode ) );
+                    files.EmplaceBack( filesIt, dirNode );
                 }
             }
         }
@@ -432,7 +432,7 @@ bool UnityNode::GetFiles( Array< FileAndOrigin > & files )
                     fi->m_Attributes = 0; // No writable bits set
                 #endif
                 fi->m_Size = 0;
-                files.Append( FileAndOrigin( fi, nullptr ) );
+                files.EmplaceBack( fi, nullptr );
             }
         }
         else if ( node->IsAFile() )
@@ -442,7 +442,7 @@ bool UnityNode::GetFiles( Array< FileAndOrigin > & files )
             if ( FileIO::GetFileInfo( node->GetName(), *fi ) )
             {
                 // only add files that exist
-                files.Append( FileAndOrigin( fi, nullptr ) );
+                files.EmplaceBack( fi, nullptr );
             }
             else
             {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ProjectGeneratorBase.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ProjectGeneratorBase.cpp
@@ -303,7 +303,7 @@ void ProjectGeneratorBase::AddConfig( const ProjectGeneratorBaseConfig & config 
     extensions.SetCapacity( sizeof( defaultExtensions ) / sizeof( char * ) );
     for ( auto & ext : defaultExtensions )
     {
-        extensions.Append( AStackString<>( ext ) );
+        extensions.EmplaceBack( ext );
     }
 }
 
@@ -410,11 +410,11 @@ void ProjectGeneratorBase::AddConfig( const ProjectGeneratorBaseConfig & config 
                                                            bool escapeQuotes )
 {
     StackArray< AString, 5 > prefixes;
-    prefixes.Append( Move( AString( "/I" ) ) );
-    prefixes.Append( Move( AString( "-I" ) ) );
-    prefixes.Append( Move( AString( "-isystem-after" ) ) ); // NOTE: before -isystem so it's checked first
-    prefixes.Append( Move( AString( "-isystem" ) ) );
-    prefixes.Append( Move( AString( "-iquote" ) ) );
+    prefixes.EmplaceBack( "/I" );
+    prefixes.EmplaceBack( "-I" );
+    prefixes.EmplaceBack( "-isystem-after" ); // NOTE: before -isystem so it's checked first
+    prefixes.EmplaceBack( "-isystem" );
+    prefixes.EmplaceBack( "-iquote" );
 
     // Extract various kinds of includes
     const bool keepFullOption = false;
@@ -428,8 +428,8 @@ void ProjectGeneratorBase::AddConfig( const ProjectGeneratorBaseConfig & config 
                                                       bool escapeQuotes )
 {
     StackArray< AString, 2 > prefixes;
-    prefixes.Append( Move( AString( "/D" ) ) );
-    prefixes.Append( Move( AString( "-D" ) ) );
+    prefixes.EmplaceBack( "/D" );
+    prefixes.EmplaceBack( "-D" );
 
     // Extract various kinds of includes
     const bool keepFullOption = false;
@@ -442,8 +442,8 @@ void ProjectGeneratorBase::AddConfig( const ProjectGeneratorBaseConfig & config 
                                                                 Array< AString > & outOptions )
 {
     StackArray< AString, 2 > prefixes;
-    prefixes.Append( Move( AString( "-std" ) ) );
-    prefixes.Append( Move( AString( "/std" ) ) );
+    prefixes.EmplaceBack( "-std" );
+    prefixes.EmplaceBack( "/std" );
 
     // Extract the options
     const bool escapeQuotes = false;

--- a/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
@@ -373,9 +373,9 @@ void Report::DoCacheStats( const FBuildStats & stats )
         uint32_t totalCacheMisses( totalCacheable - totalCacheHits );
 
         Array< PieItem > pieItems( 3, false );
-        pieItems.Append(PieItem("Uncacheable", (float)(totalOutOfDateItems - totalCacheable), 0xFF8888));
-        pieItems.Append(PieItem("Cache Miss", (float)totalCacheMisses, 0xFFCC88));
-        pieItems.Append(PieItem("Cache Hit", (float)totalCacheHits, 0x88FF88));
+        pieItems.EmplaceBack( "Uncacheable", (float)(totalOutOfDateItems - totalCacheable), 0xFF8888 );
+        pieItems.EmplaceBack( "Cache Miss", (float)totalCacheMisses, 0xFFCC88 );
+        pieItems.EmplaceBack( "Cache Hit", (float)totalCacheHits, 0x88FF88 );
         DoPieChart(pieItems, "");
 
         DoTableStart();
@@ -471,8 +471,7 @@ void Report::DoCPUTimeByType( const FBuildStats & stats )
         const float value = (float)( (double)nodeStats.m_ProcessingTimeMS / (double)1000 );
         const uint32_t color = g_ReportNodeColors[ i ];
 
-        PieItem item( typeName, value, color, (void *)i );
-        items.Append( item );
+        items.EmplaceBack( typeName, value, color, (void *)i );
     }
 
     items.Sort();

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.cpp
@@ -175,7 +175,7 @@ void ToolManifest::Initialize( const AString & mainExecutableRoot, const Depende
     m_Files.SetCapacity( dependencies.GetSize() );
     for ( const Dependency & dep : dependencies )
     {
-        m_Files.Append( ToolManifestFile( dep.GetNode()->GetName(), 0, 0, 0 ) );
+        m_Files.EmplaceBack( dep.GetNode()->GetName(), 0, 0, 0 );
     }
 }
 
@@ -296,7 +296,7 @@ void ToolManifest::DeserializeFromRemote( IOStream & ms )
         ms.Read( timeStamp );
         ms.Read( hash );
         ms.Read( uncompressedContentSize );
-        m_Files.Append( ToolManifestFile( name, timeStamp, hash, uncompressedContentSize ) );
+        m_Files.EmplaceBack( name, timeStamp, hash, uncompressedContentSize );
     }
 
     ASSERT( m_CustomEnvironmentVariables.IsEmpty() );

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
@@ -65,7 +65,7 @@ void VSProjectGenerator::AddFile( const AString & file )
     // ensure slash consistency which we rely on later
     AStackString<> fileCopy( file );
     fileCopy.Replace( FORWARD_SLASH, BACK_SLASH );
-    m_Files.Append( VSProjectFilePair() );
+    m_Files.EmplaceBack();
     m_Files.Top().m_AbsolutePath = fileCopy;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
@@ -129,12 +129,12 @@ void Job::ErrorPreformatted( const char * message )
 
         if ( FLog::IsMonitorEnabled() )
         {
-            m_Messages.Append( AStackString<>( message ) );
+            m_Messages.EmplaceBack( message );
         }
     }
     else
     {
-        m_Messages.Append( AStackString<>( message ) );
+        m_Messages.EmplaceBack( message );
     }
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -329,7 +329,7 @@ void FBuildForTest::SerializeDepGraphToText( const char * nodeName, AString& out
 {
     Node * node = m_DependencyGraph->FindNode( AStackString<>( nodeName ) );
     Dependencies deps( 1, false );
-    deps.Append( Dependency( node ) );
+    deps.EmplaceBack( node );
     m_DependencyGraph->SerializeToText( deps, outBuffer );
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestBuildFBuild.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestBuildFBuild.cpp
@@ -59,14 +59,14 @@ FBuildStats TestBuildFBuild::BuildInternal( FBuildTestOptions options, bool useD
     // Build a subset of targets as a sort of smoke test
     Array< AString > targets;
     #if defined( __WINDOWS__ )
-        targets.Append( AStackString<>( "All-x64-Debug" ) );
-        targets.Append( AStackString<>( "All-x64Clang-Release" ) );
+        targets.EmplaceBack( "All-x64-Debug" );
+        targets.EmplaceBack( "All-x64Clang-Release" );
     #elif defined( __LINUX__ )
-        targets.Append( AStackString<>( "All-x64Linux-Debug" ) );
-        targets.Append( AStackString<>( "All-x64ClangLinux-Release" ) );
+        targets.EmplaceBack( "All-x64Linux-Debug" );
+        targets.EmplaceBack( "All-x64ClangLinux-Release" );
     #elif defined( __OSX__ )
-        targets.Append( AStackString<>( "All-x64OSX-Debug" ) );
-        targets.Append( AStackString<>( "All-x64OSX-Release" ) );
+        targets.EmplaceBack( "All-x64OSX-Debug" );
+        targets.EmplaceBack( "All-x64OSX-Release" );
     #else
         #error Unknown platform
     #endif

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCompilationDatabase.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCompilationDatabase.cpp
@@ -176,7 +176,7 @@ void TestCompilationDatabase::DoTest( const char * bffFile, const char * target,
     Dependencies deps;
     Node * node = ng.FindNode( AStackString<>( target ) );
     TEST_ASSERT( node != nullptr );
-    deps.Append( Dependency( node ) );
+    deps.EmplaceBack( node );
 
     CompilationDatabase compdb;
     const AString & actualResult = compdb.Generate( ng, deps );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExec.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExec.cpp
@@ -293,7 +293,7 @@ void TestExec::Build_ExecCommand_ExpectedFailures() const
 
     // build
     Array< AString > targets( 2, false );
-    targets.Append( AStackString<>( "ExecCommandTest_OneInput_ReturnCode_ExpectFail" ) );
-    targets.Append( AStackString<>( "ExecCommandTest_OneInput_WrongOutput_ExpectFail" ) );
+    targets.EmplaceBack( "ExecCommandTest_OneInput_ReturnCode_ExpectFail" );
+    targets.EmplaceBack( "ExecCommandTest_OneInput_WrongOutput_ExpectFail" );
     TEST_ASSERT( !fBuild.Build( targets ) );
 }

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -250,7 +250,7 @@ void TestGraph::TestDirectoryListNode() const
         const AStackString<> testFolder( "Tools/FBuild/FBuildTest/Data/TestGraph/" );
     #endif
     Array< AString > patterns;
-    patterns.Append( AStackString<>( "library.*" ) );
+    patterns.EmplaceBack( "library.*" );
     DirectoryListNode::FormatName( testFolder,
                                    &patterns,
                                    true, // recursive

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestNodeReflection.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestNodeReflection.cpp
@@ -374,7 +374,7 @@ void TestNodeReflection::ArrayOfStrings_Optional_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".ArrayOfStrings" ), strings, nullptr );
 
     // Check array was set
@@ -406,8 +406,8 @@ void TestNodeReflection::ArrayOfStrings_Optional_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".ArrayOfStrings" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)
@@ -443,7 +443,7 @@ void TestNodeReflection::ArrayOfStrings_Required_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".ArrayOfStrings" ), strings, nullptr );
 
     // Check array was set
@@ -475,8 +475,8 @@ void TestNodeReflection::ArrayOfStrings_Required_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".ArrayOfStrings" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)
@@ -607,7 +607,7 @@ void TestNodeReflection::MetaFile_ArrayOfStrings_Optional_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Files" ), strings, nullptr );
 
     // Check the property was set and converted to a full paths
@@ -639,8 +639,8 @@ void TestNodeReflection::MetaFile_ArrayOfStrings_Optional_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Files" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)
@@ -676,7 +676,7 @@ void TestNodeReflection::MetaFile_ArrayOfStrings_Required_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Files" ), strings, nullptr );
 
     // Check the property was set and converted to a full path
@@ -709,8 +709,8 @@ void TestNodeReflection::MetaFile_ArrayOfStrings_Required_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Files" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)
@@ -841,7 +841,7 @@ void TestNodeReflection::MetaPath_ArrayOfStrings_Optional_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Paths" ), strings, nullptr );
 
     // Check the property was set and converted to a full paths
@@ -873,8 +873,8 @@ void TestNodeReflection::MetaPath_ArrayOfStrings_Optional_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Paths" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)
@@ -910,7 +910,7 @@ void TestNodeReflection::MetaPath_ArrayOfStrings_Required_Set() const
 
     // Set string array
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
+    strings.EmplaceBack( "value" );
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Paths" ), strings, nullptr );
 
     // Check the property was set and converted to a full path
@@ -943,8 +943,8 @@ void TestNodeReflection::MetaPath_ArrayOfStrings_Required_EmptyElement() const
 
     // Non-empty array with empty element
     Array<AString> strings;
-    strings.Append( AStackString<>( "value" ) );
-    strings.Append( AString::GetEmpty() );
+    strings.EmplaceBack( "value" );
+    strings.EmplaceBack();
     helper.m_Frame.SetVarArrayOfStrings( AStackString<>( ".Paths" ), strings, nullptr );
 
     // Check failure (empty strings in arrays are not allowed)


### PR DESCRIPTION
# Description:

This commit replaces usage of `Append` with `EmplaceBack` is 3 cases:
1. When `Append` is called on a temporary - patterns like `Append(T(...))` are replaced with `EmplaceBack(...)`.
   This saves one move construction for the stored type.
2. When a local variable is created and immediately passed to `Append`.
   This saves one copy construction for the stored type.
3. When the result of `AString::GetEmpty()` is used to put an empty string into `Array`. Same result can be archived by using `EmplaceBack()` which calls the default constructor of `AString`.
    
Unit tests for the Array itself are left intact to test `Append` and `EmplaceBack` separately.

This PR depends on #703 because GCC complains in several places about invalid conversion from `int` to pointer if the current definition of `nullptr` is used.

# Checklist:

The PR:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained** - ~~Required changes to `nullptr` are extracted into separate PR: #703, when it will be merged this PR will become self-contained.~~ Done
- [x] **Compiles on all platforms**
- [ ] **Has accompanying tests** - This if a refactoring, so no new tests.
- [x] **Passes tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** - This if a refactoring, so no documentation required.
