### PR TITLE
Add RemoveExcludeFiles in RemoveDir function

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/removedir.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/removedir.html
@@ -41,6 +41,7 @@ Deletes the contents of one or more directories.
   // Filtering options
   .RemovePatterns           // (optional) Wildcards of contents to delete (default: *)
   .RemoveExcludePaths       // (optional) Directories to ignore if recursing
+  .RemoveExcludeFiles       // (optional) Files to ignore if recursing
   
   // Additional options
   .PreBuildDependencies     // (optional) Force targets to be built before this RemoveDir
@@ -54,8 +55,8 @@ Deletes the contents of one or more directories.
     <div class='newsitembody'>
       <p>
 RemoveDir() can be used to delete the contents of a directory. By default, the sub-directories are
-recursed and all files are deleted.  Recursion can be disabled (.PathsRecurse), individual sub-directories
-can be ignored (.ExcludePaths) and files to be deleted can be filtered (.PathsPattern).
+recursed and all files are deleted.  Recursion can be disabled (.PathsRecurse), individual sub-directories or files
+can be ignored (.ExcludePaths and .ExcludeFiles) and files to be deleted can be filtered (.PathsPattern).
       </p>
     </div>
 
@@ -103,6 +104,16 @@ can be ignored (.ExcludePaths) and files to be deleted can be filtered (.PathsPa
   Example:
 <div class='code'>.RemoveExcludePaths = { 'folderA/',  // Ignore contents of "folderA"
                         'FolderB/' } // and "folderB"</div>
+ 
+  <p><hr></p>
+
+  <b>.RemoveExcludeFiles</b> - String/ArrayOfStrings - (Optional)</p>
+  <p>Specific files can be ignored during recursion.</p>
+  Example:
+<div class='code'>.RemoveExcludeFiles = 'file.txt' // Ignore file.txt</div>
+  Example:
+<div class='code'>.RemoveExcludeFiles = { 'fileA.txt',  // Ignore "fileA.txt"
+                        'fileB.txt' } // and "fileB.txt"</div>
 </div>
 	
 <!-- 

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
@@ -21,6 +21,7 @@ REFLECT_NODE_BEGIN( RemoveDirNode, Node, MetaNone() )
     REFLECT_ARRAY( m_RemovePatterns,            "RemovePatterns",       MetaOptional() )
     REFLECT(       m_RemovePathsRecurse,        "RemovePathsRecurse",   MetaOptional() )
     REFLECT_ARRAY( m_RemoveExcludePaths,        "RemoveExcludePaths",   MetaOptional() + MetaPath() )
+    REFLECT_ARRAY( m_RemoveExcludeFiles,        "RemoveExcludeFiles",   MetaOptional() + MetaFile() )
     REFLECT_ARRAY( m_PreBuildDependencyNames,   "PreBuildDependencies", MetaOptional() + MetaFile() + MetaAllowNonFile() )
 REFLECT_END( RemoveDirNode )
 
@@ -50,7 +51,7 @@ RemoveDirNode::RemoveDirNode()
                                               function,
                                               m_RemovePaths,
                                               m_RemoveExcludePaths,
-                                              Array< AString >(), // unused FilesToExclude
+                                              m_RemoveExcludeFiles, // unused FilesToExclude
                                               Array< AString >(), // unused ExcludePatterns
                                               m_RemovePathsRecurse,
                                               false, // Don't include read-only status in hash

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
@@ -30,6 +30,7 @@ private:
     bool                m_RemovePathsRecurse;
     Array< AString >    m_RemovePatterns;
     Array< AString >    m_RemoveExcludePaths;
+    Array< AString >    m_RemoveExcludeFiles;
     Array< AString >    m_PreBuildDependencyNames;
 };
 


### PR DESCRIPTION
# Description:

Ignore some files don't want to or can't be deleted ( e.g. BuildLog file can't be deleted while running clean command in vs ).

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation**
