### PR TITLE
Fix install path for VS2022

### DIFF
--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -40,7 +40,7 @@
             //
             #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe" )
                 // v17.1.4
-                .VS2022_BasePath        = 'C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC'
+                .VS2022_BasePath        = 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC'
                 .VS2022_Version         = '14.34.31933'
                 .VS2022_MSC_VER         = '1931'
             #else


### PR DESCRIPTION
# Description:
Simple fix to correct the install path of VS2022.

Please provide details for the change or fix:
The existing code was checking one path `C:/Program Files/Microsoft Visual Studio`, but attempting to use a different path (`C:/Program Files (x86)/Microsoft Visual Studio`).

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**
