### PR TITLE
Emit -monitor events for exec nodes

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueue.cpp
@@ -669,6 +669,7 @@ void JobQueue::FinishedProcessingJob( Job * job, bool success, bool wasARemoteJo
          ( node->GetType() == Node::LIBRARY_NODE ) ||
          ( node->GetType() == Node::DLL_NODE ) ||
          ( node->GetType() == Node::CS_NODE ) ||
+         ( node->GetType() == Node::EXEC_NODE ) ||
          ( node->GetType() == Node::TEST_NODE ) )
     {
         nodeRelevantToMonitorLog = true;


### PR DESCRIPTION
# Description:

Minor change to emit START_JOB and FINISH_JOB messages for exec nodes when `-monitor` is used so those local processes will appear in external monitoring apps.

FASTBuild Dashboard before this change:
<img width="902" alt="FASTBuild Dashboard-before" src="https://user-images.githubusercontent.com/1320480/87456671-1ed4af80-c5bc-11ea-8b72-ba5ecd8e208a.png">

After:
<img width="902" alt="FASTBuild Dashboard-after" src="https://user-images.githubusercontent.com/1320480/87456688-24ca9080-c5bc-11ea-9142-51b6c5c1af63.png">

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
