### PR TITLE
[Fix] Spaces were not supported in target names when using -wrapper

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -93,17 +93,19 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
         {
             m_Args += ' ';
         }
-        m_Args += thisArg;
 
         // Don't validate args for WSL forwarding
         if ( m_WrapperMode == WRAPPER_MODE_WINDOWS_SUBSYSTEM_FOR_LINUX )
         {
+            m_Args += thisArg;
             continue;
         }
 
         // options start with a '-'
         if ( thisArg.BeginsWith( '-' ) )
         {
+            m_Args += thisArg;
+
             if ( thisArg == "-continueafterdbmove" )
             {
                 m_ContinueAfterDBMove = true;
@@ -424,6 +426,10 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
         }
         else
         {
+            m_Args += '"'; // surround with quotes to avoid problems with spaces in target name
+            m_Args += thisArg;
+            m_Args += '"';
+
             // assume target
             m_Targets.Append( thisArg );
         }


### PR DESCRIPTION
# Description:

use of `-wrapper` argument was leading to a misinterpretation of targets names when containing spaces.

Ex:
fbuild -wrapper "exe Editor Release"
is interpreted as:
fbuild -wrapper exe Editor Release

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**
