### PR TITLE
Fixes lightcache randomly generating different cache keys

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
@@ -24,7 +24,6 @@ class LightCache
 {
 public:
     LightCache();
-    ~LightCache();
 
     bool Hash( ObjectNode * node,                // Object to be compiled
                const AString & compilerArgs,     // Args to extract include paths from

--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
@@ -24,6 +24,7 @@ class LightCache
 {
 public:
     LightCache();
+    ~LightCache() = default; // Destruction heavy-lifting is currently done by IncludedFile::~IncludedFile()
 
     bool Hash( ObjectNode * node,                // Object to be compiled
                const AString & compilerArgs,     // Args to extract include paths from


### PR DESCRIPTION
# Description:

Includes https://github.com/fastbuild/fastbuild/pull/624

Randomly lightcache would generate different cache keys for the same obj file. This is caused by the caching of the files in `g_AllIncludedFiles`, multi threading and not saving the defines in the file object itself. When a file was loaded from `g_AllIncludedFiles` it would not include the defines and depending what thread was running the file would be missing defines

# Checklist:

Please consider this checklist to assist with integration of your changes:

The PR:
- [x] **Is created against the Dev branch** - PRs are only accepted against the development branch.
- [x] **Is self-contained** - A well-targetted, minimal change that doesn't mix multiple pieces of functionality. Unnecessary whitespace or formatting changes are avoided.
- [x] **Compiles on all platforms** - The PR compiles without error on Windows, OSX and Linux.
- [ ] **Has accompanying tests** -  Tests for new functionality or regression tests for bug fixes are provided.
- [x] **Passes tests** - Existing and new tests pass on all platforms.
- [x] **Keeps Windows, OSX and Linux at parity** - The change makes sense for all platforms if not inherently platform-specific.
- [x] **Follows the code style** - The existing coding style and conventions are adhered to.
- [ ] **Includes documentation** - Documentation is updated or added if appropriate.
