### PR TITLE
Fixed compatibility with VS 2022 (17.2.32505.173). The IDE requires v…

### DIFF
--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -173,7 +173,7 @@ Compiler( 'Compiler-VS2022-x64' )
 [
     .VS_Version                     = .VS2022_Version
     .VS_Version_HumanReadable       = '2022'
-    .VS_SolutionVersion             = '16'
+    .VS_SolutionVersion             = '16.0.28701.123'
     .MSC_VER                        = .VS2022_MSC_VER
     .VS_ToolchainPath               = .VS2022_ToolchainPath
     .ToolChain_VS_Windows_X64       = .ToolChain_VS2022_Windows_X64


### PR DESCRIPTION
# Description:
VS 2022 (17.2.32505.173) required the full version, e.g. `17.2.32505.173` in the `.sln` file instead of a single number, e.g. `16`.

How to reproduce:
* Update the VS 2022 to the latest version `17.2.32505.173`
* Generate a .sln file with fastbuild OR create a .sln file with IDE.
* (If it was generated by VS) change the content of the file by setting the version string to a single number e.g.`VisualStudioVersion = 17`
* open the file with VS 2022, please EXPECT an error from the IDE 
![image](https://user-images.githubusercontent.com/586029/168705667-4ea1222c-4a58-4d9c-86e6-46b9b95aacfe.png)

*Note*: `16.0.28701.123` in the changes came from https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/solution-dot-sln-file?view=vs-2022, feel free to change it to any validate one.
Please provide details for the change or fix:
* Updated the content of VS2022.bff, using the full version for `VS_SolutionVersion`.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
