### PR TITLE
Add support for arrays as unary expressions

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/if.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/if.html
@@ -36,6 +36,7 @@ The following types of expressions are supported:
   <li>Boolean Values</li>
   <li>Comparisons</li>
   <li>Presence in ArrayOfStrings</li>
+  <li>Array is non-empty</li>
   <li>Compound boolean expressions of above three types</li>
 </ul>
 <b>NOTE:</b> Literal of ArrayOfStrings is not supported so far. 
@@ -177,6 +178,26 @@ Examples:
 </div>
 </div>
 
+
+<div class='newsitemheader'>Array is non-empty</div>
+<div class='newsitembody'>
+  <p>
+ArrayOfStrings or ArrayOfStructs variables can be checked to see if they are non-empty.
+</p>
+  <p>
+Examples:
+  </p>
+<div class='code'>If( .ArrayOfStructs )
+{
+// Evaluated if .ArrayOfStructs is non-empty
+}
+</div>
+<div class='code'>If( !.Bool && .ArrayOfStrings )
+{
+// Evaluated if .Bool is false and .ArrayOfStrings is non-empty
+}
+</div>
+</div>
 
 
     </div><div class='footer'>&copy; 2012-2021 Franta Fulin</div></div></div>

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestIf.cpp
@@ -25,6 +25,7 @@ private:
     void IfFunctionStringCompare() const;
     void IfFunctionSet() const;
     void IfFunctionBracket() const;
+    void IfArrayNotEmpty() const;
     void UsageError_ExtraTokensAfterExpression() const;
     void UsageError_UnsupportedTypeForIn() const;
     void UsageError_UnsupportedOperation() const;
@@ -46,6 +47,7 @@ REGISTER_TESTS_BEGIN( TestIf )
     REGISTER_TEST( IfFunctionSet )
     REGISTER_TEST( IfFunctionStringCompare )
     REGISTER_TEST( IfFunctionBracket )
+    REGISTER_TEST( IfArrayNotEmpty )
     REGISTER_TEST( UsageError_ExtraTokensAfterExpression )
     REGISTER_TEST( UsageError_UnsupportedTypeForIn )
     REGISTER_TEST( UsageError_UnsupportedOperation )
@@ -393,9 +395,24 @@ void TestIf::IfFunctionBracket() const
 #undef VARS
 }
 
-#undef TEST_EXP_TRUE
-#undef TEST_EXP_FALSE
-#undef TEST_EXP_FAIL
+void TestIf::IfArrayNotEmpty() const
+{
+#define VARS \
+    ".Struct = [.Value = 1]\n" \
+    ".NonEmptyStruct = {.Struct}\n" \
+    ".NonEmptyString = {'a', 'd'}\n" \
+    ".Empty = {}\n" \
+
+    TEST_EXP_TRUE( VARS, "(.NonEmptyStruct)" );
+    TEST_EXP_TRUE( VARS, "(.NonEmptyString)" );
+    TEST_EXP_TRUE( VARS, "!(.Empty)" );
+    TEST_EXP_FALSE( VARS, "(.Empty)" );
+    TEST_EXP_FALSE( VARS, "!(.NonEmptyStruct)" );
+    TEST_EXP_FALSE( VARS, "!(.NonEmptyString)" );
+
+#undef VARS
+}
+
 
 // UsageError_ExtraTokensAfterExpression
 //------------------------------------------------------------------------------
@@ -403,6 +420,8 @@ void TestIf::UsageError_ExtraTokensAfterExpression() const
 {
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/usageerror_extratokensafterexpression.bff", true ); // Expect failure
     TEST_ASSERT( GetRecordedOutput().Find( "Unexpected token 'and'" ) );
+
+    TEST_EXP_FAIL( ".Struct = [.Var = 1]\n.Array = {.Struct}\n", ".Struct in .Array", "Error #1071" );
 }
 
 // UsageError_UnsupportedTypeForIn
@@ -419,6 +438,11 @@ void TestIf::UsageError_UnsupportedOperation() const
 {
     Parse( "Tools/FBuild/FBuildTest/Data/TestIf/usageerror_unsupportedoperation.bff", true ); // Expect failure
     TEST_ASSERT( GetRecordedOutput().Find( "Unexpected operator '>='" ) );
+
+    TEST_EXP_FAIL( ".Struct = [.Var = 1]\n.Array = {.Struct}\n.OtherArray = {.Struct}", ".Array in .OtherArray", "Error #1070" );
 }
 
+#undef TEST_EXP_TRUE
+#undef TEST_EXP_FALSE
+#undef TEST_EXP_FAIL
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Description:

Add support for `If( .Array )` to check if an array has any elements.
Useful for constructs like

```
Alias("Foo") { .Targets = .SomeArrayThatMightBeEmpty }
```

As `.Targets` cannot be empty for an `Alias` -- now you can do:

```
If(.SomeArrayThatMightBeEmpty) {
    Alias("Foo") { .Targets = .SomeArrayThatMightBeEmpty }
}
```

Please provide details for the change or fix:
 - (For changes or new functionality) Detail the motivation/use-case behind the change and any context required to understand it.
 - (For fixes) Describe the bug/problem being fixed.
 - (If appropriate) Link to any associated issues.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [X] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [X] **Includes documentation**
