### PR TITLE
TestProjectGeneration: Expect quoted paths in IntellisenseAndCodeSense test

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -609,7 +609,15 @@ void TestProjectGeneration::XCodeProj_CodeSense_Check( const char * projectFile 
                 // Check that we separated path from the option name correctly.
                 TEST_ASSERT( ( pathStartPos == token.Get() ) || ( pathStartPos[ -1 ] == '/' ) );
 
-                const char * pathEndPos = token.GetEnd() - ( token.EndsWith( ',' ) ? 1 : 0 );
+                const char * pathEndPos = token.GetEnd();
+                if ( pathEndPos[ -1 ] == ',' )
+                {
+                    --pathEndPos;
+                }
+                if ( pathEndPos[ -1 ] == '"' )
+                {
+                    --pathEndPos;
+                }
                 includes.EmplaceBack( pathStartPos, pathEndPos );
             }
             continue;


### PR DESCRIPTION
# Description:

This patch fixes the `IntellisenseAndCodeSense` test in case when the full path to the repository checkout contains any character that forces `XCodeProjectGenerator` to write quoted include paths to the `.pbxproj` file (see `XCodeProjectGenerator::ShouldQuoteString()`).

Previously the test didn't account for possibility of a quoted path and the trailing quote was left in paths saved to the includes array.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux** (I tested it only on Linux x86_64.)
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
