### PR TITLE
fix windows tray icon menu

### DIFF
--- a/Code/OSUI/OSMenu.cpp
+++ b/Code/OSUI/OSMenu.cpp
@@ -80,7 +80,7 @@ bool OSMenu::ShowAndWaitForSelection( uint32_t & outIndex )
         // display popup menu at mouse position
         POINT curPoint;
         GetCursorPos( &curPoint );
-        SetForegroundWindow( (HWND)m_Menu );
+        SetForegroundWindow( (HWND)m_Parent->GetHandle() );
 
         // Show menu and block until hidden
         // NOTE: TPM_RETURNCMD makes this BOOL return actually a UINT


### PR DESCRIPTION
SetForegroundWindow should set parent handle