### PR TITLE
Add .SourceMapping_Experimental to Compiler node

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -50,8 +50,9 @@ distribution, caching and more.
   .AllowResponseFile            // (optional) Allow response files to be used if not auto-detected (default: false)
   
   // Temporary Options
-  .UseLightCache_Experimental   // (optional) Enabled experimental "light" caching mode (default: false)
-  .UseRelativePaths_Experimental// (optional) Enabled experimental relative path use (default: false)
+  .UseLightCache_Experimental   // (optional) Enable experimental "light" caching mode (default: false)
+  .UseRelativePaths_Experimental// (optional) Enable experimental relative path use (default: false)
+  .SourceMapping_Experimental   // (optional) Use Clang's -fdebug-source-map option to remap source files
   .ClangFixupUnity_Disable      // (optional) Disable preprocessor fixup for Unity files (default: false)
 }
 </div>
@@ -376,6 +377,19 @@ Compiler( 'Compiler-x64Intel' )
     <p><font color=red>NOTE:</font> This feature is incomplete and should not be used.</p>
 
   	<p><hr></p>
+
+  <p><b>.SourceMapping_Experimental</b> - String - (Optional)</p>
+  <p>Provides a new root to remap source file paths to so they are recorded in the debugging information as if they were stored under the new root. For example, if $_WORKING_DIR_$ is "/path/to/original", a source file "src/main.cpp" would normally be recorded as being stored under "/path/to/original/src/main.cpp", but with .SourceMapping_Experimental='/another/root' it would be recorded as "/another/root/src/main.cpp" instead.</p>
+
+  <p>While the same effect could be achieved by passing "-fdebug-prefix-map=$_WORKING_DIR_$=/another/root" to the compiler via .CompilerOptions, doing so prevents caching from working across machines that use different root paths because the cache keys would not match.</p>
+
+  <p>Source mapping can help make builds more reproducible, and also improve the debugging experience by making it easier for the debugger to find source files when debugging a binary built on another machine. See the <a href="https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html">GCC documentation for -fdebug-prefix-map</a> for more information.</p>
+
+    <p><font color=red>NOTE:</font> This feature currently only works on Clang 3.8+ and GCC.</p>
+    <p><font color=red>NOTE:</font> Paths expanded from the __FILE__ macro are not remapped because that requires Clang 10+ and GCC 8+ (-fmacro-debug-map).</p>
+    <p><font color=red>NOTE:</font> Only one mapping can be provided, and the source directory for the mapping is always $_WORKING_DIR_$.</p>
+
+    <p><hr></p>
 
 	<p><b>.ClangFixupUnity_Disable</b> - Boolean - (Optional)</p>
 	<p>Disable preprocessor fixup for Unity files (default: false).</p> 

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -31,6 +31,7 @@ REFLECT_NODE_BEGIN( CompilerNode, Node, MetaNone() )
     REFLECT_ARRAY( m_Environment,   "Environment",          MetaOptional() )
     REFLECT( m_UseLightCache,       "UseLightCache_Experimental", MetaOptional() )
     REFLECT( m_UseRelativePaths,    "UseRelativePaths_Experimental", MetaOptional() )
+    REFLECT( m_SourceMapping,       "SourceMapping_Experimental", MetaOptional() )
 
     // Internal
     REFLECT( m_CompilerFamilyEnum,  "CompilerFamilyEnum",   MetaHidden() )

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -57,6 +57,7 @@ public:
 
     const AString & GetExecutable() const { return m_StaticDependencies[ 0 ].GetNode()->GetName(); }
     const char * GetEnvironmentString() const;
+    const AString & GetSourceMapping() const { return m_SourceMapping; };
 
 private:
     bool InitializeCompilerFamily( const BFFToken * iter, const Function * function );
@@ -81,6 +82,7 @@ private:
     bool                    m_UseRelativePaths;
     ToolManifest            m_Manifest;
     Array< AString >        m_Environment;
+    AString                 m_SourceMapping;
 
     // Internal state
     mutable const char *    m_EnvironmentString;

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -58,7 +58,7 @@ public:
     }
     inline ~NodeGraphHeader() = default;
 
-    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 153 };
+    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 154 };
 
     bool IsValid() const
     {

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -130,7 +130,7 @@ private:
     static bool StripTokenWithArg_MSVC( const char * tokenToCheckFor, const AString & token, size_t & index );
     static bool StripToken( const char * tokenToCheckFor, const AString & token, bool allowStartsWith = false );
     static bool StripToken_MSVC( const char * tokenToCheckFor, const AString & token, bool allowStartsWith = false );
-    bool BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool useDeoptimization, bool useShowIncludes, bool finalize, const AString & overrideSrcFile = AString::GetEmpty() ) const;
+    bool BuildArgs( const Job * job, Args & fullArgs, Pass pass, bool useDeoptimization, bool useShowIncludes, bool useSourceMapping, bool finalize, const AString & overrideSrcFile = AString::GetEmpty() ) const;
 
     void ExpandCompilerForceUsing( Args & fullArgs, const AString & pre, const AString & post ) const;
     bool BuildPreprocessedOutput( const Args & fullArgs, Job * job, bool useDeoptimization ) const;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/SourceMapping/File.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/SourceMapping/File.cpp
