### PR TITLE
Adds `.Environment` option to the `Exec` function

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/exec.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/exec.html
@@ -54,6 +54,9 @@ The executable will be run if the outputfile is out of date (with respect to the
   ; Additional options
   .PreBuildDependencies   ; (optional) Force targets to be built before this Exec (Rarely needed,
                           ; but useful when Exec relies on externally generated files).
+
+  .Environment             ; (optional) Environment variables used when running the executable
+                           ; If not set, uses .Environment from your Settings node
 }
 </div>
 <p><b>Build-Time Substitutions</b>

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -49,9 +49,11 @@ private:
     bool                m_ExecAlways;
     bool                m_ExecInputPathRecurse;
     Array< AString >    m_PreBuildDependencyNames;
+    Array< AString >    m_Environment;
 
     // Internal State
     uint32_t            m_NumExecInputFiles;
+    mutable const char * m_EnvironmentString        = nullptr;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildTest/Data/TestExec/exec.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestExec/exec.bff
@@ -165,4 +165,3 @@ Exec( "ExecCommandTest_OneInput_WrongOutput_ExpectFail" )
     .ExecReturnCode = 0
     .ExecUseStdOutAsOutput = false
 }
-

--- a/Code/Tools/FBuild/FBuildTest/Data/TestExec/execenv.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestExec/execenv.bff
@@ -1,0 +1,52 @@
+// Exec
+//
+// Run an arbitrary executable
+//
+//------------------------------------------------------------------------------
+
+// Use the standard test environment
+//------------------------------------------------------------------------------
+#include "../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+// A simple exe
+// ExecEnv.exe takes dumps the environment variables to stdout
+//--------------------
+.OutPath                 = "$Out$/Test/Exec/"
+.EnvHelperExecutableName = "$OutPath$execenv.exe"
+{
+    .LinkerOutputFile = .EnvHelperExecutableName
+
+    ObjectList( "ExecEnv-Lib" )
+    {
+        .CompilerInputFiles = 'Tools/FBuild/FBuildTest/Data/TestExec/execenv.cpp'
+        .CompilerOutputPath = '$OutPath$/'
+        #if __WINDOWS__
+            .CompilerOptions    + ' /EHsc'
+                                - ' /Wall'
+        #endif
+    }
+
+    Executable( "EnvHelperExe" )
+    {
+        .LinkerOutput       = .LinkerOutputFile
+        #if __WINDOWS__
+            .LinkerOptions      + ' kernel32.lib'
+                                + ' libcpmt.lib'
+                                + .CRTLibs_Static
+        #endif
+        .Libraries          = { "ExecEnv-Lib" }
+    }
+}
+
+//--------------------
+// Tests the FB_ENV_TEST_VALUE environment variable is set
+Exec( "ExecEnvCommandTest" )
+{
+    .ExecExecutable = .EnvHelperExecutableName
+    .ExecOutput = '$OutPath$\dummy_file_does_not_exist.txt.out' // No output files expected
+    .ExecWorkingDir = .OutPath
+    .ExecReturnCode = 0
+    .Environment    = { "FB_ENV_TEST_VALUE=FASTbuild" }
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestExec/execenv.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestExec/execenv.cpp
@@ -1,0 +1,40 @@
+//
+// An simple executable to test the environment variable FB_ENV_TEST_VALUE is set
+//
+#if defined( __WINDOWS__ )
+    #include <Windows.h>
+#elif defined( __LINUX__ ) || defined( __APPLE__ )
+    #include <stdlib.h>
+#else
+    #error Unknown platform
+#endif
+
+#include <string.h>
+
+int main(int, char *[], char *[])
+{
+    #if defined( __WINDOWS__ )
+        char envVar[15];
+        DWORD ret = GetEnvironmentVariable( "FB_ENV_TEST_VALUE", envVar, 15 );
+
+        // variable does not exist or is longer than expected
+        if ( ret == 0 || ret > 9 )
+        {
+            return 1;
+        }
+    #elif defined( __LINUX__ ) || defined( __APPLE__ )
+        const char * envVar = getenv( "FB_ENV_TEST_VALUE" );
+        if ( !envVar )
+        {
+            return 1;
+        }
+    #else
+        #error Unknown platform
+    #endif
+    
+    if ( strcmp( envVar, "FASTbuild" ) == 0 )
+    {
+        return 0;
+    }
+    return 1;
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExec.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExec.cpp
@@ -27,6 +27,7 @@ private:
     void Build_ExecCommand_MultipleInputChange() const;
     void Build_ExecCommand_UseStdOut() const;
     void Build_ExecCommand_ExpectedFailures() const;
+    void Build_ExecEnvCommand() const;
     void Exclusions() const;
 };
 
@@ -40,6 +41,7 @@ REGISTER_TESTS_BEGIN( TestExec )
     REGISTER_TEST( Build_ExecCommand_MultipleInputChange )
     REGISTER_TEST( Build_ExecCommand_UseStdOut )
     REGISTER_TEST( Build_ExecCommand_ExpectedFailures )
+    REGISTER_TEST( Build_ExecEnvCommand )
     REGISTER_TEST( Exclusions )
 REGISTER_TESTS_END
 
@@ -297,6 +299,39 @@ void TestExec::Build_ExecCommand_ExpectedFailures() const
     targets.EmplaceBack( "ExecCommandTest_OneInput_ReturnCode_ExpectFail" );
     targets.EmplaceBack( "ExecCommandTest_OneInput_WrongOutput_ExpectFail" );
     TEST_ASSERT( !fBuild.Build( targets ) );
+}
+
+//------------------------------------------------------------------------------
+void TestExec::Build_ExecEnvCommand() const
+{
+    // Build execenv.exe
+    FBuildTestOptions options;
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestExec/execenv.bff";
+    options.m_NumWorkerThreads = 1;
+
+    FBuild fBuild( options );
+    fBuild.Initialize();
+
+    const AStackString<> execenv( "../tmp/Test/Exec/execenv.exe" );
+
+    // clean up anything left over from previous runs
+    EnsureFileDoesNotExist( execenv );
+
+    // build (via alias)
+    TEST_ASSERT( fBuild.Build( "EnvHelperExe" ) );
+
+    // make sure all output is where it is expected
+    EnsureFileExists( execenv );
+
+    // Check stats
+    //               Seen,  Built,  Type
+    CheckStatsNode ( 1,     1,      Node::OBJECT_NODE );
+    CheckStatsNode ( 1,     1,      Node::OBJECT_LIST_NODE );
+    CheckStatsNode ( 1,     1,      Node::ALIAS_NODE );
+    CheckStatsNode ( 1,     1,      Node::EXE_NODE );
+
+    // Run the execenv command and ensure we get the expected output
+    TEST_ASSERT( fBuild.Build( "ExecEnvCommandTest" ) );
 }
 
 // Exclusions


### PR DESCRIPTION
# Description:

Adds `.Environment` option to the `Exec` function. Its implemented the same as how its implemented on the `Compiler`, `DLL`, `Executable`, `Library` and `Test` functions.

Includes a unit test that provides environment variables via this option to an executable that dumps the values via stdout and then validates that the values returned are the overridden values.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation**
