### PR TITLE
Fix missing dependencies when arguments are passed in exotic ways

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -924,25 +924,48 @@ void LinkerNode::GetAssemblyResourceFiles( Args & fullArgs, const AString & pre,
 
 // IsStartOfLinkerArg
 //------------------------------------------------------------------------------
-/*static*/ bool LinkerNode::IsStartOfLinkerArg( const AString & token, const char * arg )
+/*static*/ bool LinkerNode::IsStartOfLinkerArg( const AString & token, const char * arg, bool * foundLeadingQuote )
 {
     ASSERT( token.IsEmpty() == false );
 
-    // Args start with -
-    if ( token[0] != '-' )
+    const char * tokenString = token.Get();
+    uint32_t tokenLength = token.GetLength();
+
+    const bool hasLeadingQuote = token[ 0 ] == '"';
+    if ( foundLeadingQuote )
     {
-        return false;
+        *foundLeadingQuote = hasLeadingQuote;
+    }
+
+    // Args start with -
+    if ( hasLeadingQuote || tokenString[ 0 ] != '-' )
+    {
+        // But could be wrapped in quotes, so try again to see if we find one
+        if ( hasLeadingQuote && tokenLength > 1 )
+        {
+            ++tokenString;
+            --tokenLength;
+
+            if ( tokenString[ 0 ] != '-' )
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
     }
 
     // Length check to early out
     const size_t argLen = AString::StrLen( arg );
-    if ( ( token.GetLength() - 1 ) < argLen )
+    if ( ( tokenLength - 1 ) < argLen )
     {
         return false; // token is too short
     }
 
     // Args are case-sensitive
-    return ( AString::StrNCmp( token.Get() + 1, arg, argLen ) == 0 );
+    return ( AString::StrNCmp( tokenString + 1, arg, argLen ) == 0 );
 }
 
 // EmitCompilationMessage
@@ -1421,6 +1444,11 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
                                              bool canonicalizePath,
                                              bool isMSVC )
 {
+    AStackString<> tokenNoQuotes;
+
+    const char * tokenStart = it->Get();
+    const char * tokenEnd = it->GetEnd();
+
     // check for expected arg
     if ( isMSVC )
     {
@@ -1431,15 +1459,23 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     }
     else
     {
-        if ( LinkerNode::IsStartOfLinkerArg( *it, arg ) == false )
+        bool foundLeadingQuote;
+        if ( LinkerNode::IsStartOfLinkerArg( *it, arg, &foundLeadingQuote ) == false )
         {
             return false; // not our arg, not consumed
+        }
+
+        if ( foundLeadingQuote )
+        {
+            Args::StripQuotes( it->Get(), it->GetEnd(), tokenNoQuotes );
+            tokenStart = tokenNoQuotes.Get();
+            tokenEnd = tokenNoQuotes.GetEnd();
         }
     }
 
     // get remainder of token after arg
-    const char * valueStart = it->Get() + AString::StrLen( arg ) + 1;
-    const char * valueEnd = it->GetEnd();
+    const char * valueStart = tokenStart + AString::StrLen( arg ) + 1;
+    const char * valueEnd = tokenEnd;
 
     // if no remainder, arg value is next token
     if ( valueStart == valueEnd )

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -1271,8 +1271,8 @@ void LinkerNode::GetImportLibName( const AString & args, AString & importLibName
     {
         bool found = false;
 
-        // is the file a full path?
-        if ( ( itL->GetLength() > 2 ) && ( (*itL)[ 1 ] == ':' ) )
+        // is the file a full or relative path?
+        if ( PathUtils::IsFullPath( *itL ) || ( itL->Find( NATIVE_SLASH ) != nullptr ) || ( itL->Find( OTHER_SLASH ) != nullptr ) )
         {
             // check file exists in current location
             if ( !GetOtherLibrary( nodeGraph, iter, function, otherLibraries, AString::GetEmpty(), *itL, found ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
@@ -43,7 +43,7 @@ public:
     static bool IsLinkerArg_MSVC( const AString & token, const char * arg );
     static bool IsStartOfLinkerArg_MSVC( const AString & token, const char * arg );
 
-    static bool IsStartOfLinkerArg( const AString & token, const char * arg );
+    static bool IsStartOfLinkerArg( const AString & token, const char * arg, bool * foundLeadingQuote = nullptr );
 
 protected:
     friend class TestLinker;

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
@@ -59,6 +59,26 @@ void TestLinker::ArgHelpers() const
         TEST_ASSERT( LinkerNode::IsStartOfLinkerArg( token, "L" ) );
     }
 
+    // Test -l:
+    {
+        AStackString<> token( "-l:libFullName.a" );
+        TEST_ASSERT( LinkerNode::IsStartOfLinkerArg( token, "l" ) );
+
+        // test that the optional argument is filled correctly when passed
+        bool foundLeadingQuote;
+        TEST_ASSERT( LinkerNode::IsStartOfLinkerArg( token, "l", &foundLeadingQuote ) && !foundLeadingQuote );
+    }
+
+    // Test quoted
+    {
+        AStackString<> token( "\"-l:libFullName.a\"" );
+        TEST_ASSERT( LinkerNode::IsStartOfLinkerArg( token, "l" ) );
+
+        // test that the optional argument is filled correctly when passed
+        bool foundLeadingQuote;
+        TEST_ASSERT( LinkerNode::IsStartOfLinkerArg( token, "l", &foundLeadingQuote ) && foundLeadingQuote );
+    }
+
     // Check case sensitive is respected
     {
         AStackString<> token( "-l" );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
@@ -175,6 +175,18 @@ void TestLinker::LibrariesOnCommandLine() const
         }
     #endif
 
+    // MSVC: relative path
+    {
+        const bool isMSVC = true;
+        AStackString<> args( "./Tools/FBuild/FBuildTest/Data/TestLinker/LibrariesOnCommandLine/dummy1.lib" );
+
+        Dependencies foundLibraries;
+        LinkerNode::GetOtherLibraries( nodeGraph, iter, nullptr, args, foundLibraries, isMSVC );
+
+        TEST_ASSERT( foundLibraries.GetSize() == 1 );
+        TEST_ASSERT( foundLibraries[ 0 ].GetNode()->GetName().EndsWith( "dummy1.lib" ) );
+    }
+
     // MSVC: libs missing
     {
         const bool isMSVC = true;


### PR DESCRIPTION
# Description:

Some Executables and DLLs were not being rebuilt when they should have been, and that was caused by the way the libraries were passed to the linker command line, either by using relative path, or by wrapping the lib with double quotes on non-msvc linkers.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [X] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**

Fixes #875 