### PR TITLE
Fix envvar leak

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -1115,9 +1115,11 @@ bool Node::InitializePreBuildDependencies( NodeGraph & nodeGraph, const BFFToken
     // in some cases. For simplicity, we protect in all cases even
     // if we could avoid it as the mutex will not be heavily constested.
     MutexHolder mh( g_NodeEnvStringMutex );
-
-    // Caller owns thr memory
-    inoutCachedEnvString = Env::AllocEnvironmentString( envVars );
+    if ( !inoutCachedEnvString )
+    {
+        // Caller owns the memory
+        inoutCachedEnvString = Env::AllocEnvironmentString( envVars );
+    }
     return inoutCachedEnvString;
 }
 


### PR DESCRIPTION
# Description:

Fix the memory leak of environment variable, GetEnvironmentString could be called with already allocated memory which we would lose track of

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**
