### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/actions/DownloadFBuild/action.yml
+++ b/.github/actions/DownloadFBuild/action.yml
@@ -1,0 +1,24 @@
+name: Download FASTBuild
+description: Downloads the FBuild binary, stores it in a temporary directory and exports full path to in FBUILD_PATH environment variable.
+
+inputs:
+  version:
+    description: Version to download
+    required: false
+    default: 1.05
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ runner.temp }}
+      run: |
+        case "${{ runner.os }}" in
+          Linux)   FN="FASTBuild-Linux-x64-v${{ inputs.version }}.zip"   FBUILD=fbuild ;;
+          macOS)   FN="FASTBuild-OSX-x64-v${{ inputs.version }}.zip"     FBUILD=FBuild ;;
+          Windows) FN="FASTBuild-Windows-x64-v${{ inputs.version }}.zip" FBUILD=FBuild.exe ;;
+        esac
+        curl -fL "https://fastbuild.org/downloads/v${{ inputs.version }}/${FN}" -o "${FN}"
+        unzip "${FN}" ${FBUILD}
+        chmod +x ${FBUILD}
+        echo "FBUILD_PATH=${RUNNER_TEMP}/${FBUILD}" >> "${GITHUB_ENV}"

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,0 +1,100 @@
+name: Linux CI
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: Code
+
+jobs:
+  linux-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cfg: Build & Tests
+            gcc: 10
+            clang: 12
+            os: ubuntu-20.04
+          - cfg: Build
+            gcc: 7
+            clang: 9
+            os: ubuntu-18.04
+          - cfg: ASan
+            gcc: 10
+            clang: 12
+            os: ubuntu-20.04
+          - cfg: MSan
+            gcc: 10
+            clang: 12
+            os: ubuntu-20.04
+            can-fail: true
+          - cfg: TSan
+            gcc: 10
+            clang: 12
+            os: ubuntu-20.04
+            can-fail: true
+
+    name: Linux (${{ matrix.cfg }}, GCC ${{ matrix.gcc }}, Clang ${{ matrix.clang }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.can-fail || false }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/DownloadFBuild
+
+      - name: Configure fbuild.bff
+        env:
+          GCC: gcc-${{ matrix.gcc }}
+          GXX: g++-${{ matrix.gcc }}
+          CLANG: clang-${{ matrix.clang }}
+          CLANGXX: clang++-${{ matrix.clang }}
+        run: |
+          for x in ${GCC} ${GXX} $(${GCC} -print-prog-name=cc1) $(${GCC} -print-prog-name=cc1plus) ${CLANG} ${CLANGXX}; do
+            echo $x; which $x && readlink -f $(which $x)
+            echo
+          done
+          ${GCC} --version
+          ${CLANG} --version
+          # Inject "#define CI_BUILD" into root configs to activate CI logic.
+          sed -i -e "1i\\
+          #define CI_BUILD
+          " fbuild.bff Tools/FBuild/FBuildTest/Data/testcommon.bff
+          # Put full paths to GCC binaries into config files.
+          sed -i -e "
+          s:GCC_BINARY:$(which ${GCC}):
+          s:GXX_BINARY:$(which ${GXX}):
+          s:CC1_BINARY:$(${GCC} -print-prog-name=cc1):
+          s:CC1PLUS_BINARY:$(${GCC} -print-prog-name=cc1plus):
+          " ../External/SDK/GCC/Linux/GCC_CI.bff
+          # Put full paths to Clang binaries into config files.
+          sed -i -e "
+          s:CLANG_BINARY:$(which ${CLANG}):
+          s:CLANGXX_BINARY:$(which ${CLANGXX}):
+          " ../External/SDK/Clang/Linux/Clang_CI.bff
+
+      - name: Build
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary All-x64{,Clang}Linux-{Debug,Profile,Release}
+
+      - name: Tests
+        if: ${{ matrix.cfg == 'Build & Tests' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary Tests
+
+      - name: ASan
+        if: ${{ matrix.cfg == 'ASan' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary {CoreTest,FBuildTest}-RunTest-x64ClangLinux-ASan
+
+      - name: MSan
+        if: ${{ matrix.cfg == 'MSan' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary {CoreTest,FBuildTest}-RunTest-x64ClangLinux-MSan
+
+      - name: TSan
+        if: ${{ matrix.cfg == 'TSan' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary {CoreTest,FBuildTest}-RunTest-x64ClangLinux-TSan
+
+      - name: Build (NoUnity)
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary -nounity -clean All-x64{,Clang}Linux-Debug

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -1,0 +1,54 @@
+name: OSX CI
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: Code
+
+jobs:
+  osx-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cfg: Build & Tests
+            os: macos-10.15
+
+    name: OSX (${{ matrix.cfg }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/DownloadFBuild
+
+      - name: Configure fbuild.bff
+        run: |
+          for x in clang clang++; do
+            echo $x; which $x
+            echo
+          done
+          clang --version
+          # Inject "#define CI_BUILD" into root configs to activate CI logic.
+          sed -i -e "1i\\
+          #define CI_BUILD
+          " fbuild.bff Tools/FBuild/FBuildTest/Data/testcommon.bff
+          # Put full paths to Clang binaries into config files.
+          sed -i -e "
+          s:CLANG_BINARY:$(which clang):
+          s:CLANGXX_BINARY:$(which clang++):
+          " ../External/SDK/Clang/OSX/Clang_CI.bff
+
+      - name: Build
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary All-x64OSX-{Debug,Profile,Release}
+
+      - name: Tests
+        if: ${{ matrix.cfg == 'Build & Tests' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary Tests
+
+      - name: Build (NoUnity)
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary -nounity -clean All-x64OSX-Debug

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,64 @@
+name: Windows CI
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: Code
+
+jobs:
+  windows-ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cfg: Build & Tests
+            vs: 2019
+            os: windows-2019
+          - cfg: Build
+            vs: 2017
+            os: windows-2019
+          - cfg: Build
+            vs: 2015
+            os: windows-2019
+          - cfg: Analyze
+            vs: 2019
+            os: windows-2019
+
+    name: Windows (${{ matrix.cfg }}, VS ${{ matrix.vs }})
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/DownloadFBuild
+
+      - name: Configure fbuild.bff
+        run: |
+          'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\LLVM\x64\bin\clang.exe' --version
+          # Inject "#define CI_BUILD" into root configs to activate CI logic.
+          sed -i -e "1i\\
+          #define CI_BUILD
+          " fbuild.bff Tools/FBuild/FBuildTest/Data/testcommon.bff
+          # Comment all "#define USING_VS" lines and then uncomment the one we want.
+          sed -i -e "
+          /#define USING_VS/ s:^[^#]*://:
+          /#define USING_VS${{ matrix.vs }}/ s:^[^#]*::
+          " ../External/SDK/VisualStudio/VisualStudio.bff
+
+      - name: Build
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary All-x64{,Clang}-{Debug,Profile,Release}
+
+      - name: Tests
+        if: ${{ matrix.cfg == 'Build & Tests' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary Tests
+
+      - name: Analyze
+        if: ${{ matrix.cfg == 'Analyze' }}
+        run: ${FBUILD_PATH} -nostoponerror -summary All-x64-Analyze
+
+      - name: Build (NoUnity)
+        if: ${{ startsWith(matrix.cfg, 'Build') }}
+        run: ${FBUILD_PATH} -nostoponerror -summary -nounity -clean All-x64{,Clang}-Debug

--- a/Code/Core/CoreTest/Tests/TestSemaphore.cpp
+++ b/Code/Core/CoreTest/Tests/TestSemaphore.cpp
@@ -93,12 +93,12 @@ void TestSemaphore::WaitTimeout() const
 
     // Check for timeout
     {
-        const bool signalled = s.Wait( 1 ); // Wait 1ms
+        const bool signalled = s.Wait( 50 ); // Wait 50ms
         TEST_ASSERT( signalled == false ); // Should not be signalled (should time out)
     }
 
     // ensure some sensible time has elapsed
-    ASSERT( t.GetElapsed() > 0.001f ); // 1ms (allow wide margin of error)
+    TEST_ASSERT( t.GetElapsed() > 0.025f ); // 25ms (allow wide margin of error)
 }
 
 // MaxCount

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -84,6 +84,11 @@
             .TestOutput                     = "$OutputBase$/$ProjectPath$/TestOutput.txt"
             .TestWorkingDir                 = 'Tools/FBuild/FBuildTest'
             .TestTimeOut                    = 1000
+            #if CI_BUILD
+                // Temporarily showing output to help identify things on the CI
+                // that are significantly slower than local runs
+                .TestAlwaysShowOutput       = true // Show test timings on the CI
+            #endif
         }
 
         #if __WINDOWS__

--- a/Code/fbuild.bff
+++ b/Code/fbuild.bff
@@ -42,6 +42,10 @@ Settings
         // - Only in Debug as this impacts performance (inlining)
         // - Only when not building from tests (FASTBuild building itself)
         .UnityInputIsolateWritableFiles = true
+        // Also not when building on CI (which builds from git).
+        #if CI_BUILD
+            .UnityInputIsolateWritableFiles = false
+        #endif
     #endif
 ]
 .Analyze_Config =

--- a/External/SDK/Clang/Clang.bff
+++ b/External/SDK/Clang/Clang.bff
@@ -3,16 +3,16 @@
 
 // Select desired Clang version
 //------------------------------------------------------------------------------
-#if __LINUX__
+#if __LINUX__ && !CI_BUILD
     //#define USING_CLANG_3
     //#define USING_CLANG_6
     #define USING_CLANG_10
 #endif
-#if __OSX__
+#if __OSX__ && !CI_BUILD
     #define USING_CLANG_8
     //#define USING_CLANG_12
 #endif
-#if __WINDOWS__
+#if __WINDOWS__ && !CI_BUILD
     //#define USING_CLANG_7
     //#define USING_CLANG_8
     //#define USING_CLANG_9
@@ -23,6 +23,9 @@
 // Activate
 //------------------------------------------------------------------------------
 #if __LINUX__
+    #if CI_BUILD
+        #include "Linux/Clang_CI.bff"
+    #endif
     #if USING_CLANG_3
         #include "Linux/Clang3.bff"
     #endif
@@ -34,6 +37,9 @@
     #endif
 #endif
 #if __OSX__
+    #if CI_BUILD
+        #include "OSX/Clang_CI.bff"
+    #endif
     #if USING_CLANG_8
         #include "OSX/Clang8.bff"
     #endif
@@ -42,6 +48,9 @@
     #endif
 #endif
 #if __WINDOWS__
+    #if CI_BUILD
+        #define USING_CLANG_11
+    #endif
     #if USING_CLANG_7
         #include "Windows/Clang7.bff"
     #endif

--- a/External/SDK/Clang/Linux/Clang_CI.bff
+++ b/External/SDK/Clang/Linux/Clang_CI.bff
@@ -1,0 +1,63 @@
+// Clang
+//------------------------------------------------------------------------------
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-Clang' )
+{
+    .Executable                     = 'CLANG_BINARY'
+    .CompilerFamily                 = 'clang' // Specify compiler family explicitly because binary name may change at any moment
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_RELATIVE_PATHS
+        .UseRelativePaths_Experimental = true
+    #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_Clang_Linux =
+[
+    .Platform                       = 'x64ClangLinux'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-Clang'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -m64'           // x86_64
+                                    + ' -D__LINUX__'    // Platform define
+                                    + ' -D__X64__'      // Architecture define
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'   // warnings as errors
+                                    + ' -Wextra'
+                                    + ' -Wshadow'
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+                                    + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'CLANGXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2"'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -1,0 +1,115 @@
+// Apple Clang 12.0.0
+//------------------------------------------------------------------------------
+
+#define CLANG_SUPPORTS_ARMOSX
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-Clang12' )
+{
+    .Executable                     = 'CLANGXX_BINARY'
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_RELATIVE_PATHS
+        .UseRelativePaths_Experimental = true
+    #endif
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_Clang_OSX =
+[
+    .Platform                       = 'x64OSX'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-Clang12'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -arch x86_64'   // Intel 64-bit
+                                    + ' -D__OSX__'      // Platform define
+                                    + ' -D__APPLE__'    // Platform define
+                                    + ' -D__X64__'      // Architecture define
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'       // warnings as errors
+                                    + ' -Wextra'
+
+                                    // Disabled warnings
+                                    + ' -Wno-#pragma-messages'
+                                    + ' -Wno-invalid-offsetof'      // we get the offset of members in non-POD types
+                                    + ' -Wno-implicit-exception-spec-mismatch' // Fires on our new/delete operator (Clang bug?)
+
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'CLANGXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2" -g -arch x86_64'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+.ToolChain_Clang_ARMOSX =
+[
+    .Platform                       = 'ARMOSX'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-Clang12'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -arch arm64'    // Apple Silicon
+                                    + ' -D__OSX__'      // Platform define
+                                    + ' -D__APPLE__'    // Platform define
+                                    + ' -D__ARM64__'    // Architecture define
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'       // warnings as errors
+                                    + ' -Wextra'
+
+                                    // Disabled warnings
+                                    + ' -Wno-#pragma-messages'
+                                    + ' -Wno-invalid-offsetof'      // we get the offset of members in non-POD types
+                                    + ' -Wno-implicit-exception-spec-mismatch' // Fires on our new/delete operator (Clang bug?)
+
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'CLANGXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2" -g -arch arm64'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/Clang/Windows/Clang11.bff
+++ b/External/SDK/Clang/Windows/Clang11.bff
@@ -1,6 +1,9 @@
 // Clang 11.x.x
 //------------------------------------------------------------------------------
 .Clang11_BasePath     = '$_CURRENT_BFF_DIR_$/11.0.0'
+#if CI_BUILD
+    .Clang11_BasePath = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/LLVM/x64'
+#endif
 
 // Compiler
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Windows/Clang11.bff
+++ b/External/SDK/Clang/Windows/Clang11.bff
@@ -80,6 +80,7 @@ Compiler( 'Compiler-Clang11-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang7.bff
+++ b/External/SDK/Clang/Windows/Clang7.bff
@@ -72,6 +72,7 @@ Compiler( 'Compiler-Clang7-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang8.bff
+++ b/External/SDK/Clang/Windows/Clang8.bff
@@ -80,6 +80,7 @@ Compiler( 'Compiler-Clang8-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/Clang/Windows/Clang9.bff
+++ b/External/SDK/Clang/Windows/Clang9.bff
@@ -81,6 +81,7 @@ Compiler( 'Compiler-Clang9-NonCL' )
 
                                     // Include paths
                                     + ' -I"./"'
+                                    + .VSIncludePaths_ClangCl
 
                                     // x64
                                     + ' -m64'

--- a/External/SDK/GCC/GCC.bff
+++ b/External/SDK/GCC/GCC.bff
@@ -3,7 +3,7 @@
 
 // Select desired GCC version
 //------------------------------------------------------------------------------
-#if __LINUX__
+#if __LINUX__ && !CI_BUILD
     //#define USING_GCC_4
     //#define USING_GCC_7
     #define USING_GCC_9
@@ -12,6 +12,9 @@
 // Activate
 //------------------------------------------------------------------------------
 #if __LINUX__
+    #if CI_BUILD
+        #include "Linux/GCC_CI.bff"
+    #endif
     #if USING_GCC_4
         #include "Linux/GCC4.bff"
     #endif

--- a/External/SDK/GCC/Linux/GCC_CI.bff
+++ b/External/SDK/GCC/Linux/GCC_CI.bff
@@ -1,0 +1,67 @@
+// GCC
+//------------------------------------------------------------------------------
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-GCC' )
+{
+    .Executable                     = 'GXX_BINARY'
+    .ExtraFiles                     = {
+                                        '/usr/bin/as'
+                                        'CC1_BINARY'
+                                        'CC1PLUS_BINARY'
+                                      }
+    .CompilerFamily                 = 'gcc' // Specify compiler family explicitly because binary name may change at any moment
+
+    // Allow tests to activate some experimental behavior
+    #if ENABLE_SOURCE_MAPPING
+        .SourceMapping_Experimental = '/fastbuild-test-mapping'
+    #endif
+}
+
+// ToolChain
+//------------------------------------------------------------------------------
+.ToolChain_GCC_Linux =
+[
+    .Platform                       = 'x64Linux'
+
+    // Compiler Options
+    .Compiler                       = 'Compiler-GCC'
+    .CommonCompilerOptions          = ' -o "%2" "%1"'   // Input/Output
+                                    + ' -c'             // Compile only
+                                    + ' -g'             // Generate debug info
+                                    + ' -m64'           // x86_64
+                                    + ' -D__LINUX__'    // Platform define
+                                    + ' -D__X64__'      // Architecture define
+                                    + ' -ffreestanding' // prevent extra magic includes like stdc-predefs.h
+
+                                    // Include paths
+                                    + ' -I./'
+
+                                    // Enable warnings
+                                    + ' -Wall -Werror -Wfatal-errors'   // warnings as errors
+                                    + ' -Wextra'
+                                    + ' -Wshadow'
+
+    .CompilerOptions                = ' -std=c++11 $CommonCompilerOptions$'
+                                    + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+                                    + ' -fdiagnostics-color=auto'
+    .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
+
+    // Librarian
+    .Librarian                      = '/usr/bin/ar'
+    .LibrarianOptions               = 'rcs "%2" "%1"'
+
+    // Linker
+    .Linker                         = 'GXX_BINARY'
+    .LinkerOptions                  = '"%1" -o "%2"'
+
+    // File Extensions
+    .LibExtension                   = '.a'
+    .ExeExtension                   = ''
+
+    // Exception Control
+    .UseExceptions                  = ' -fexceptions'
+]
+
+//------------------------------------------------------------------------------

--- a/External/SDK/VisualStudio/VS2015.bff
+++ b/External/SDK/VisualStudio/VS2015.bff
@@ -1,6 +1,34 @@
 // Visual Studio 2015
 //------------------------------------------------------------------------------
-.VS2015_BasePath        = '$_CURRENT_BFF_DIR_$/2015'
+//
+// Detect VS2015
+//
+// We search in the following locations, in order of preference:
+//  1) Vendorized in External (side by side with this bff)
+//  2) Part of a Visual Studio installation (Program Files)
+//
+#if file_exists( "2015/VC/bin/amd64/cl.exe" )
+    //
+    // Use vendorized toolchain
+    //
+    .VS2015_BasePath        = '$_CURRENT_BFF_DIR_$/2015'
+#else
+    //
+    // Use Visual Studio installation
+    //
+    #if file_exists( "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe" )
+        .VS2015_BasePath        = 'C:/Program Files (x86)/Microsoft Visual Studio 14.0'
+    #else
+        //
+        // Failed
+        //
+        Print( '-----------------------------------------------------------------------' )
+        Print( '- Unable to auto-detect VS2015 - please specify installation manually -' )
+        Print( '-----------------------------------------------------------------------' )
+        .VS2015_BasePath        = .Set_Path_Here    // <-- Set path here
+    #endif
+#endif
+
 .VS2015_ToolchainPath    = '$VS2015_BasePath$'
 
 // X64 Compiler

--- a/External/SDK/VisualStudio/VS2015.bff
+++ b/External/SDK/VisualStudio/VS2015.bff
@@ -37,6 +37,7 @@ Compiler( 'Compiler-VS2015-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2015_BasePath$/VC/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2015_BasePath$/VC/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2015_BasePath$/VC/lib/amd64"'
     .VCPackagesPath                 = '$VS2015_BasePath$/VC/vcpackages'
 

--- a/External/SDK/VisualStudio/VS2017.bff
+++ b/External/SDK/VisualStudio/VS2017.bff
@@ -85,6 +85,7 @@ Compiler( 'Compiler-VS2017-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2017_ToolchainPath$/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2017_ToolchainPath$/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2017_ToolchainPath$/lib/x64"'
     .VCPackagesPath                 = '$VS2017_BasePath$/../Common7/IDE/VC/vcpackages'
 

--- a/External/SDK/VisualStudio/VS2017.bff
+++ b/External/SDK/VisualStudio/VS2017.bff
@@ -8,6 +8,7 @@
 //  2) Specified via environment variables (VS Command Prompt)
 //  3) Part of a Visual Studio installation (Program Files)
 //  4) Part of a BuildTools installation
+//  5) Part of a Visual Studio 2019 installation (used by GitHub Actions)
 //
 #if file_exists( "2017/Community/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64/cl.exe" )
     //
@@ -40,11 +41,21 @@
                 .VS2017_Version         = '14.16.27023'
             #else
                 //
-                // Failed
+                // Use Visual Studio 2019 Enterprise installation (used by GitHub Actions)
                 //
-                Error( 'Unable to auto-detect VS2017 - please specify installation manually ' )
-                .VS2017_BasePath        = .Set_Path_Here    // <-- Set path here
-                .VS2017_Version         = .Set_Version_Here // <-- Set version here
+                #if file_exists( "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64/cl.exe" )
+                    .VS2017_BasePath        = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC'
+                    .VS2017_Version         = '14.16.27023'
+                #else
+                    //
+                    // Failed
+                    //
+                    Print( '-----------------------------------------------------------------------' )
+                    Print( '- Unable to auto-detect VS2017 - please specify installation manually -' )
+                    Print( '-----------------------------------------------------------------------' )
+                    .VS2017_BasePath        = .Set_Path_Here    // <-- Set path here
+                    .VS2017_Version         = .Set_Version_Here // <-- Set version here
+                #endif
             #endif
         #endif
     #endif

--- a/External/SDK/VisualStudio/VS2019.bff
+++ b/External/SDK/VisualStudio/VS2019.bff
@@ -35,14 +35,23 @@
             .VS2019_MSC_VER         = '1929'
         #else
             //
-            // Failed
+            // Use Visual Studio 2019 Enterprise installation (used by GitHub Actions)
             //
-            Print( '-----------------------------------------------------------------------' )
-            Print( '- Unable to auto-detect VS2019 - please specify installation manually -' )
-            Print( '-----------------------------------------------------------------------' )
-            .VS2019_BasePath        = .Set_Path_Here    // <-- Set path here
-            .VS2019_Version         = .Set_Version_Here // <-- Set version here
-            .VS2019_MSC_VER         = .Set_MSC_VER_Here // <-- Set MSC_VER here
+            #if file_exists( "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30037/bin/Hostx64/x64/cl.exe" )
+                .VS2019_BasePath        = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC'
+                .VS2019_Version         = '14.29.30037'
+                .VS2019_MSC_VER         = '1929'
+            #else
+                //
+                // Failed
+                //
+                Print( '-----------------------------------------------------------------------' )
+                Print( '- Unable to auto-detect VS2019 - please specify installation manually -' )
+                Print( '-----------------------------------------------------------------------' )
+                .VS2019_BasePath        = .Set_Path_Here    // <-- Set path here
+                .VS2019_Version         = .Set_Version_Here // <-- Set version here
+                .VS2019_MSC_VER         = .Set_MSC_VER_Here // <-- Set MSC_VER here
+            #endif
         #endif
     #endif
 #endif

--- a/External/SDK/VisualStudio/VS2019.bff
+++ b/External/SDK/VisualStudio/VS2019.bff
@@ -85,6 +85,7 @@ Compiler( 'Compiler-VS2019-x64' )
 
     // Paths
     .VSIncludePaths                 = ' -I"$VS2019_ToolchainPath$/include/"'
+    .VSIncludePaths_ClangCl         = ' /imsvc "$VS2019_ToolchainPath$/include/"'
     .VSLibPaths                     = ' /LIBPATH:"$VS2019_ToolchainPath$/lib/x64"'
     .VCPackagesPath                 = '$VS2019_BasePath$/../Common7/IDE/VC/vcpackages'
 


### PR DESCRIPTION
Since Travis CI became unusable and was removed, FASTBuild is in need of another CI solution as bugs that could be easily caught by CI are starting to creep in: #845, #846, #847.

# Description:

The first two commits are from PR #846 and #847, they are fixing issues that ware found during the setup of CI.
 
Third commit fixes test failure that occurred only on CI runners and I wasn't able to reproduce locally (so it is not clear if that change should go in if this PR is not accepted).

The last commit adds GitHub Action configs to perform checking of PRs and pushes. It also extends VS autodetection with install location of VS on GitHub Windows runners.

Currently the following jobs are defined:
* Linux (Build & Tests, GCC 10, Clang 12)
  Checks compilation with newest compilers (available out of the box), and runs tests (using `Tests` target).
* Linux (Build, GCC 7, Clang 9)
  Checks compilation with oldest compilers (available out of the box).
* Linux (ASan, GCC 10, Clang 12)
  Runs tests compiled with Clang in Address Sanitizer mode.
* Linux (MSan, GCC 10, Clang 12)
  Runs tests compiled with Clang in Memory Sanitizer mode.
* Linux (TSan, GCC 10, Clang 12)
  Runs tests compiled with Clang in Thread Sanitizer mode.
* OSX (Build & Tests)
  Checks compilation with Apple Clang 12 (the only version available out of the box), and runs tests (using `Tests` target).
* Windows (Build & Tests, VS 2019)
  Checks compilation with VS 2019 and Clang 11 and runs tests (using `Tests` target).
* Windows (Build, VS 2017)
  Checks compilation with VS 2017 and Clang 11.
* Windows (Build, VS 2015)
  Checks compilation with VS 2015 and Clang 11.
* Windows (Analyze, VS 2019)
  Builds `All-x64-Analyze` target with VS 2019 performing static analysis.

There are currently some problems that aren't solved and for which I added workarounds:
* ThreadSanitizer found a race in `TestDistributed.TestLocalRace` test ~~once~~twice: https://github.com/dummyunit/fastbuild/runs/2947618917#step:9:1209 https://github.com/dummyunit/fastbuild/runs/2964252136#step:9:1209 I didn't investigate further ~~as this happened only once so far~~.
   As a workaround I marked the corresponding job with `continue-on-error: true` which hopefully should keep overall Ci status green when that job fails.
* Test `TestTestTCPConnectionPool.TestConnectionCount` failed once in `x64ClangLinux-MSan` due to to timeout: https://github.com/dummyunit/fastbuild/runs/2953262398#step:8:320 I didn't investigate further as this happened only once so far.
   The workaround is the same as in the previous case.
* MSVC static analysis fails when WinSDK 10.0.19041.0 is used, the failure is caused by errors reported by analyzer in `WS2tcpip.h`: https://github.com/dummyunit/fastbuild/runs/2945765753#step:7:35
   ~~As a workaround the previous available WinSDK version is used in the corresponding job.~~ There is now a proper fix for this: a6e5b46c

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** (N/A)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