@@ -1,0 +1,5 @@
+const char* Function()
+{
+    // .obj file will contain filename, surrounded by these tokens
+    return "FILE_MACRO_START(" __FILE__ ")FILE_MACRO_END";
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/SourceMapping/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/SourceMapping/fbuild.bff
@@ -1,0 +1,36 @@
+#define ENABLE_SOURCE_MAPPING // Shared compiler config will check this
+
+#include "../../../../../Code/Tools/FBuild/FBuildTest/Data/testcommon.bff"
+Settings
+{
+    #if __WINDOWS__
+        #import TMP
+        .CachePath          = '$TMP$\.fbuild.cache'
+    #endif
+    #if __LINUX__
+        .CachePath          = '/tmp/.fbuild.cache'
+        Using( .LinuxGCCToolChain )
+    #endif
+    #if __OSX__
+        .CachePath          = '/tmp/.fbuild.cache'
+        Using( .OSXClangToolChain )
+    #endif
+}
+
+// Compile object
+//------------------------------------------------------------------------------
+ObjectList( 'ObjectList' )
+{
+    #if __WINDOWS__
+        Using( .ToolChain_Clang_Windows )
+    #endif
+    #if __LINUX__
+        Using( .ToolChain_Clang_Linux )
+    #endif
+    #if __OSX__
+        Using( .ToolChain_Clang_OSX )
+    #endif
+
+    .CompilerInputFiles         = 'File.cpp'
+    .CompilerOutputPath         = '../out/'
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestObject.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestObject.cpp
@@ -31,6 +31,7 @@ private:
     void TestStaleDynamicDeps() const;
     void ModTimeChangeBackwards() const;
     void CacheUsingRelativePaths() const;
+    void SourceMapping() const;
 };
 
 // Register Tests
@@ -41,6 +42,7 @@ REGISTER_TESTS_BEGIN( TestObject )
     REGISTER_TEST( TestStaleDynamicDeps )       // Test dynamic deps are cleared when necessary
     REGISTER_TEST( ModTimeChangeBackwards )
     REGISTER_TEST( CacheUsingRelativePaths )
+    REGISTER_TEST( SourceMapping )
 REGISTER_TESTS_END
 
 // MSVCArgHelpers
@@ -415,6 +417,72 @@ void TestObject::CacheUsingRelativePaths() const
 
         TEST_ASSERT( fBuild.GetStats().GetCacheHits() == 1 );
     }
