### PR TITLE
Use MSVC headers in x64Clang configuration

### DIFF
--- a/External/SDK/Clang/Windows/Clang11.bff
+++ b/External/SDK/Clang/Windows/Clang11.bff
@@ -80,6 +80,7 @@ Compiler( 'Compiler-Clang11-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang7.bff
+++ b/External/SDK/Clang/Windows/Clang7.bff
@@ -72,6 +72,7 @@ Compiler( 'Compiler-Clang7-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang8.bff
+++ b/External/SDK/Clang/Windows/Clang8.bff
@@ -80,6 +80,7 @@ Compiler( 'Compiler-Clang8-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang9.bff
+++ b/External/SDK/Clang/Windows/Clang9.bff
@@ -81,6 +81,7 @@ Compiler( 'Compiler-Clang9-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/VisualStudio/VS2015.bff
+++ b/External/SDK/VisualStudio/VS2015.bff
@@ -37,6 +37,7 @@ Compiler( 'Compiler-VS2015-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2015_BasePath$/VC/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2015_BasePath$/VC/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2015_BasePath$/VC/lib/amd64"'
     .VCPackagesPath                 = '$VS2015_BasePath$/VC/vcpackages'
 

--- a/External/SDK/VisualStudio/VS2017.bff
+++ b/External/SDK/VisualStudio/VS2017.bff
@@ -85,6 +85,7 @@ Compiler( 'Compiler-VS2017-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2017_ToolchainPath$/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2017_ToolchainPath$/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2017_ToolchainPath$/lib/x64"'
     .VCPackagesPath                 = '$VS2017_BasePath$/../Common7/IDE/VC/vcpackages'
 

--- a/External/SDK/VisualStudio/VS2019.bff
+++ b/External/SDK/VisualStudio/VS2019.bff
@@ -85,6 +85,7 @@ Compiler( 'Compiler-VS2019-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2019_ToolchainPath$/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2019_ToolchainPath$/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2019_ToolchainPath$/lib/x64"'
     .VCPackagesPath                 = '$VS2019_BasePath$/../Common7/IDE/VC/vcpackages'
 


### PR DESCRIPTION
# Description:

This fixes build on Windows with Clang using VS2015 or VS2019 and new WinSDK versions.
Currently the build fails with errors about not found include files `excpt.h` and `vcruntime.h`, both are included in WinSDK headers:
```
C:\Program Files (x86)\Windows Kits\10/Include/10.0.19041.0/um\windows.h(167,10): fatal error: 'excpt.h' file not found
C:\Program Files (x86)\Windows Kits\10/Include/10.0.19041.0/ucrt\corecrt.h(10,10): fatal error: 'vcruntime.h' file not found
```

This was observed with Clang 11 (installed via Visual Studio installer) and WinSDK 10.0.19041.0.

We need to specify the include path to MSVC headers using `/imsvc` because otherwise the build fails due to warnings in MSVC headers reported Clang. So the `.VSIncludePaths` variable couldn't be reused.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** (N/A)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
