### PR TITLE
Fix response file argument computation

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/Args.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/Args.cpp
@@ -171,7 +171,7 @@ bool Args::Finalize( const AString & exe, const AString & nodeNameForError, Args
     }
 
     // Create new args referencing response file
-    m_ResponseFileArgs = "@\"";
+    m_ResponseFileArgs = "\"@";
     m_ResponseFileArgs += m_ResponseFile.GetResponseFilePath();
     m_ResponseFileArgs += "\"";
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/fbuild.bff
@@ -1,0 +1,35 @@
+//
+// TestArgs - ResponseFile
+//
+// Check the invocation command-line
+//
+//------------------------------------------------------------------------------
+
+// Use the standard test environment
+//------------------------------------------------------------------------------
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+{
+    // Common settings
+    .CompilerInputPath          = 'Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/'
+    .UnityOutputPath            = '$Out$/Test/ObjectList/ResponseFile/'
+    .CompilerOutputPath         = '$Out$/Test/ObjectList/ResponseFile/'
+
+    Compiler( 'ClangAlwaysUsingResponseFiles' )
+    {
+      .Root                     = '$Clang10_BasePath$'
+      .Executable               = '$Root$/clang'
+      .ForceResponseFile        = true
+    }
+
+    ObjectList( 'ResponseFilePath' )
+    {
+        .Compiler = 'ClangAlwaysUsingResponseFiles'
+    }
+}
+
+Alias( 'Test' )
+{
+    .Targets = { 'ResponseFilePath' }
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/file.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/file.cpp
@@ -1,0 +1,4 @@
+// simple valid file
+void Function()
+{
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestArgs.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestArgs.cpp
@@ -29,6 +29,7 @@ private:
     void ResponseFile_IfNeeded_Long() const;
     void ResponseFile_Always_Short() const;
     void ResponseFile_Always_Long() const;
+    void ResponseFile_CommandLineQuoting() const;
 
     // Helpers
     void Check( ArgsResponseFileMode mode,
@@ -52,6 +53,7 @@ REGISTER_TESTS_BEGIN( TestArgs )
     REGISTER_TEST( ResponseFile_IfNeeded_Long )
     REGISTER_TEST( ResponseFile_Always_Short )
     REGISTER_TEST( ResponseFile_Always_Long )
+    REGISTER_TEST( ResponseFile_CommandLineQuoting )
 REGISTER_TESTS_END
 
 // Unused
@@ -107,6 +109,18 @@ void TestArgs::ResponseFile_Always_Long() const
 {
     //     Mode                             LongArgs    Success     UseResponseFile
     Check( ArgsResponseFileMode::ALWAYS,    true,       true,       true );
+}
+
+// ResponseFile_CommandLineQuoting
+//------------------------------------------------------------------------------
+void TestArgs::ResponseFile_CommandLineQuoting() const
+{
+    FBuildTestOptions options;
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestArgs/ResponseFile/fbuild.bff";
+
+    FBuild fBuild( options );
+    TEST_ASSERT( fBuild.Initialize() );
+    TEST_ASSERT( fBuild.Build( "ResponseFilePath" ) );
 }
 
 // Check


### PR DESCRIPTION
Here's what you get if you try to use response files with clang under GNU/Linux:

```
4> clang: error: no such file or directory: '@"/tmp/_fbuild.tmp/0x8a3452e1/core_4/args.rsp"'
clang: error: no input files
```

The problem here is the double quotes.

The command-line using a response file should look like this:
```
 [...] "@/path/to/my/reponse/file/with spaces/in/it"  [...]
```

But it actually is like this ( the '@' sign and leading double-quote are swapped ).
```
 [...] @"/path/to/my/reponse/file/with spaces/in/it"  [...]
```

This will prevent the double-quotes to be interpreted by the shell, which lead the above argument to be seen as two arguments:
```
@"/path/to/my/reponse/file/with
spaces/in/it"
```

More problematic: it breaks clang (at least under GNU/linux), because clang doesn't know what to do with double-quotes (they should be interpreted by the shell, but they shouldn't be part of the argv received by the application).

For reference, here's the clang code that reads the response files in the command line :  https://github.com/llvm/llvm-project/blob/e3f02302e318837d2421c6425450f04ae0a82b90/llvm/lib/Support/CommandLine.cpp#L1139 


# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [X] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**
