### PR TITLE
fix #892 : sendfile will transfer at most 0x7ffff000 (2,147,479,552) …

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -252,7 +252,28 @@
         return false;
     }
 
-    ssize_t bytesCopied = sendfile( dest, source, 0, stat_source.st_size );
+    ssize_t bytesCopied = 0;
+    ssize_t offset = 0;
+
+    while ( offset < stat_source.st_size )
+    {
+        ssize_t count = 0;
+        ssize_t remaining = stat_source.st_size - offset;
+        if ( remaining > SSIZE_MAX )
+        {
+            count = SSIZE_MAX;
+        }
+        else
+        {
+            count = remaining;
+        }
+        ssize_t sent = sendfile( dest, source, &offset, count );
+        if ( sent == 0 || sent == -1 )
+        {
+            break;
+        }
+        bytesCopied += sent;
+    }
 
     close( source );
     close( dest );


### PR DESCRIPTION
# Description:

Please provide details for the change or fix:
fix #892 : sendfile will transfer at most 0x7ffff000 (2,147,479,552) bytes

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
