### PR TITLE
Adds a `-distcompressionlevel` flag

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/options.html
+++ b/Code/Tools/FBuild/Documentation/docs/options.html
@@ -80,6 +80,10 @@
     <td>Enable distributed compilation.</td>
   </tr>
   <tr>
+    <td><a href="#distcompressionlevel">-distcompressionlevel [level]</a></td>
+    <td>Control compression level of jobs sent out for distribution. (Default -1)</td>
+  </tr>
+  <tr>
     <td><a href="#distverbose">-distverbose</a></td>
     <td>Enable detailed logging for distributed compilation.</td>
   </tr>
@@ -345,6 +349,15 @@ be reproduced in the debugger.</p>
     <div class='newsitemheader' id="dist">-dist</div>
     <div class='newsitembody'>
 <p>Enable distributed compilation. Requires some build configuration.</p>
+
+    <div class='newsitemheader' id="distcompressionlevel">-distcompressionlevel [level]</div>
+    <div class='newsitembody'>
+<p>Control compression level of jobs sent out for distribution. (Default -1)</p>
+<p>This can be used to increase the level of compression for jobs sent out for distribution, trading increased CPU time
+        in order to reduce network transfer. This can be useful in network bandwidth limited environments. Note that
+        this value does not affect the compression level of the responses sent back from workers.</p>
+<p>See option <a href="#cachecompressionlevel">-cachecompressionlevel</a> for more details on compression levels and
+        their performance.</p>
 </div>
 
     <div class='newsitemheader' id="distverbose">-distverbose</div>

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -173,6 +173,26 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
                 m_Args += argv[ sizeIndex ];
                 continue;
             }
+            else if (thisArg == "-distcompressionlevel")
+            {
+                const int sizeIndex = (i + 1);
+                int32_t distributionCompressionLevel;
+                if ((sizeIndex >= argc) ||
+                    (AString::ScanS(argv[sizeIndex], "%i", &distributionCompressionLevel) != 1) ||
+                    ((distributionCompressionLevel < -128) || (distributionCompressionLevel > 12))) // See Compressor for valid ranges
+                {
+                    OUTPUT("FBuild: Error: Missing or bad <level> for '-distcompressionlevel' argument\n");
+                    OUTPUT("Try \"%s -help\"\n", programName.Get());
+                    return OPTIONS_ERROR;
+                }
+                m_DistributionCompressionLevel = static_cast<int16_t>(distributionCompressionLevel);
+                i++; // skip extra arg we've consumed
+
+                // add to args we might pass to subprocess
+                m_Args += ' ';
+                m_Args += argv[sizeIndex];
+                continue;
+            }
             else if ( thisArg == "-clean" )
             {
                 m_ForceCleanBuild = true;

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -76,7 +76,7 @@ public:
     bool        m_NoLocalConsumptionOfRemoteJobs    = false;
     bool        m_AllowLocalRace                    = true;
     uint16_t    m_DistributionPort                  = Protocol::PROTOCOL_PORT;
-    int16_t     m_DistributionCompressionLevel           = -1; // See Compresssor.h
+    int16_t     m_DistributionCompressionLevel      = -1; // See Compresssor.h
 
     // General Output
     bool        m_ShowVerbose                       = false;

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -76,6 +76,7 @@ public:
     bool        m_NoLocalConsumptionOfRemoteJobs    = false;
     bool        m_AllowLocalRace                    = true;
     uint16_t    m_DistributionPort                  = Protocol::PROTOCOL_PORT;
+    int16_t     m_DistributionCompressionLevel           = -1; // See Compresssor.h
 
     // General Output
     bool        m_ShowVerbose                       = false;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -510,7 +510,7 @@ Node::BuildResult ObjectNode::DoBuildWithPreProcessor( Job * job, bool useDeopti
     {
         // compress job data
         Compressor c;
-        c.Compress( job->GetData(), job->GetDataSize() );
+        c.Compress( job->GetData(), job->GetDataSize(), FBuild::Get().GetOptions().m_DistributionCompressionLevel );
         size_t compressedSize = c.GetResultSize();
         job->OwnData( c.ReleaseResult(), compressedSize, true );
 


### PR DESCRIPTION
# Description:

Adds a flag for enabling network compression for jobs sent out by the client. This flag helps improve job distribution for low upload bandwidth connections.

Open to suggestions on a better flag name, since technically this flag only controls compression for jobs sent and not received.

# Checklist:

The pull request:
- ☑ **Is created against the Dev branch**
- ☑ **Is self-contained**
- ⚠️ **Compiles on Windows, OSX and Linux**
             - Have not confirmed compilation on OSX and Linux
- ❎ **Has accompanying tests**
- ☑ **Passes existing tests**
- ☑ **Keeps Windows, OSX and Linux at parity**
- ☑ **Follows the code style**
- ☑ **Includes documentation**
