### PR TITLE
Remove /sourceDependencies for preprocessed file compilation

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_CL.cpp
+++ b/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_CL.cpp
@@ -136,6 +136,20 @@ CompilerDriver_CL::~CompilerDriver_CL() = default;
         return true;
     }
 
+    // Remove "/sourceDependencies <arg>" since we've already generated the source dependencies
+    // during preprocessing, and generating it again would be wrong (since the dependencies of
+    // the preprocessed file are not the same).
+    if (IsCompilerArg_MSVC(token, "sourceDependencies"))
+    {
+        ++index; // Skip next arg which specifies the mode for '/sourceDependencies'
+        return true;
+	}
+    // Remove "/sourceDependencies<arg>"
+    if (IsStartOfCompilerArg_MSVC(token, "sourceDependencies"))
+    {
+        return true;
+    }
+    
     return false;
 }
 


### PR DESCRIPTION
# Description:

When compiling a preprocessed file locally, the `/sourceDependencies` argument should be removed, as to avoid invalidating the dependencies JSON file (since the dependencies of an already-preprocessed file are not the same as the original source code).

# Testing:

This PR does not include test coverage for time constraint reasons, but this should be possible to test automatically:
 - Make a CPP with an #include
 - Compile with /sourceDependencies
 - Check that the content of the JSON file being produced is valid

An "invalid" JSON file has two observable symptoms:
 - An empty `Includes` array
 - `Source` points to the temporary pre-processed file generated by FBuild rather than the real source file

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux** (mostly n/a - only affects `cl.exe`)
- [ ] **Has accompanying tests** (no coverage included, apologies)
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity** (only affects `cl.exe`)
- [x] **Follows the code style**
- [x] **Includes documentation**
