### PR TITLE
Fix -cacheinfo and -cachetrim on case-sensitive filesystems

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/Cache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/Cache.cpp
@@ -326,7 +326,7 @@ void Cache::GetCacheFiles( bool showProgress,
         {
             // Get Files
             AStackString<> path;
-            path.Format( "%s%02x%c%02x%c", m_CachePath.Get(),
+            path.Format( "%s%02X%c%02X%c", m_CachePath.Get(),
                                                (uint32_t)i,
                                                NATIVE_SLASH,
                                                (uint32_t)j,


### PR DESCRIPTION
# Description:
`ICache::GetCacheId` generates names for cache file using uppercase hex letters A-F. This also affects names of sub-directories in which these files are stored.
`Cache::GetCacheFiles` on the other hand generated names for these sub-directories using lowercase hex letters. As the result that function looked for cache files in different directories.

This worked fine on Windows (and on OSX?) due name matching being case-insensitive. But caused a severe undercounting of the cache directory size (at least by a factor of 6.5) on Linux, unless case-insensitive filesystem was being used for cache (eg. mounted VirtualBox shared folder).

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** - There are no tests for `-cachetrim` currently. Should I add some? Or should I add tests for `Cache::GetCacheFiles`? (this would be easier)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
