### PR TITLE
Fix NodeGraph::CleanPath() for paths ending with \. or /.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -1541,7 +1541,7 @@ bool NodeGraph::CheckDependencies( Node * nodeToBuild, const Dependencies & depe
             {
                 // check for \.\ (or \./)
                 char nextChar = *( src + 1 );
-                if ( ( nextChar == NATIVE_SLASH ) || ( nextChar == OTHER_SLASH ) )
+                if ( ( nextChar == NATIVE_SLASH ) || ( nextChar == OTHER_SLASH ) || ( nextChar == '\0' ) )
                 {
                     src++; // skip . and slashes
                     while ( ( *src == NATIVE_SLASH ) || ( *src == OTHER_SLASH ) )

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -410,22 +410,30 @@ void TestGraph::TestCleanPath() const
     CHECK( "..\\file.dat",          "C:\\Windows\\file.dat",            "/tmp/file.dat" )
     CHECK( "..\\..\\file.dat",      "C:\\file.dat",                     "/file.dat" )
     CHECK( "..\\..\\..\\file.dat",  "C:\\file.dat",                     "/file.dat" )
+    CHECK( "folder\\..\\",          "C:\\Windows\\System32\\",          "/tmp/subDir/" )
+    CHECK( "folder\\..",            "C:\\Windows\\System32\\",          "/tmp/subDir/" )
 
     //   "/../"
     CHECK( "file.dat",              "C:\\Windows\\System32\\file.dat",  "/tmp/subDir/file.dat" )
     CHECK( "../file.dat",           "C:\\Windows\\file.dat",            "/tmp/file.dat" )
     CHECK( "../../file.dat",        "C:\\file.dat",                     "/file.dat" )
     CHECK( "../../../file.dat",     "C:\\file.dat",                     "/file.dat" )
+    CHECK( "folder/../",            "C:\\Windows\\System32\\",          "/tmp/subDir/" )
+    CHECK( "folder/..",             "C:\\Windows\\System32\\",          "/tmp/subDir/" )
 
     //   "\.\"
     CHECK( ".\\file.dat",           "C:\\Windows\\System32\\file.dat",          "/tmp/subDir/file.dat" )
     CHECK( "folder\\.\\file.dat",   "C:\\Windows\\System32\\folder\\file.dat",  "/tmp/subDir/folder/file.dat" )
     CHECK( ".\\.\\.\\file.dat",     "C:\\Windows\\System32\\file.dat",          "/tmp/subDir/file.dat" )
+    CHECK( "folder\\.\\",           "C:\\Windows\\System32\\folder\\",          "/tmp/subDir/folder/" )
+    CHECK( "folder\\.",             "C:\\Windows\\System32\\folder\\",          "/tmp/subDir/folder/" )
 
     //   "/./"
     CHECK( "./file.dat",            "C:\\Windows\\System32\\file.dat",          "/tmp/subDir/file.dat" )
     CHECK( "folder/./file.dat",     "C:\\Windows\\System32\\folder\\file.dat",  "/tmp/subDir/folder/file.dat" )
     CHECK( "./././file.dat",        "C:\\Windows\\System32\\file.dat",          "/tmp/subDir/file.dat" )
+    CHECK( "folder/./",             "C:\\Windows\\System32\\folder\\",          "/tmp/subDir/folder/" )
+    CHECK( "folder/.",              "C:\\Windows\\System32\\folder\\",          "/tmp/subDir/folder/" )
 
     //   full path '\'
     #if defined( __WINDOWS__ )


### PR DESCRIPTION
# Description:

Previously, in paths ending with `\.` or `/.` the trailing dot was not removed. This made setting properties to the working directory unintuitive.

For example setting `.ProjectBasePath` to `'.'` didn't work, strings in `VSProjectGenerator::m_BasePaths` had a dot at the end, `BeginsWithI()` check against absolute paths to project files never succeeded and all files were dumped into the project without directory structure. Of course setting `.ProjectBasePath` to `'./'` did work, but that is not very intuitive. At least I had to dig through the sources to find that workaround.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation** N/A