+}
+
+// SourceMapping
+//------------------------------------------------------------------------------
+void TestObject::SourceMapping() const
+{
+    #if defined( __WINDOWS__ )
+        // Not tested on Windows because MSVC doesn't currently support source mapping.
+    #else
+        // Source files
+        const char * srcPath = "Tools/FBuild/FBuildTest/Data/TestObject/SourceMapping/";
+        const char * fileA = "File.cpp";
+        const char * fileB = "fbuild.bff";
+        const char * files[] = { fileA, fileB };
+
+        // Dest paths
+        const char * dstPath = "../tmp/Test/Object/SourceMapping/Code";
+
+        #if defined( __WINDOWS__ )
+            const char * objFile = "../tmp/Test/Object/SourceMapping/out/File.obj";
+        #else
+            const char * objFile = "../tmp/Test/Object/SourceMapping/out/File.o";
+        #endif
+
+        // Copy file structure to destination
+        for ( const char * file : files )
+        {
+            AStackString<> src, dst;
+            src.Format( "%s/%s", srcPath, file );
+            dst.Format( "%s/%s", dstPath, file );
+            TEST_ASSERT( FileIO::EnsurePathExistsForFile( dst ) );
+            TEST_ASSERT( FileIO::FileCopy( src.Get(), dst.Get() ) );
+        }
+
+        // Build in destination path
+        {
+            // Init
+            FBuildTestOptions options;
+            options.m_ConfigFile = "fbuild.bff";
+            AStackString<> codeDir;
+            GetCodeDir( codeDir );
+            codeDir.Trim( 0, 5 ); // Remove Code/
+            codeDir += "tmp/Test/Object/SourceMapping/Code/";
+            options.SetWorkingDir( codeDir );
+            FBuild fBuild( options );
+            TEST_ASSERT( fBuild.Initialize() );
+
+            // Compile
+            TEST_ASSERT( fBuild.Build( AStackString<>( "ObjectList" ) ) );
+        }
+
+        // Check the object file to make sure the debugging information has been remapped
+        {
+            // Read obj file into memory
+            AString buffer;
+            {
+                FileStream f;
+                TEST_ASSERT( f.Open( objFile ) );
+                buffer.SetLength( (uint32_t)f.GetFileSize() );
+                TEST_ASSERT( f.ReadBuffer( buffer.Get(), f.GetFileSize() ) == f.GetFileSize() );
+                buffer.Replace( (char)0, ' ' ); // Make string seaches simpler
+            }
+
+            TEST_ASSERT( buffer.Find( "/fastbuild-test-mapping" ) );
+        }
+    #endif
 }
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang6.bff
+++ b/External/SDK/Clang/Linux/Clang6.bff
@@ -13,6 +13,9 @@ Compiler( 'Compiler-Clang6' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/Linux/Clang_CI.bff
+++ b/External/SDK/Clang/Linux/Clang_CI.bff
@@ -12,6 +12,9 @@ Compiler( 'Compiler-Clang' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/OSX/Clang8.bff
+++ b/External/SDK/Clang/OSX/Clang8.bff
@@ -13,6 +13,9 @@ Compiler( 'Compiler-Clang8' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif    
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -12,6 +12,9 @@ Compiler( 'Compiler-Clang' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif    
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/Windows/Clang10.bff
+++ b/External/SDK/Clang/Windows/Clang10.bff
@@ -20,6 +20,9 @@ Compiler( 'Compiler-Clang10' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/Windows/Clang7.bff
+++ b/External/SDK/Clang/Windows/Clang7.bff
@@ -16,6 +16,9 @@ Compiler( 'Compiler-Clang7' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/Windows/Clang8.bff
+++ b/External/SDK/Clang/Windows/Clang8.bff
@@ -21,6 +21,9 @@ Compiler( 'Compiler-Clang8' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/Clang/Windows/Clang9.bff
+++ b/External/SDK/Clang/Windows/Clang9.bff
@@ -20,6 +20,9 @@ Compiler( 'Compiler-Clang9' )
     #if ENABLE_RELATIVE_PATHS
         .UseRelativePaths_Experimental = true
     #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/GCC/Linux/GCC4.bff
+++ b/External/SDK/GCC/Linux/GCC4.bff
@@ -13,6 +13,11 @@ Compiler( 'Compiler-GCC4' )
                                         '$GCC4_BasePath$/cc1plus'
                                       }
     .CompilerFamily                 = 'gcc' // TODO: Remove when FASTBuild detection is improved
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/GCC/Linux/GCC7.bff
+++ b/External/SDK/GCC/Linux/GCC7.bff
@@ -13,6 +13,11 @@ Compiler( 'Compiler-GCC7' )
                                         '/usr/lib/gcc/x86_64-linux-gnu/7/cc1plus'
                                       }
     .CompilerFamily                 = 'gcc' // TODO: Remove when FASTBuild detection is improved
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain

--- a/External/SDK/GCC/Linux/GCC_CI.bff
+++ b/External/SDK/GCC/Linux/GCC_CI.bff
@@ -12,6 +12,11 @@ Compiler( 'Compiler-GCC' )
                                         'CC1PLUS_BINARY'
                                       }
     .CompilerFamily                 = 'gcc' // Specify compiler family explicitly because binary name may change at any moment
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
 }
 
 // ToolChain


### PR DESCRIPTION
# Description:

This change adds a new `.SourceMapping_Experimental` property to `Compiler` nodes that allows you to remap source file paths as they appear in the debugging information to make them appear to be stored under a different path. This can be useful for reproducible builds (https://reproducible-builds.org/docs/build-path/) or for improving the debugging experience under `gdb` and `lldb` which - unlike the Visual Studio debugger - don't have an **automatic** way to remap source paths when debugging a binary built on another machine (you can set the mappings during debugging, but this allows you to bake that into the binary so you don't have to).

This new option amounts to passing `-fdebug-prefix-map=$_WORKING_DIR_$=$SourceMapping_Experimental$` to the compiler. The key reason for FASTBuild to do this itself via this new property instead of just passing that option yourself via `.CompilerOptions` is to ensure that caching still works across machines that use different source roots.

This only works on GCC and Clang. MSVC doesn't have a source remapping option (but Visual Studio has better support for automatic remapping, so it's much less of an issue).

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**: MSVC doesn't have source mapping capabilities.
- [x] **Follows the code style**
- [x] **Includes documentation**
