### PR TITLE
Support caching of .gcno files

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/features/distribution.html
+++ b/Code/Tools/FBuild/Documentation/docs/features/distribution.html
@@ -51,7 +51,7 @@ settings, it will automatically build the impacted object(s) locally. A build ca
 <p>
 <b>GCC/SNC/Clang</b>
 <ul>
-  <li>No restrictions.</li>
+  <li>-ftest-coverage (and --coverage) cannot be distributed: .gcno files would contain wrong paths, .gcda files would be created in a wrong place.</li>
 </ul>
 <b>MSVC</b>
 <ul>

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1041,6 +1041,8 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
             flags.Set( CompilerFlags::FLAG_DIAGNOSTICS_COLOR_AUTO );
         }
 
+        bool coverage = false;
+
         Array< AString > tokens;
         args.Tokenize( tokens );
         const AString * const end = tokens.End();
@@ -1055,6 +1057,20 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
             else if ( token.BeginsWith( "-fdiagnostics-color" ) || token == "-fno-diagnostics-color" )
             {
                 flags.Clear( CompilerFlags::FLAG_DIAGNOSTICS_COLOR_AUTO );
+            }
+            else if ( token == "-ftest-coverage" )
+            {
+                flags.Set( CompilerFlags::FLAG_GCOV_COVERAGE );
+            }
+            else if ( token == "-fno-test-coverage" )
+            {
+                flags.Clear( CompilerFlags::FLAG_GCOV_COVERAGE );
+            }
+            else if ( token == "--coverage" )
+            {
+                // --coverage implies -ftest-coverage.
+                // But unlike -ftest-coverage it can't be reverted with -fno-test-coverage, so we need to handle it after the loop.
+                coverage = true;
             }
             else if ( token.BeginsWith( "-werror" ) )
             {
@@ -1076,6 +1092,11 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
                 }
             }
         }
+
+        if ( coverage )
+        {
+            flags.Set( CompilerFlags::FLAG_GCOV_COVERAGE );
+        }
     }
 
     // check for cacheability/distributability for non-MSVC
