### PR TITLE
Fix empty array type mismatch bug

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
@@ -371,7 +371,7 @@ BFFVariable * BFFVariable::ConcatVarsRecurse( const AString & dstName, const BFF
             values.Append( varDst->GetArrayOfStructs() );
             values.Append( varSrc->GetArrayOfStructs() );
 
-            BFFVariable *result = FNEW(BFFVariable(dstName, values));
+            BFFVariable *result = FNEW(BFFVariable(dstName, values, VAR_ARRAY_OF_STRUCTS ));
             return result;
         }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/BFFVariable.cpp
@@ -271,31 +271,62 @@ BFFVariable * BFFVariable::ConcatVarsRecurse( const AString & dstName, const BFF
     {
         // Mismatched - is there a supported conversion?
 
-        // String to ArrayOfStrings
-        if ( ( dstType == BFFVariable::VAR_ARRAY_OF_STRINGS ) &&
-             ( srcType == BFFVariable::VAR_STRING) )
-        {
-            const uint32_t num = (uint32_t)( 1 + varDst->GetArrayOfStrings().GetSize() );
-            StackArray<AString> values;
-            values.SetCapacity( num );
-            values.Append( varDst->GetArrayOfStrings() );
-            values.Append( varSrc->GetString() );
+        const bool dstIsEmpty = ( varDst == nullptr ) ||
+            ( dstType == BFFVariable::VAR_ARRAY_OF_STRINGS && varDst->GetArrayOfStrings().IsEmpty() ) ||
+            ( dstType == BFFVariable::VAR_ARRAY_OF_STRUCTS && varDst->GetArrayOfStructs().IsEmpty() );
+        const bool srcIsEmpty =
+            ( srcType == BFFVariable::VAR_ARRAY_OF_STRINGS && varSrc->GetArrayOfStrings().IsEmpty() ) ||
+            ( srcType == BFFVariable::VAR_ARRAY_OF_STRUCTS && varSrc->GetArrayOfStructs().IsEmpty() );
 
+        // String to ArrayOfStrings or empty array
+        if ( ( dstType == BFFVariable::VAR_ARRAY_OF_STRINGS || dstIsEmpty ) &&
+             ( srcType == BFFVariable::VAR_STRING ) )
+        {
+            StackArray<AString> values;
+            values.SetCapacity( varDst->GetArrayOfStrings().GetSize() + 1 );
+            if ( !dstIsEmpty )
+            {
+                values.Append( varDst->GetArrayOfStrings() );
+            }
+            values.Append( varSrc->GetString() );
             BFFVariable *result = FNEW(BFFVariable(dstName, values));
             return result;
         }
-
-        // Struct to ArrayOfStructs
-        if ( ( dstType == BFFVariable::VAR_ARRAY_OF_STRUCTS ) &&
+        // Struct to ArrayOfStructs or empty array concatenation
+        if ( ( dstType == BFFVariable::VAR_ARRAY_OF_STRUCTS || dstIsEmpty ) &&
              ( srcType == BFFVariable::VAR_STRUCT ) )
         {
-            const uint32_t num = (uint32_t)( 1 + varDst->GetArrayOfStructs().GetSize() );
+            const uint32_t num = (uint32_t)( 1 + ( ( !dstIsEmpty ) ? varDst->GetArrayOfStructs().GetSize() : 0 ) );
             StackArray<const BFFVariable *> values;
             values.SetCapacity( num );
-            values.Append( varDst->GetArrayOfStructs() );
+            if ( !dstIsEmpty )
+            {
+                values.Append( varDst->GetArrayOfStructs() );
+            }
             values.Append( varSrc );
 
-            BFFVariable *result = FNEW( BFFVariable( dstName, values ) );
+            BFFVariable *result = FNEW( BFFVariable( dstName, values, VAR_ARRAY_OF_STRUCTS ) );
+            return result;
+        }
+
+        // Empty array to Array of any type or visc-versa
+        if ( ( ( dstType == BFFVariable::VAR_ARRAY_OF_STRUCTS || dstType == BFFVariable::VAR_ARRAY_OF_STRINGS ) && srcIsEmpty ) ||
+            ( ( srcType == BFFVariable::VAR_ARRAY_OF_STRUCTS || srcType == BFFVariable::VAR_ARRAY_OF_STRINGS ) && dstIsEmpty ) )
+        {
+            const BFFVariable * src;
+            if (srcIsEmpty) {
+                src = varDst;
+            }
+            else {
+                src = varSrc;
+            }
+            BFFVariable * result = FNEW(BFFVariable(dstName, src->m_Type));
+            if (src->m_Type == BFFVariable::VAR_ARRAY_OF_STRINGS) {
+                result->SetValueArrayOfStrings(src->GetArrayOfStrings());
+            }
+            else {
+                result->SetValueArrayOfStructs(src->GetArrayOfStructs());
+            }
             return result;
         }
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/struct_concatenation.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/struct_concatenation.bff
@@ -89,6 +89,13 @@ Print( "---- ArrayOfStructs Recursion" )
     .StructC    = .StructA
                 + .StructB
     Print( .StructC )
+    {
+        Using(.StructC)
+        ForEach(.S in .ArrayOfStructs)
+        {
+            // Check that we actually made an array
+        }
+    }
 }
 
 // Left contains empty arrays

--- a/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/struct_concatenation.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestBFFParsing/struct_concatenation.bff
@@ -90,3 +90,61 @@ Print( "---- ArrayOfStructs Recursion" )
                 + .StructB
     Print( .StructC )
 }
+
+// Left contains empty arrays
+//--------------------------------------------------------------------
+Print( "---- Left contains empty arrays" )
+{
+    .Struct1 = [ .String = '1' ]
+    .StructA = [
+        .EmptyA = {}
+        .EmptyB = {}
+        .EmptyC = {}
+        .EmptyD = {}
+    ]
+    .StructB = [
+        .EmptyA = { 'C' }
+        .EmptyB = 'C'
+        .EmptyC = { .Struct1 }
+        .EmptyD = .Struct1
+    ]
+    .StructA + .StructB
+    Print(.StructA)
+    {
+        Using(.StructA)
+        ForEach(.StructA in .EmptyA,
+                .StructB in .EmptyB,
+                .StructC in .EmptyC,
+                .StructD in .EmptyD,
+        )
+        {
+            // Check that we actually made arrays
+        }
+    }
+}
+
+// Right contains empty arrays
+//--------------------------------------------------------------------
+Print( "---- Right contains empty arrays" )
+{
+    .Struct1 = [ .String = '1' ]
+    .StructA = [
+        .EmptyA = { 'C' }
+        .EmptyB = { .Struct1 }
+    ]
+    .StructB = [
+        .EmptyA = {}
+        .EmptyB = {}
+    ]
+    .StructA + .StructB
+    Print(.StructA)
+    {
+        Using(.StructA)
+        ForEach(.StructA in .EmptyA,
+                .StructB in .EmptyB,
+        )
+        {
+            // Check that we actually made arrays
+        }
+    }
+}


### PR DESCRIPTION
# Description:
This PR fixes issue #904
Prior to this PR when recursively concatenating structs,  concatenating to empty arrays contained within a struct would improperly fail due to a type mismatch for the concatenation operation. This PR fixes this issue and adds a pair of test cases to check for.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
