### PR TITLE
Allow to manually enable asserts in non-debug builds

### DIFF
--- a/Code/Core/Env/Assert.cpp
+++ b/Code/Core/Env/Assert.cpp
@@ -116,6 +116,9 @@ bool IsDebuggerAttached()
         }
         return true; // break execution
     #else
+        (void)message;
+        (void)file;
+        (void)line;
         return true; // break execution
     #endif
 }
@@ -142,6 +145,10 @@ bool IsDebuggerAttached()
 
         return Failure( buffer.Get(), file, line );
     #else
+        (void)message;
+        (void)file;
+        (void)line;
+        (void)fmtString;
         return true; // break execution
     #endif
 }

--- a/Code/Core/Env/Assert.h
+++ b/Code/Core/Env/Assert.h
@@ -10,27 +10,25 @@
 //------------------------------------------------------------------------------
 #if defined( __WINDOWS__ )
     #define BREAK_IN_DEBUGGER __debugbreak()
-#elif defined( __APPLE__ )
+#elif defined( __LINUX__ ) || defined( __APPLE__ )
     #define BREAK_IN_DEBUGGER __builtin_trap()
-#elif defined( __LINUX__ )
-    #if defined( __X64__ )
-        #define BREAK_IN_DEBUGGER __asm__ __volatile__("int $3")
-    #else
-        #define BREAK_IN_DEBUGGER __builtin_trap()
-    #endif
 #else
     #error Unknown platform
+#endif
+
+#if !defined( DEBUG ) && !defined( RELEASE )
+    #error neither DEBUG nor RELEASE were defined
 #endif
 
 // Global functions
 //------------------------------------------------------------------------------
 bool IsDebuggerAttached();
 
-// DEBUG
-//------------------------------------------------------------------------------
 #ifdef DEBUG
     #define ASSERTS_ENABLED
+#endif
 
+#ifdef ASSERTS_ENABLED
     // Create a no-return helper to improve static analysis
     #if defined( __WINDOWS__ )
         __declspec(noreturn) void NoReturn();
@@ -96,10 +94,7 @@ bool IsDebuggerAttached();
 
         static AssertCallback * s_AssertCallback;
     };
-
-// RELEASE
-//------------------------------------------------------------------------------
-#elif defined ( RELEASE )
+#else
     #define ASSERT( expression )            \
         do {                                \
         PRAGMA_DISABLE_PUSH_MSVC(4127)      \
@@ -118,8 +113,6 @@ bool IsDebuggerAttached();
         PRAGMA_DISABLE_PUSH_MSVC(4127)      \
         } while ( false )                   \
         PRAGMA_DISABLE_POP_MSVC
-#else
-    #error neither DEBUG nor RELEASE were defined
 #endif
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/SmallBlockAllocator.cpp
+++ b/Code/Core/Mem/SmallBlockAllocator.cpp
@@ -12,9 +12,7 @@
 #include "Core/Mem/MemPoolBlock.h"
 #include "Core/Process/Atomic.h"
 #include "Core/Process/Mutex.h"
-#if defined( DEBUG )
-    #include "Core/Process/Thread.h"
-#endif
+#include "Core/Process/Thread.h"
 #include "Core/Strings/AStackString.h"
 #include "Core/Tracing/Tracing.h"
 
@@ -32,7 +30,7 @@
 // Static Data
 //------------------------------------------------------------------------------
 /*static*/ bool                                 SmallBlockAllocator::s_ThreadSafeAllocs( true );
-#if defined( DEBUG )
+#if defined( ASSERTS_ENABLED )
     /*static*/ uint64_t                         SmallBlockAllocator::s_ThreadSafeAllocsDebugOwnerThread( 0 );
 #endif
 /*static*/ void *                               SmallBlockAllocator::s_BucketMemoryStart( MEM_BUCKETS_NOT_INITIALIZED );
@@ -143,9 +141,7 @@ void * SmallBlockAllocator::Alloc( size_t size, size_t align )
     }
 
     // Sanity check that we're being used safely
