### PR TITLE
Adding remote CPU time to FASTBuild reports

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/Report.cpp
@@ -324,6 +324,12 @@ void Report::CreateOverview( const FBuildStats & stats )
     float localRatio = ( totalLocalCPUInSeconds / totalBuildTime );
     Write( "<tr><td>CPU Time</td><td>%s (%2.1f:1)</td></tr>\n", buffer.Get(), (double)localRatio );
 
+    // Remote CPU Time
+    float totalRemoteCPUInSeconds = (float)( (double)stats.m_TotalRemoteCPUTimeMS / (double)1000 );
+    stats.FormatTime( totalRemoteCPUInSeconds, buffer );
+    float remoteRatio = ( totalRemoteCPUInSeconds / totalBuildTime );
+    Write( "<tr><td>Remote CPU Time</td><td>%s (%2.1f:1)</td></tr>\n", buffer.Get(), (double)remoteRatio );
+
     // version info
     Write( "<tr><td>Version</td><td>%s %s</td></tr>\n", FBUILD_VERSION_STRING, FBUILD_VERSION_PLATFORM );
 


### PR DESCRIPTION
# Description:

This change adds Remote CPU Time to FASTBuild HTML reports to be more consistent with the summary ([#844](https://github.com/fastbuild/fastbuild/issues/844)).

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** (N/A)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
