### PR TITLE
Fix Compress() and Decompress() in MultiBuffer

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/MultiBuffer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/MultiBuffer.cpp
@@ -162,7 +162,8 @@ void MultiBuffer::Compress( int32_t compressionLevel )
     c.Compress( m_WriteStream->GetData(), m_WriteStream->GetSize(), compressionLevel );
 
     // Transfer compressed results
-    m_WriteStream->Replace( c.ReleaseResult(), c.GetResultSize() );
+    const size_t compressedSize = c.GetResultSize();
+    m_WriteStream->Replace( c.ReleaseResult(), compressedSize );
 }
 
 // Decompress
@@ -183,7 +184,8 @@ bool MultiBuffer::Decompress()
     }
 
     // Transfer decompressed results
-    m_ReadStream->Replace( c.ReleaseResult(), c.GetResultSize(), true ); // true = own data
+    const size_t decompressedSize = c.GetResultSize();
+    m_ReadStream->Replace( c.ReleaseResult(), decompressedSize, true ); // true = own data
     return true;
 }
 


### PR DESCRIPTION
# Description:

Calls to `Replace()` in `Compress()` and `Decompress()` in `MultiBuffer` worked correctly only when `Compressor::GetResultSize()` from the second argument was called before `Compressor::ReleaseResult()` from the first argument.

But the order of evaluation of function arguments is unspecified in C++, so the code worked with some compilers (eg. GCC 10) and produced incorrect results (zero data size in `m_ReadStream` or `m_WriteStream`) with others (eg. Clang 12).

In the end this problem was caught by several tests:
* TestBuildFBuild.BuildCleanWithCache
* TestCache.ConsistentCacheKeysWithDist
* TestPrecompiledHeaders.TestPCHWithCache

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux** (I tested it only on Linux x86_64.)
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
