### PR TITLE
Fix issue 786 with dispatch re-entry check for DEBUGSPAM()

### DIFF
--- a/Code/Core/Tracing/Tracing.cpp
+++ b/Code/Core/Tracing/Tracing.cpp
@@ -245,10 +245,12 @@ bool Tracing::Callbacks::DispatchCallbacksDebugSpam( const char * message )
     {
         if ( (*cb)( message ) == false )
         {
+            m_InCallbackDispatch = false;
             return true; // callback wants msg supressed
         }
     }
 
+    m_InCallbackDispatch = false;
     return false;
 }
 


### PR DESCRIPTION
# Description:

As discussed in #786, this fixes dispatch re-entry check in Tracing::Callbacks::DispatchCallbacksDebugSpam() to allow further logs to be recorded.

This issue occured with PROTOCOL_DEBUG_ENABLED defined, which enables the use of DEBUGSPAM() to output protocol debug log, and was preventing any further logs.

I have only compiled it on Windows.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
