### PR TITLE
Linux: Set thread stack size always above PTHREAD_STACK_MIN.

### DIFF
--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -15,6 +15,7 @@
 #if defined( __APPLE__ ) || defined( __LINUX__ )
     #include <errno.h>
     #include <pthread.h>
+    #include <limits.h>
     #include <unistd.h>
 #endif
 
@@ -143,6 +144,11 @@ public:
             // To account for that double the requested stack size for the thread.
             stackSize *= 2;
         #endif
+        // Necessary on Aarch64, where it's 131072 in my tests. Sometimes we ask for 65536.
+        if ( stackSize < PTHREAD_STACK_MIN )
+        {
+	    stackSize = PTHREAD_STACK_MIN;
+        }
         pthread_t h( 0 );
         pthread_attr_t threadAttr;
         VERIFY( pthread_attr_init( &threadAttr ) == 0 );


### PR DESCRIPTION
# Description:

On AArch64 (ARM64) on Linux, `Thread::CreateThread` would fail when calling
`pthread_attr_setstacksize` returned EINVAL, with stackSize=65536.

This fixes it by honoring the documented minimum limit: PTHREAD_STACK_MIN.

# Checklist:

The pull request:
- [ ] **Is created against the Dev branch**
- [ ] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
