### PR TITLE
Avoid dependency on glibc 2.34 when building against it

### DIFF
--- a/Code/Core/CoreTest/CoreTest.bff
+++ b/Code/Core/CoreTest/CoreTest.bff
@@ -69,6 +69,7 @@
             #endif
             #if __LINUX__
                 .LinkerOptions                  + ' -pthread -lrt'
+                                                + ' -Wl,--wrap=__libc_start_main'
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$BuildConfigName$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$BuildConfigName$' }

--- a/Code/Core/Env/glibc_compat.h
+++ b/Code/Core/Env/glibc_compat.h
@@ -8,8 +8,26 @@
 //------------------------------------------------------------------------------
 #undef _FORTIFY_SOURCE
 
-// Use older memcpy
+// Use older implementations of glibc functions
 //------------------------------------------------------------------------------
+__asm__( ".symver dlclose,dlclose@GLIBC_2.2.5" );
+__asm__( ".symver dlerror,dlerror@GLIBC_2.2.5" );
+__asm__( ".symver dlopen,dlopen@GLIBC_2.2.5" );
+__asm__( ".symver dlsym,dlsym@GLIBC_2.2.5" );
 __asm__( ".symver memcpy,memcpy@GLIBC_2.2.5" );
+__asm__( ".symver pthread_attr_setstacksize,pthread_attr_setstacksize@GLIBC_2.2.5" );
+__asm__( ".symver pthread_create,pthread_create@GLIBC_2.2.5" );
+__asm__( ".symver pthread_detach,pthread_detach@GLIBC_2.2.5" );
+__asm__( ".symver pthread_join,pthread_join@GLIBC_2.2.5" );
+__asm__( ".symver pthread_mutexattr_init,pthread_mutexattr_init@GLIBC_2.2.5" );
+__asm__( ".symver pthread_mutexattr_settype,pthread_mutexattr_settype@GLIBC_2.2.5" );
+__asm__( ".symver pthread_timedjoin_np,pthread_timedjoin_np@GLIBC_2.3.3" );
+__asm__( ".symver sem_destroy,sem_destroy@GLIBC_2.2.5" );
+__asm__( ".symver sem_init,sem_init@GLIBC_2.2.5" );
+__asm__( ".symver sem_post,sem_post@GLIBC_2.2.5" );
+__asm__( ".symver sem_timedwait,sem_timedwait@GLIBC_2.2.5" );
+__asm__( ".symver sem_wait,sem_wait@GLIBC_2.2.5" );
+__asm__( ".symver shm_open,shm_open@GLIBC_2.2.5" );
+__asm__( ".symver shm_unlink,shm_unlink@GLIBC_2.2.5" );
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Env/libc_start_main.cpp
+++ b/Code/Core/Env/libc_start_main.cpp
@@ -1,0 +1,85 @@
+// libc_start_main
+//
+// A workaround for changes in glibc 2.34 that made programs linked with it incompatible with older libc.so.
+//
+// In glibc 2.34 the way in which global initialization and destruction functions are called was changed:
+// https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=035c012e32c11e84d64905efaf55e74f704d3668
+//
+// Previously each executable contained functions __libc_csu_init and __libc_csu_fini that iterated
+// through all global initialization and destruction functions and the program entry point (_start)
+// passed their addresses to the main startup code (__libc_start_main) implemented in libc.so.
+//
+// In glibc 2.34 __libc_csu_init and __libc_csu_fini are removed, _start passes null pointers to __libc_start_main
+// and __libc_start_main finds and executes global initialization and destruction functions by itself.
+// As this new behavior of _start is incompatible with __libc_start_main present in old libc.so,
+// __libc_start_main got a new symbol version and now programs built with glibc 2.34 link to __libc_start_main@@GLIBC_2.34.
+//
+// To be able to continue to use any glibc to build executables that will run on older systems we undo all of that:
+// 1. We implement our own __libc_csu_init and __libc_csu_fini when building with glibc >= 2.34.
+// 2. We hook calls __libc_start_main by using --wrap= linker option.
+// 3. In our hook for __libc_start_main we call the real old __libc_start_main.
+// 4. If we are building with glibc >= 2.34 we pass addresses of our __libc_csu_* implementations to __libc_start_main.
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include <errno.h> // for __GLIBC__ and __GLIBC_MINOR__
+
+#if defined( __GLIBC__ )
+
+    #if ( __GLIBC__ * 1000 + __GLIBC_MINOR__ ) >= 2034
+
+        extern void (*__init_array_start[])( int, char **, char ** );
+        extern void (*__init_array_end[])( int, char **, char ** );
+        extern void (*__fini_array_start[])( void );
+        extern void (*__fini_array_end[])( void );
+
+        extern "C" void _init();
+        extern "C" void _fini();
+
+        // We are using same names as in glibc for those functions (and not making them static).
+        // That way we will get a "multiple definition" linker error if they will be somehow pulled from glibc.
+        extern "C" int __libc_csu_init( int argc, char ** argv, char ** envp )
+        {
+            _init();
+            for ( auto p = __init_array_start; p != __init_array_end; )
+                (*p++)( argc, argv, envp );
+            return 0;
+        }
+        extern "C" void __libc_csu_fini()
+        {
+            for ( auto p = __fini_array_end; p != __fini_array_start; )
+                (*--p)();
+            _fini();
+        }
+
+    #endif
+
+    extern "C" int __libc_start_main(
+        int (*main)( int, char **, char ** ),
+        int argc, char ** argv,
+        int (*init)( int, char **, char ** ),
+        void (*fini)( void ),
+        void (*rtld_fini)( void ),
+        void * stack_end );
+
+    __asm__( ".symver __libc_start_main,__libc_start_main@GLIBC_2.2.5" );
+
+    extern "C" int __wrap___libc_start_main(
+        int (*main)( int, char **, char ** ),
+        int argc, char ** argv,
+        int (*init)( int, char **, char ** ),
+        void (*fini)( void ),
+        void (*rtld_fini)( void ),
+        void * stack_end )
+    {
+        #if ( __GLIBC__ * 1000 + __GLIBC_MINOR__ ) >= 2034
+            init = __libc_csu_init;
+            fini = __libc_csu_fini;
+        #endif
+        return __libc_start_main( main, argc, argv, init, fini, rtld_fini, stack_end );
+    }
+
+#endif
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuild/FBuild.bff
+++ b/Code/Tools/FBuild/FBuild/FBuild.bff
@@ -69,7 +69,13 @@
                                             + ' /MANIFESTINPUT:%3'
             #endif
             #if __LINUX__
