### PR TITLE
Fix warnings when building in Clang 14 on Linux

### DIFF
--- a/Code/Core/Containers/Forward.h
+++ b/Code/Core/Containers/Forward.h
@@ -8,7 +8,7 @@ template < class T, class U > struct ForwardType< T &, U & >    { using type = T
     __pragma( clang diagnostic push )
     __pragma( clang diagnostic ignored "-Wcomma" )
 #endif
-template < class T, class U > struct ForwardType< T &, U >      { static_assert( ( sizeof( T ), false ), "can not forward rvalue as lvalue" ); };
+template < class T, class U > struct ForwardType< T &, U >      { static_assert( ( (void)sizeof( T ), false ), "can not forward rvalue as lvalue" ); };
 #if defined( __WINDOWS__) && defined( __clang__ )
     __pragma( clang diagnostic pop )
 #endif


### PR DESCRIPTION
# Description:

Clang 14 started to emit `-Wunused-value` for the left side of the comma operator even in constexpr/template contexts: https://godbolt.org/z/aP6r313v3
This change in behavior breaks the build via this warning:
```
./Core/Containers/Forward.h:11:84: error: left operand of comma operator has no effect [-Werror,-Wunused-value]
template < class T, class U > struct ForwardType< T &, U >      { static_assert( ( sizeof( T ), false ), "can not forward rvalue as lvalue" ); };
```

I also suspect that `#pragma`s disabling `-Wcomma` around this code might not be needed after this change. I can't check that as the commit in which they were added doesn't mention which version of Clang produced `-Wcomma` there.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** N/A
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** N/A
