### PR TITLE
- allow defining a custom tool in the VSProjectFileType

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
@@ -77,6 +77,7 @@ REFLECT_STRUCT_BEGIN( VSProjectConfig, VSProjectConfigBase, MetaNone() )
 REFLECT_END( VSProjectConfig )
 
 REFLECT_STRUCT_BEGIN_BASE( VSProjectFileType )
+    REFLECT(        m_Tool,                         "Tool",                         MetaNone() )
     REFLECT(        m_FileType,                     "FileType",                     MetaNone() )
     REFLECT(        m_Pattern,                      "Pattern",                      MetaNone() )
 REFLECT_END( VSProjectFileType )

--- a/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.h
@@ -91,6 +91,7 @@ class VSProjectFileType : public Struct
 {
     REFLECT_STRUCT_DECLARE( VSProjectFileType )
 public:
+    AString             m_Tool;     // e.g. "Natvis"
     AString             m_FileType; // e.g. "CppForm"
     AString             m_Pattern;  // e.g. "Code\Forms\*.h" (can be full filename also)
 };

--- a/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/VSProjectGenerator.cpp
@@ -133,25 +133,31 @@ const AString & VSProjectGenerator::GenerateVCXProj( const AString & projectFile
         {
             const AString & fileName = filePathPair.m_ProjectRelativePath;
 
+            const char * tool = nullptr;
             const char * fileType = nullptr;
             const VSProjectFileType * const end = fileTypes.End();
             for ( const VSProjectFileType * it=fileTypes.Begin(); it!=end; ++it )
             {
                 if ( AString::MatchI( it->m_Pattern.Get(), fileName.Get() ) )
                 {
+                    tool = it->m_Tool.Get();
                     fileType = it->m_FileType.Get();
                     break;
                 }
             }
+            if ( !tool )
+            {
+                tool = "CustomBuild";
+            }
             if ( fileType )
             {
-                WriteF( "    <CustomBuild Include=\"%s\">\n", fileName.Get() );
+                WriteF( "    <%s Include=\"%s\">\n", tool, fileName.Get() );
                 WriteF( "        <FileType>%s</FileType>\n", fileType );
-                Write( "    </CustomBuild>\n" );
+                WriteF( "    </%s>\n", tool );
             }
             else
             {
-                WriteF( "    <CustomBuild Include=\"%s\" />\n", fileName.Get() );
+                WriteF( "    <%s Include=\"%s\" />\n", tool, fileName.Get() );
             }
         }
         Write("  </ItemGroup>\n" );


### PR DESCRIPTION
In some of my VCXProj targets I include *.natvis files that have the "Item Type" configured as "Custom Build Tool".
`<CustomBuild Include="test.natvis" />`

I tried using the ProjectFileTypes to change the "Item Type":
```
.Natvis = [
  .FileType = 'Document'
  .Pattern = '*.natvis'
]
.ProjectFileTypes = { .Natvis }
```
The generated output was:
```
<CustomBuild Include="test.natvis">
  <FileType>Document</FileType>
</CustomBuild>
```

The new Tool parameter allows us to achieve the following output:
```
<Natvis Include="test.natvis">
  <FileType>Document</FileType>
</Natvis>
```

[https://github.com/fastbuild/fastbuild/issues/831](https://github.com/fastbuild/fastbuild/issues/831)
