### PR TITLE
Update ObjectNode.cpp

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2052,6 +2052,23 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
             return NODE_RESULT_FAILED;
         }
     }
+    {
+        // add UTF8-BOM to source files
+        const char * lastDot = fileName.FindLast( '.' );
+        if ( ( lastDot != nullptr ) && ( lastDot[1] != '\0' ) )
+        {
+            AStackString<> extension( lastDot + 1 );
+            if ( ( extension == "cpp" ) || ( extension == "cc" ) || ( extension == "cxx" ) || ( extension == "c++" || extension == "cp" || extension == "CPP" || extension == "C" || extension == "inc" ) )
+            {
+                unsigned char c1 = 0xEF;
+                unsigned char c2 = 0xBB;
+                unsigned char c3 = 0xBF;
+                tmpFile.WriteBuffer(&c1, 1);
+                tmpFile.WriteBuffer(&c2, 1);
+                tmpFile.WriteBuffer(&c3, 1);
+            }
+        }
+    }
     if ( tmpFile.Write( dataToWrite, dataToWriteSize ) != dataToWriteSize )
     {
         job->Error( "Failed to write to temp file. Error: %s TmpFile: '%s' Target: '%s'", LAST_ERROR_STR, tmpFileName.Get(), GetName().Get() );


### PR DESCRIPTION
# Description:

Please provide details for the change or fix:
 - The source file is saved in utf8-bom. When compiling Chinese strings in distributed mode, c2001: newline in constant error will be reported. However, the temporary file is saved in utf8. After adding utf8-bom, the compilation passes

# Checklist:

The pull request:
- [ ] **Is created against the Dev branch**
- [ ] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