-    #if defined( DEBUG )
-        ASSERT( s_ThreadSafeAllocs || ( s_ThreadSafeAllocsDebugOwnerThread == (uint64_t)Thread::GetCurrentThreadId() ) );
-    #endif
+    ASSERT( s_ThreadSafeAllocs || ( s_ThreadSafeAllocsDebugOwnerThread == (uint64_t)Thread::GetCurrentThreadId() ) );
 
         void* ptr;
 
@@ -195,9 +191,7 @@ bool SmallBlockAllocator::Free( void * ptr )
     #endif
 
     // Sanity check that we're being used safely
-    #if defined( DEBUG )
-        ASSERT( s_ThreadSafeAllocs || ( s_ThreadSafeAllocsDebugOwnerThread == (uint64_t)Thread::GetCurrentThreadId() ) );
-    #endif
+    ASSERT( s_ThreadSafeAllocs || ( s_ThreadSafeAllocsDebugOwnerThread == (uint64_t)Thread::GetCurrentThreadId() ) );
 
     // Free it
     if ( s_ThreadSafeAllocs )
@@ -226,7 +220,7 @@ bool SmallBlockAllocator::Free( void * ptr )
         ASSERT( s_ThreadSafeAllocsDebugOwnerThread == 0 );
 
         // Store the new owner thread for further safety checks
-        #if defined( DEBUG )
+        #if defined( ASSERTS_ENABLED )
             s_ThreadSafeAllocsDebugOwnerThread = (uint64_t)Thread::GetCurrentThreadId();
         #endif
     }
@@ -237,7 +231,7 @@ bool SmallBlockAllocator::Free( void * ptr )
         ASSERT( s_ThreadSafeAllocsDebugOwnerThread == (uint64_t)Thread::GetCurrentThreadId() );
 
         // Store the new owner thread for further safety checks
-        #if defined( DEBUG )
+        #if defined( ASSERTS_ENABLED )
             s_ThreadSafeAllocsDebugOwnerThread = 0;
         #endif
     }

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -19,6 +19,7 @@
 
 // Includes
 //------------------------------------------------------------------------------
+#include "Core/Env/Assert.h"
 #include "Core/Mem/MemPoolBlock.h"
 #include "Core/Process/Mutex.h"
 
@@ -72,7 +73,7 @@
 
         // Single Threaded Mode
         static bool         s_ThreadSafeAllocs;
-        #if defined( DEBUG )
+        #if defined( ASSERTS_ENABLED )
             // When in single-threaded mode, catch unsafe use
             static uint64_t s_ThreadSafeAllocsDebugOwnerThread;
         #endif


### PR DESCRIPTION
# Description:

* Some code assumed that `ASSERTS_ENABLED` is defined when `DEBUG` is defined and vice versa. This made it difficult to temporary enable asserts in non-debug builds by defining `ASSERTS_ENABLED` as such code started to produce warnings and/or errors.
* Always use `__builtin_trap()` to break into debugger on Linux.
   `__builtin_trap()` generates `ud2` instruction on x86. Both `ud2` and `int3` stop the program execution when the program is run under `gdb`, but execution of `ud2` generates `SIGILL` instead of `SIGTRAP` and the latter isn't intercepted by libFuzzer runtime. So with `int3` asserts just terminate BFFFuzzer instead of handling the crash (saving the input, displaying stack trace and restarting fuzzing).

The goal of these changes is to be able to check test corpus generated by BFFFuzzer for possible asserts that it might trigger, for now by manually defining `ASSERTS_ENABLED` and rebuilding BFFFuzzer.

The pull request:
- [x] **Is created against the Dev branch**
- [ ] **Is self-contained** (There are two independent changes that could have been in different PRs, so I guess the PR is not self-contained. But they are thematically related and work towards the same goal so maybe it is OK to have them in one PR. I could split the PR if needed.)
- [ ] **Compiles on Windows, OSX and Linux** (Checked only Windows (VS 2019) and Linux (GCC 10, Clang 12))
- [ ] **Has accompanying tests** (N/A)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** (N/A)