@@ -1085,10 +1106,13 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
          flags.IsCodeWarriorWii() ||
          flags.IsGreenHillsWiiU() )
     {
-        // creation of the PCH must be done locally to generate a usable PCH
-        // Objective C/C++ cannot be distributed
-        // Source mappings are not currently forwarded so can only compiled locally
-        if ( !creatingPCH && !objectiveC && !hasSourceMapping )
+        // * Creation of the PCH must be done locally to generate a usable PCH
+        // * Objective C/C++ cannot be distributed
+        // * Source mappings are not currently forwarded so can only compiled locally
+        // * Remote compilation with Gcov coverage is disabled as it has some issues:
+        //   1. .gcno files will contain incorrect build root path (working directory on the worker).
+        //   2. Object files compiled remotely will create .gcda files in the directory where these object files were stored on the worker.
+        if ( !creatingPCH && !objectiveC && !hasSourceMapping && !( flags.IsUsingGcovCoverage() ) )
         {
             if ( isDistributableCompiler )
             {
@@ -1267,6 +1291,18 @@ void ObjectNode::GetNativeAnalysisXMLPath( AString& outXMLFileName ) const
     const char * extPos = sourceName.FindLast( '.' ); // Only last extension removed
     outXMLFileName.Assign( sourceName.Get(), extPos ? extPos : sourceName.GetEnd() );
     outXMLFileName += ".nativecodeanalysis.xml";
+}
+
+// GetGCNOPath
+//------------------------------------------------------------------------------
+void ObjectNode::GetGCNOPath( AString & gcnoFileName ) const
+{
+    ASSERT( IsUsingGcovCoverage() );
+
+    // TODO:B The .gcno path can be manually specified with -fprofile-note=
+    const char * extPos = m_Name.FindLast( '.' ); // Only last extension removed
+    gcnoFileName.Assign( m_Name.Get(), extPos ? extPos : m_Name.GetEnd() );
+    gcnoFileName += ".gcno";
 }
 
 // GetObjExtension
@@ -1599,21 +1635,16 @@ void ObjectNode::GetExtraCacheFilePaths( const Job * job, Array< AString > & out
         return;
     }
 
-    // Only the MSVC compiler creates extra objects
     const ObjectNode * objectNode = node->CastTo< ObjectNode >();
-    if ( objectNode->m_CompilerFlags.IsMSVC() == false )
-    {
-        return;
-    }
 
-    // Precompiled Headers have an extra file
-    if ( objectNode->m_CompilerFlags.IsCreatingPCH() )
+    // MSVC precompiled headers have an extra file
+    if ( objectNode->m_CompilerFlags.IsCreatingPCH() && objectNode->m_CompilerFlags.IsMSVC() )
     {
         // .pch.obj
         outFileNames.Append( m_PCHObjectFileName );
     }
 
-    // Static analysis adds extra files
+    // MSVC static analysis adds extra files
     if ( objectNode->m_CompilerFlags.IsUsingStaticAnalysisMSVC() )
     {
         if ( objectNode->m_CompilerFlags.IsCreatingPCH() )
@@ -1637,6 +1668,15 @@ void ObjectNode::GetExtraCacheFilePaths( const Job * job, Array< AString > & out
         AStackString<> xmlFileName;
         GetNativeAnalysisXMLPath( xmlFileName );
         outFileNames.Append( xmlFileName );
+    }
+
+    // Gcov coverage adds extra file
+    if ( objectNode->m_CompilerFlags.IsUsingGcovCoverage() )
+    {
+        // .gcno
+        AStackString<> gcnoFileName;
+        GetGCNOPath( gcnoFileName );
+        outFileNames.Append( gcnoFileName );
     }
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -76,6 +76,7 @@ public:
         bool IsDiagnosticsColorAuto() const         { return ( ( m_Flags & FLAG_DIAGNOSTICS_COLOR_AUTO ) != 0 ); }
         bool IsWarningsAsErrorsClangGCC() const     { return ( ( m_Flags & FLAG_WARNINGS_AS_ERRORS_CLANGGCC ) != 0 ); }
         bool IsClangCl() const                      { return ( ( m_Flags & FLAG_CLANG_CL ) != 0 ); }
+        bool IsUsingGcovCoverage() const            { return ( ( m_Flags & FLAG_GCOV_COVERAGE ) != 0 ); }
 
         enum Flag : uint32_t
         {
@@ -103,6 +104,7 @@ public:
             FLAG_DIAGNOSTICS_COLOR_AUTO         = 0x800000,
             FLAG_WARNINGS_AS_ERRORS_CLANGGCC    = 0x1000000,
             FLAG_CLANG_CL                       = 0x2000000,
+            FLAG_GCOV_COVERAGE                  = 0x4000000,
         };
 
         void Set( Flag flag )       { m_Flags |= flag; }
@@ -142,6 +144,7 @@ public:
     bool IsUsingStaticAnalysisMSVC() const  { return m_CompilerFlags.IsUsingStaticAnalysisMSVC(); }
     bool IsOrbisWavePSSLC() const           { return m_CompilerFlags.IsOrbisWavePSSLC(); }
     bool IsWarningsAsErrorsClangGCC() const { return m_CompilerFlags.IsWarningsAsErrorsClangGCC(); }
+    bool IsUsingGcovCoverage() const        { return m_CompilerFlags.IsUsingGcovCoverage(); }
 
     virtual void SaveRemote( IOStream & stream ) const override;
     static Node * LoadRemote( IOStream & stream );
@@ -156,6 +159,7 @@ public:
 
     void GetPDBName( AString & pdbName ) const;
     void GetNativeAnalysisXMLPath( AString& outXMLFileName ) const;
+    void GetGCNOPath( AString & gcnoFileName ) const;
 
     const char * GetObjExtension() const;
 

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -754,6 +754,14 @@ void Client::ProcessJobResultCommon( const ConnectionInfo * connection, bool isC
                 result = WriteFileToDisk( xmlFileName, mb, fileIndex++ );
             }
 
+            // 4. .gcno (optional)
+            if ( result && on->IsUsingGcovCoverage() )
+            {
+                AStackString<> gcnoFileName;
+                on->GetGCNOPath( gcnoFileName );
+                result = WriteFileToDisk( gcnoFileName, mb, fileIndex++ );
+            }
+
             if ( result )
             {
                 // record new file time

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
@@ -420,6 +420,7 @@ void JobQueueRemote::FinishedProcessingJob( Job * job, bool success )
     const ObjectNode * node = job->GetNode()->CastTo< ObjectNode >();
     const bool includePDB = node->IsUsingPDB();
     const bool usingStaticAnalysis = node->IsUsingStaticAnalysisMSVC();
+    const bool usingGcovCoverage = node->IsUsingGcovCoverage();
 
     // Determine list of files to send
 
@@ -444,6 +445,15 @@ void JobQueueRemote::FinishedProcessingJob( Job * job, bool success )
         AStackString<> xmlFileName;
         node->GetNativeAnalysisXMLPath( xmlFileName );
         fileNames.Append( xmlFileName );
+    }
+
+    // 4. .gcno file (optional)
+    //--------------------------------------------
+    if ( usingGcovCoverage )
+    {
+        AStackString<> gcnoFileName;
+        node->GetGCNOPath( gcnoFileName );
+        fileNames.Append( gcnoFileName );
     }
 
     MultiBuffer mb;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_GCNO/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_GCNO/fbuild.bff
@@ -1,0 +1,29 @@
+//
+// Test extra cached file: .gcno
+//
+//------------------------------------------------------------------------------
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {} // use Standard Environment
+
+ObjectList( 'ObjectList' )
+{
+    #if __WINDOWS__
+        // Use Clang in Clang mode (clang.exe not clang-cl.exe)
+        Using( .ToolChain_ClangNonCL_Windows )
+    #endif
+    #if __LINUX__
+        Using( .ToolChain_GCC_Linux )
+    #endif
+    #if __OSX__
+        #if __ARM64__
+            Using( .ToolChain_Clang_ARMOSX )
+        #else
+            Using( .ToolChain_Clang_OSX )
+        #endif
+    #endif
+
+    .CompilerInputFiles = { '$TestRoot$/Data/TestCache/ExtraFiles_GCNO/file.cpp' }
+    .CompilerOutputPath = '$Out$/Test/Cache/ExtraFiles_GCNO/'
+    .CompilerOptions    + ' --coverage'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_GCNO/file.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_GCNO/file.cpp
@@ -1,0 +1,7 @@
+int func( int x )
+{
+    if ( x < 0 )
+        return -x;
+    else
+        return x;
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/fbuild.bff
@@ -1,0 +1,14 @@
+//
+// Test extra cached file: .nativecodeanalysis.xml
+//
+//------------------------------------------------------------------------------
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {} // use Standard Environment
+
+ObjectList( 'ObjectList' )
+{
+    .CompilerInputFiles = { '$TestRoot$/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/file.cpp' }
+    .CompilerOutputPath = '$Out$/Test/Cache/ExtraFiles_NativeCodeAnalysisXML/'
+    .CompilerOptions    + ' /analyze'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/file.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/file.cpp
@@ -1,0 +1,1 @@
+void func() {}

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
@@ -12,6 +12,7 @@
 #include "Tools/FBuild/FBuildCore/Protocol/Server.h"
 
 // Core
+#include "Core/FileIO/FileIO.h"
 #include "Core/Profile/Profile.h"
 #include "Core/Strings/AStackString.h"
 
@@ -48,6 +49,10 @@ private:
     void Analyze_MSVC_WarningsOnly_WriteFromDist() const;
     void Analyze_MSVC_WarningsOnly_ReadFromDist() const;
 
+    void ExtraFiles( const char * bffPath, const char * extraFilePath ) const;
+    void ExtraFiles_NativeCodeAnalysisXML() const;
+    void ExtraFiles_GCNO() const;
+
     // Helpers
     void CheckForDependencies( const FBuildForTest & fBuild, const char * const files[], size_t numFiles ) const;
     void LightCache_IncludeUsingUndefinedMacros( const char * consfigFile,
@@ -65,7 +70,10 @@ REGISTER_TESTS_BEGIN( TestCache )
     REGISTER_TEST( Read )
     REGISTER_TEST( ReadWrite )
     REGISTER_TEST( ConsistentCacheKeysWithDist )
+    REGISTER_TEST( ExtraFiles_GCNO )
     #if defined( __WINDOWS__ )
+        REGISTER_TEST( ExtraFiles_NativeCodeAnalysisXML )
+
         REGISTER_TEST( LightCache_IncludeUsingMacro )
         REGISTER_TEST( LightCache_IncludeUsingMacro2 )
         REGISTER_TEST( LightCache_IncludeUsingMacro3 )
@@ -1042,6 +1050,66 @@ void TestCache::Analyze_MSVC_WarningsOnly_ReadFromDist() const
     #if defined( _MSC_VER ) && ( _MSC_VER >= 1910 ) // From VS2017 or later
         TEST_ASSERT( xml.Find( "<DEFECTCODE>6387</DEFECTCODE>" ) );
     #endif
+}
+
+// ExtraFiles
+//------------------------------------------------------------------------------
+void TestCache::ExtraFiles( const char * bffPath, const char * extraFilePath ) const
+{
+    FBuildTestOptions options;
+    options.m_ForceCleanBuild = true;
+    options.m_CacheVerbose = true;
+    options.m_ConfigFile = bffPath;
+
+    // Do first build writing to cache
+    {
+        options.m_UseCacheRead = false;
+        options.m_UseCacheWrite = true;
+        FBuildForTest fBuild( options );
+        TEST_ASSERT( fBuild.Initialize() );
+
+        TEST_ASSERT( fBuild.Build( "ObjectList" ) );
+
+        // Ensure cache was written to
+        const FBuildStats::Stats & objStats = fBuild.GetStats().GetStatsFor( Node::OBJECT_NODE );
+        TEST_ASSERT( objStats.m_NumCacheStores == objStats.m_NumProcessed );
+        TEST_ASSERT( objStats.m_NumBuilt == objStats.m_NumProcessed );
+    }
+
+    // Remove the extra file to ensure that it will be restored from cache and not be left over from the first build.
+    TEST_ASSERT( FileIO::FileDelete( extraFilePath ) );
+
+    // Do second build reading from cache
+    {
+        options.m_UseCacheRead = true;
+        options.m_UseCacheWrite = false;
+        FBuildForTest fBuild( options );
+        TEST_ASSERT( fBuild.Initialize() );
+
+        TEST_ASSERT( fBuild.Build( "ObjectList" ) );
+
+        // Ensure cache was read from
+        const FBuildStats::Stats & objStats = fBuild.GetStats().GetStatsFor( Node::OBJECT_NODE );
+        TEST_ASSERT( objStats.m_NumCacheHits == objStats.m_NumProcessed );
+        TEST_ASSERT( objStats.m_NumBuilt == 0 );
+    }
+
+    // Check that extra file was restored from cache.
+    TEST_ASSERT( FileIO::FileExists( extraFilePath ) );
+}
+
+// ExtraFiles_NativeCodeAnalysisXML
+//------------------------------------------------------------------------------
+void TestCache::ExtraFiles_NativeCodeAnalysisXML() const
+{
+    ExtraFiles( "Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_NativeCodeAnalysisXML/fbuild.bff", "../tmp/Test/Cache/ExtraFiles_NativeCodeAnalysisXML/file.nativecodeanalysis.xml" );
+}
+
+// ExtraFiles_GCNO
+//------------------------------------------------------------------------------
+void TestCache::ExtraFiles_GCNO() const
+{
+    ExtraFiles( "Tools/FBuild/FBuildTest/Data/TestCache/ExtraFiles_GCNO/fbuild.bff", "../tmp/Test/Cache/ExtraFiles_GCNO/file.gcno" );
 }
 
 // CheckForDependencies


### PR DESCRIPTION
# Description:

GCC's instrumentation for code coverage (also known as gcov coverage) relies on `.gcno` files generated alongside `.o` files during compilation.
Previously FASTBuild didn't store these files in the cache, this effectively made caching unusable for such build configurations as object files retrieved from cache would miss corresponding `.gcno` file (or that file could be stale, which probably is even worse).

To solve this problem we now store `.gcno` files in the cache, similarly to `.nativecodeanalysis.xml` files that are produced by MSVC.

Also distribution is now disabled for object files that use options enabling generation of `.gcno` files. Distributed compilation in that case produces barely usable results:
1. `.gcno` files contain incorrect build root path (working directory on the worker, instead of the local working directory).
2. `.gcda` files (which are created at runtime by instrumented code) are created in wrong directories, namely in the directory where object files were stored on the worker.

While these issues are not critical (`.gcda` files can be moved manually to correct places, build root path stored in `.gcno` files can be overridden by `gcov` options) enabling distribution would also require bumping the version of distribution protocol, and it is not worth it for a barely usable results.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
    I have added a test that verifies that `.gcno` file is created when object file is retrieved from the cache.
    I have also added a similar test for `.nativecodeanalysis.xml` files, it probably duplicates some part of `PrecompiledHeaderCacheAnalyze_MSVC` test, but it was too easy to generalize such tests. I hope that is OK.
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation**
    Added a mention that distribution is disabled for GCC/Clang when code coverage options (`-ftest-coverage` or `--coverage`) are used.