### PR TITLE
Core: adapt to Aarch64 on Linux (ARM64)

### DIFF
--- a/Code/Core/Env/Assert.h
+++ b/Code/Core/Env/Assert.h
@@ -13,7 +13,11 @@
 #elif defined( __APPLE__ )
     #define BREAK_IN_DEBUGGER __builtin_trap();
 #elif defined( __LINUX__ )
-    #define BREAK_IN_DEBUGGER __asm__ __volatile__("int $3")
+    #if defined(__X64__)
+        #define BREAK_IN_DEBUGGER __asm__ __volatile__("int $3")
+    #else
+        #define BREAK_IN_DEBUGGER __builtin_trap();
+    #endif
 #else
     #error Unknown platform
 #endif

--- a/Code/Core/Env/Types.h
+++ b/Code/Core/Env/Types.h
@@ -82,7 +82,7 @@ typedef signed int          int32_t;
 #endif
 #ifndef uintptr_t
     #if defined( __LINUX__ )
-        #ifdef __x86_64__
+        #if defined(__X64__) || defined(__ARM64__)
             typedef uint64_t    uintptr_t;
         #else
             typedef uint32_t    uintptr_t;


### PR DESCRIPTION
# Description:

This makes the necessary changes in Core to support ARM64 in Linux.

I chose to use the __ARM64__ define that was introduced recently for ARM on OSX, rather than
use a gcc specific define.

# Checklist:

The pull request:
- [ ] **Is created against the Dev branch**
- [ ] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
