### PR TITLE
Fix crash on wrong literal type in boolean evaluator

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
@@ -149,6 +149,18 @@ void TestIf::IfFunctionBool() const
 
     TEST_EXP_TRUE( ".True = true\n .False = false", "true && .True && true || !false || .False" );
 
+    // Non-existent variable
+    TEST_EXP_FAIL( ".Bool = true", ".Bool == .A", "Unknown variable '.A'" );
+
+    // Incorrect RHS operand type
+    TEST_EXP_FAIL( ".Bool = true\n .A = 1234", ".Bool == .A", "Property '.A' must be of type <Bool> (found <Int>)" );
+    TEST_EXP_FAIL( ".Bool = true\n .A = 'xy'", ".Bool == .A", "Property '.A' must be of type <Bool> (found <String>)" );
+    TEST_EXP_FAIL( ".Bool = true\n .A = {''}", ".Bool == .A", "Property '.A' must be of type <Bool> (found <ArrayOfStrings>)" );
+    TEST_EXP_FAIL( ".Bool = true\n .S = []\n .A = {.S}", ".Bool == .A", "Property '.A' must be of type <Bool> (found <ArrayOfStructs>)" );
+    // TODO: Currently produces error #1071 "Unexpected token" instead of #1050
+    TEST_EXP_FAIL( ".Bool = true", ".Bool == 12", "Error #1071" );
+    TEST_EXP_FAIL( ".Bool = true", ".Bool == ''", "Error #1071" );
+
     // Legacy
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/if_function_boolean.bff" );
     TEST_ASSERT( GetRecordedOutput().Find( "Failure" ) == nullptr );
@@ -217,6 +229,17 @@ void TestIf::IfFunctionInt() const
 
 #undef VARS
 
+    // Non-existent variable
+    TEST_EXP_FAIL( ".Int = 1", ".Int == .A", "Unknown variable '.A'" );
+
+    // Incorrect RHS operand type
+    TEST_EXP_FAIL( ".Int = 1\n .A = true", ".Int == .A", "Property '.A' must be of type <Int> (found <Bool>)" );
+    TEST_EXP_FAIL( ".Int = 1\n .A = 'xy'", ".Int == .A", "Property '.A' must be of type <Int> (found <String>)" );
+    TEST_EXP_FAIL( ".Int = 1\n .A = {''}", ".Int == .A", "Property '.A' must be of type <Int> (found <ArrayOfStrings>)" );
+    TEST_EXP_FAIL( ".Int = 1\n .S = []\n .A = {.S}", ".Int == .A", "Property '.A' must be of type <Int> (found <ArrayOfStructs>)" );
+    TEST_EXP_FAIL( ".Int = 1", ".Int == true", "Property '<literal>' must be of type <Int> (found <Bool>)" );
+    TEST_EXP_FAIL( ".Int = 1", ".Int == 'xy'", "Property '<literal>' must be of type <Int> (found <String>)" );
+
     // Legacy
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/if_function_int.bff" );
     TEST_ASSERT( GetRecordedOutput().Find( "Failure" ) == nullptr );
@@ -282,6 +305,18 @@ void TestIf::IfFunctionStringCompare() const
 
 #undef VARS
 
+    // Non-existent variable
+    TEST_EXP_FAIL( ".String = ''", ".String == .A", "Unknown variable '.A'" );
+
+    // Incorrect RHS operand type
+    TEST_EXP_FAIL( ".String = ''\n .A = true", ".String == .A", "Property '.A' must be of type <String> (found <Bool>)" );
+    TEST_EXP_FAIL( ".String = ''\n .A = 1234", ".String == .A", "Property '.A' must be of type <String> (found <Int>)" );
+    TEST_EXP_FAIL( ".String = ''\n .A = {''}", ".String == .A", "Property '.A' must be of type <String> (found <ArrayOfStrings>)" );
+    TEST_EXP_FAIL( ".String = ''\n .S = []\n .A = {.S}", ".String == .A", "Property '.A' must be of type <String> (found <ArrayOfStructs>)" );
+    // TODO: Currently produces error #1071 "Unexpected token" instead of #1050
+    TEST_EXP_FAIL( ".String = ''", ".String == true", "Error #1071" );
+    TEST_EXP_FAIL( ".String = ''", ".String == 1234", "Error #1071" );
+
     // Legacy
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/if_function_stringcompare.bff" );
     TEST_ASSERT( GetRecordedOutput().Find( "Failure" ) == nullptr );
@@ -304,6 +339,19 @@ void TestIf::IfFunctionSet() const
     TEST_EXP_FALSE( VARS, ".D in .ABC" );
 
 #undef VARS
+
+    // Non-existent variable
+    TEST_EXP_FAIL( ".String = ''", ".String in .A", "Unknown variable '.A'" );
+
+    // Incorrect RHS operand type
+    TEST_EXP_FAIL( ".String = ''\n .A = true", ".String in .A", "Property '.A' must be of type <ArrayOfStrings> (found <Bool>)" );
+    TEST_EXP_FAIL( ".String = ''\n .A = 1234", ".String in .A", "Property '.A' must be of type <ArrayOfStrings> (found <Int>)" );
+    TEST_EXP_FAIL( ".String = ''\n .A = 'xy'", ".String in .A", "Property '.A' must be of type <ArrayOfStrings> (found <String>)" );
+    TEST_EXP_FAIL( ".String = ''\n .S = []\n .A = {.S}", ".String in .A", "Property '.A' must be of type <ArrayOfStrings> (found <ArrayOfStructs>)" );
+    // TODO: Currently produces error #1071 "Unexpected token" instead of #1050
+    TEST_EXP_FAIL( ".String = ''", ".String in true", "Error #1071" );
+    TEST_EXP_FAIL( ".String = ''", ".String in 1234", "Error #1071" );
+    TEST_EXP_FAIL( ".String = ''", ".String in 'xy'", "Property '<literal>' must be of type <ArrayOfStrings> (found <String>)" );
 }
 
 void TestIf::IfFunctionBracket() const


### PR DESCRIPTION
# Description:

This fixes 2 problems:
* A crash found by BFFFuzzer in `Operand::Ensure()` on code that refers to a non-existing variable: `.A='' If (.A>.B) {}`
* Continuation of parsing after error about incorrect type of the RHS argument of operator `in`. For example this code printed "True": `.A=1 If (('x' in .A) || true) { Print("True") }`

Changes:
* All token validation steps are moved to `Operand` and `OperandOf` constructors. This provides a nice invariant: if `IsValid()` is false then there was an error, for which an error message was already emitted, and the parsing should be aborted.
* `EnsureValid()` is removed in favor of always checking `IsValid()` after constructing `OperandOf` (except in cases where the token validity is already checked beforehand).
* Added handling of non-variable tokens in the code reporting error 1050 for incorrect operand type.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux** (Checked only Windows (VS 2019) and Linux (GCC 10, Clang 12))
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
