### PR TITLE
Avoid dependency on glibc 2.33 and 2.17 when building against them

### DIFF
--- a/Code/Core/Env/glibc_compat.h
+++ b/Code/Core/Env/glibc_compat.h
@@ -8,8 +8,51 @@
 //------------------------------------------------------------------------------
 #undef _FORTIFY_SOURCE
 
-// Use older memcpy
+// Use older implementations of glibc functions
 //------------------------------------------------------------------------------
+__asm__( ".symver clock_gettime,clock_gettime@GLIBC_2.2.5" );
 __asm__( ".symver memcpy,memcpy@GLIBC_2.2.5" );
+
+//------------------------------------------------------------------------------
+
+// Use stat,lstat,fstat implementations from older versions of glibc for better Linux distro compatibility
+//------------------------------------------------------------------------------
+#include <sys/stat.h>
+
+// In glibc 2.33 implementation of various stat functions was changed - usage of proxy functions (__xstat, etc.) was removed.
+// As a result code built with glibc 2.33 headers links to stat@GLIBC_2.33 instead of __xstat@GLIBC_2.2.5.
+// But in this case we can't use the __asm__(".symver") trick to use old versions of those functions,
+// because there are no compatible versions - those proxy functions have a different signature.
+// Thus we must use a more involved hack to force usage of old versions to avoid depending on a new glibc version.
+
+#if defined( __GLIBC__ ) && ( __GLIBC__ * 1000 + __GLIBC_MINOR__ ) >= 2033
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+    int __xstat( int ver, const char * path, struct stat * buf );
+    __extern_inline int stat( const char * path, struct stat * buf )
+    {
+        return __xstat( 0 /*_STAT_VER*/, path, buf );
+    }
+
+    int __lxstat( int ver, const char * path, struct stat * buf );
+    __extern_inline int lstat( const char * path, struct stat * buf )
+    {
+        return __lxstat( 0 /*_STAT_VER*/, path, buf );
+    }
+
+    int __fxstat( int ver, int fildes, struct stat * buf );
+    __extern_inline int fstat( int fildes, struct stat * buf )
+    {
+        return __fxstat( 0 /*_STAT_VER*/, fildes, buf );
+    }
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/fbuild.bff
@@ -43,9 +43,8 @@ ObjectList( 'Compile' )
 ObjectList( 'Compile-InjectHeader' )
 {
     #if __WINDOWS__ // Using clang-cl on Windows
-        .CompilerOptions                = ' "/FICore/Env/glibc_compat.h" $CompilerOptions$'
-                                        + ' -Wno-reserved-id-macro'
+        .CompilerOptions                = ' "/FITools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/injected.h" $CompilerOptions$'
     #else
-        .CompilerOptions                = ' -include Core/Env/glibc_compat.h $CompilerOptions$'
+        .CompilerOptions                = ' -include Tools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/injected.h $CompilerOptions$'
     #endif
 }

--- a/Code/Tools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/injected.h
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestUnity/ClangStaticAnalysis/injected.h
@@ -1,0 +1,1 @@
+#define A_MARCO


### PR DESCRIPTION
# Description:

Since the compatibility with old glibc versions was addressed previously (db78492682, #225, #398) it has regressed several times:
* In 0.97 fbuild started requiring glibc 2.10 due to usage of `accept4()`. That function first appeared in glibc 2.10 so this dependency is not easy to avoid. Also requiring glibc 2.10 shouldn't be a problem as no supported distribution is using glibc older than that.
* In 1.03 fbuild started requiring glibc 2.17 due to usage of `clock_gettime()`. Since that function was used well before 1.03, the dependency was most likely caused by building on a newer distribution than before.
* Very soon fbuild might start requiring glibc 2.33 due to usage of `stat()`, `lstat()` and `fstat()`, as the way they are implemented was changed in that version.

Fixing dependency on glibc 2.17 is easy - we use the `__asm__(".symver")` trick to link to the old implementation.
According to glibc 2.17 release notes (https://sourceware.org/legacy-ml/libc-announce/2012/msg00001.html) the new version of `clock_gettime()` was introduced to improve performance of singe-threaded programs, so we can continue to use the old version.

Fixing dependency on glibc 2.33 is harder as implementation of `stat()`, `lstat()`, etc. was changed significantly.
Previously they were implemented as inline wrappers directly in `sys/stat.h` and were calling internal implementation functions (like `__xstat()`). And executables were then linking to those internal functions.
In 2.33 this indirection was removed and now executables are linked to real `stat()`, `lstat()`, etc. in libc.so.6.
So to stay compatible with old glibc versions we have to implement those wrappers ourselves when we are building with glibc 2.33 or above.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
   Adding tests for this is an interesting idea, we can even test this on CI building against the latest glibc. But I think this is better to be done in a different PR (and maybe discussed beforehand).
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** N/A
