### PR TITLE
Fix issue 795 with missing missing newline character in ListDependenciesNode::EmitOutputMessage() log

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.cpp
@@ -202,7 +202,7 @@ void ListDependenciesNode::EmitOutputMessage() const
 {
     if ( FBuild::Get().GetOptions().m_ShowCommandSummary )
     {
-        FLOG_OUTPUT( "DepList: '%s' -> '%s'", m_Source.Get(), GetName().Get() );
+        FLOG_OUTPUT( "DepList: '%s' -> '%s'\n", m_Source.Get(), GetName().Get() );
     }
 }
 


### PR DESCRIPTION
# Description:
As discussed in #795, add missing newline character in ListDependenciesNode::EmitOutputMessage() log

Compiled only on Windows.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