-                .LinkerOptions              + ' -pthread -ldl -lrt'
+                // In glibc 2.34 libpthread, libdl and librt were merged into libc.
+                // Unversioned symlinks for these shared libraries are no longer installed and instead dummy static libraries are provided.
+                // This means that now we can't link with these libraries in a usual way (-ldl, etc.), if we try we will instead link with dummy static libraries,
+                // and as a result our binary won't load on system with older glibc due to unresolved symbols.
+                // To ensure that we are linked to all needed libraries we now link directly to versioned shared library files.
+                .LinkerOptions              + ' -l:libpthread.so.0 -l:libdl.so.2 -l:librt.so.1'
+                                            + ' -Wl,--wrap=__libc_start_main'
 
                 .LinkerStampExe             = '/bin/bash'
                 .ExtractDebugInfo           = 'objcopy --only-keep-debug $LinkerOutput$ $LinkerOutput$.debug'

--- a/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
+++ b/Code/Tools/FBuild/FBuildTest/FBuildTest.bff
@@ -71,6 +71,7 @@
             #endif
             #if __LINUX__
                 .LinkerOptions              + ' -pthread -ldl -lrt'
+                                            + ' -Wl,--wrap=__libc_start_main'
             #endif
         }
         Alias( '$ProjectName$-$Platform$-$BuildConfigName$' ) { .Targets = '$ProjectName$-Exe-$Platform$-$BuildConfigName$' }

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorker.bff
@@ -112,7 +112,8 @@
                 .LinkerOptions              + ' -framework Cocoa'
             #endif
             #if __LINUX__
-                .LinkerOptions              + ' -pthread -ldl -lrt'
+                .LinkerOptions              + ' -l:libpthread.so.0 -l:libdl.so.2 -l:librt.so.1'
+                                            + ' -Wl,--wrap=__libc_start_main'
 
                 .LinkerStampExe             = '/bin/bash'
                 .ExtractDebugInfo           = 'objcopy --only-keep-debug $LinkerOutput$ $LinkerOutput$.debug'


### PR DESCRIPTION
# Description:

This PR continues to proactively fix issues that prevent building FASTBuild with new glibc versions and have it run on system with older glibc installed. Previous such PR is #854 

Glibc 2.34 broke forward compatibility again in two entirely new ways.

The first issue is that in glibc 2.34 the way in which global initialization and destruction functions are called was changed:
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=035c012e32c11e84d64905efaf55e74f704d3668

Previously each executable contained functions `__libc_csu_init` and `__libc_csu_fini` that iterated through all global initialization and destruction functions and the program entry point (`_start`) passed their addresses to the main startup code (`__libc_start_main`) implemented in `libc.so`.

In glibc 2.34 `__libc_csu_init` and `__libc_csu_fini` are removed, `_start` passes null pointers to `__libc_start_main` and `__libc_start_main` finds and executes global initialization and destruction functions by itself.
As this new behavior of `_start` is incompatible with `__libc_start_main` present in old `libc.so`, `__libc_start_main` got a new symbol version and now programs built with glibc 2.34 link to `__libc_start_main@@GLIBC_2.34`.

To be able to continue to use any glibc to build executables that will run on older systems we undo all of that:
1. We implement our own `__libc_csu_init` and `__libc_csu_fini` when building with glibc >= 2.34.
2. We hook calls `__libc_start_main` by using `--wrap=` linker option.
3. In our hook for `__libc_start_main` we call the real old `__libc_start_main`.
4. If we are building with glibc >= 2.34 we pass addresses of our `__libc_csu_`* implementations to `__libc_start_main`.

The second issue is that in glibc 2.34 libpthread, libdl and librt were merged into libc. Unversioned symlinks for these shared libraries are no longer installed and instead dummy static libraries are provided.
This means that now we can't link with these libraries in a usual way (`-ldl`, etc.), if we try we will instead link with dummy static
libraries, and as a result our binary won't load on system with older glibc due to unresolved symbols.

To ensure that we are linked to all needed libraries we now link directly to versioned shared library files.

Also many functions got new symbol versions, so we add corresponding `__asm__(".symver")` lines to `glibc_compat.h`.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** Discussion about tests is here: https://github.com/fastbuild/fastbuild/pull/854#issuecomment-991695813
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** N/A
