### PR TITLE
TestObject: Fix ordering of actions in some tests

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestObject.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestObject.cpp
@@ -512,14 +512,15 @@ void TestObject::ClangExplicitLanguageType() const
         // Init
         FBuildTestOptions options;
         options.m_ConfigFile = configFile;
-        FBuild fBuild( options );
-        TEST_ASSERT( fBuild.Initialize() );
 
         // Force remote
         options.m_AllowDistributed = true;
         options.m_NoLocalConsumptionOfRemoteJobs = true;
         options.m_AllowLocalRace = false;
         options.m_DistributionPort = Protocol::PROTOCOL_TEST_PORT;
+
+        FBuild fBuild( options );
+        TEST_ASSERT( fBuild.Initialize() );
 
         // start a client to emulate the other end
         Server s( 1 );
@@ -563,12 +564,12 @@ void TestObject::ClangDependencyArgs() const
         options.m_AllowLocalRace = false;
         options.m_DistributionPort = Protocol::PROTOCOL_TEST_PORT;
 
+        FBuild fBuild( options );
+        TEST_ASSERT( fBuild.Initialize() );
+
         // start a client to emulate the other end
         Server s( 1 );
         s.Listen( Protocol::PROTOCOL_TEST_PORT );
-
-        FBuild fBuild( options );
-        TEST_ASSERT( fBuild.Initialize() );
 
         // Compile
         TEST_ASSERT( fBuild.Build( "ClangDependencyArgs" ) );


### PR DESCRIPTION
# Description:

* In ClangExplicitLanguageType test an `FBuildOptions` instance was modified after it was passed to `FBuild` constructor. As a result additional options that were forcing remote compilation were ignored.
* In ClangDependencyArgs test `FBuild::Initialize()` was called after a `Server` instance was created. `FBuild::Initialize()` temporarily places `SmallBlockAllocator` into single-threaded mode, but this is not safe as `Server` objects creates other threads that can try to allocate memory. A similar problem was fixed in the past: 7bd20da821 (#606)

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
