### PR TITLE
Prevent Windows systems from sleeping while fbuild.exe is running

### DIFF
--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -339,12 +339,12 @@ public:
 #endif
 
 
-// SetContinuousThreadExecutionMode
+// PreventSleep
 //------------------------------------------------------------------------------
-/*static*/ void Thread::SetContinuousThreadExecutionMode()
+/*static*/ void Thread::PreventSleep()
 {
  #if defined( __WINDOWS__ )
-    SetThreadExecutionState(ES_CONTINUOUS);
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
  #endif
 
 }

--- a/Code/Core/Process/Thread.cpp
+++ b/Code/Core/Process/Thread.cpp
@@ -338,4 +338,15 @@ public:
     }
 #endif
 
+
+// SetContinuousThreadExecutionMode
+//------------------------------------------------------------------------------
+/*static*/ void Thread::SetContinuousThreadExecutionMode()
+{
+ #if defined( __WINDOWS__ )
+    SetThreadExecutionState(ES_CONTINUOUS);
+ #endif
+
+}
+
 //------------------------------------------------------------------------------

--- a/Code/Core/Process/Thread.h
+++ b/Code/Core/Process/Thread.h
@@ -49,7 +49,7 @@ public:
 
     static void SetThreadName( const char * name );
 
-    static void SetContinuousThreadExecutionMode();
+    static void PreventSleep();
 
 private:
     static ThreadId s_MainThreadId;

--- a/Code/Core/Process/Thread.h
+++ b/Code/Core/Process/Thread.h
@@ -49,6 +49,8 @@ public:
 
     static void SetThreadName( const char * name );
 
+    static void SetContinuousThreadExecutionMode();
+
 private:
     static ThreadId s_MainThreadId;
 };

--- a/Code/Tools/FBuild/FBuild/Main.cpp
+++ b/Code/Tools/FBuild/FBuild/Main.cpp
@@ -106,6 +106,9 @@ int Main( int argc, char * argv[] )
         VERIFY( SetPriorityClass( GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS ) );
     #endif
 
+    // Prevent sleep when fbuild is running.
+    Thread::SetContinuousThreadExecutionMode();
+
     // don't buffer output
     VERIFY( setvbuf( stdout, nullptr, _IONBF, 0 ) == 0 );
     VERIFY( setvbuf( stderr, nullptr, _IONBF, 0 ) == 0 );

--- a/Code/Tools/FBuild/FBuild/Main.cpp
+++ b/Code/Tools/FBuild/FBuild/Main.cpp
@@ -106,8 +106,8 @@ int Main( int argc, char * argv[] )
         VERIFY( SetPriorityClass( GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS ) );
     #endif
 
-    // Prevent sleep when fbuild is running.
-    Thread::SetContinuousThreadExecutionMode();
+    // Prevent sleep when fbuild.exe is running.
+    Thread::PreventSleep();
 
     // don't buffer output
     VERIFY( setvbuf( stdout, nullptr, _IONBF, 0 ) == 0 );


### PR DESCRIPTION
# Description:

Use [SetThreadExecutionState](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate?redirectedfrom=MSDN) to prevent the system from entering sleep when running on windows.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
