### PR TITLE
Add support for non-recursive input paths in VCXProject and XCodeProject

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/vcxproject.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/vcxproject.html
@@ -39,6 +39,7 @@ Generates a project file for use with Visual Studio, allowing integration of FAS
   // Input Options
   .ProjectInputPaths              // (optional) Paths to include in project
   .ProjectInputPathsExclude       // (optional) Paths to exclude from project
+  .ProjectInputPathsRecurse       // (optional) Recurse into project input paths when finding files (default true)
   .ProjectPatternToExclude        // (optional) Pattern(s) for files to exclude from project
   .ProjectAllowedFileExtensions   // (optional) Extensions to allow in path searches
   .ProjectFiles                   // (optional) List of files to include in project
@@ -189,6 +190,13 @@ Generates a project file for use with Visual Studio, allowing integration of FAS
                               }</div>
       <hr>    
 
+      <p><b>.ProjectInputPathsRecurse</b> - bool - (Optional)</p>
+      <p>Toggles whether to recurse into subdirectories of .ProjectInputPaths
+      when finding files to add to the project.
+      </p>
+      Example:
+<div class='code'>.ProjectInputPathsRecurse   = false</div>
+      <hr>
       
       <p><b>.ProjectPatternToExclude</b> - String or ArrayOfStrings - (Optional)</p>
       <p>Pattern(s) for files to exclude from project.</p>

--- a/Code/Tools/FBuild/Documentation/docs/functions/xcodeproject.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/xcodeproject.html
@@ -40,6 +40,7 @@
   // Input Options
   .ProjectInputPaths             // (optional) Path(s) containing files to include in project 
   .ProjectInputPathsExclude      // (optional) Path(s) to exclude from project
+  .ProjectInputPathsRecurse      // (optional) Recurse into project input paths when finding files (default true)
   .ProjectPatternToExclude       // (optional) Pattern(s) for files to exclude from project
   .ProjectFiles                  // (optional) File(s) to include in project
   .ProjectFilesToExclude         // (optional) File(s) to exclude from project
@@ -137,6 +138,14 @@
                             }</div>
       <hr>
       
+      <p><b>.ProjectInputPathsRecurse</b> - bool - (Optional)</p>
+      <p>Toggles whether to recurse into subdirectories of .ProjectInputPaths
+      when finding files to add to the project.
+      </p>
+      Example:
+<div class='code'>.ProjectInputPathsRecurse   = false</div>
+      <hr>
+
       <p><b>.ProjectPatternToExclude</b> - String or ArrayOfStrings - (Optional)</p>
       <p>One or more patterns can be specified to ignore during directory traversal.
       </p>

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -63,7 +63,7 @@ public:
     }
     inline ~NodeGraphHeader() = default;
 
-    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 167 };
+    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 168 };
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == NODE_GRAPH_CURRENT_VERSION; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.cpp
@@ -90,6 +90,7 @@ REFLECT_END( VSProjectImport )
 REFLECT_NODE_BEGIN( VCXProjectNode, VSProjectBaseNode, MetaName( "ProjectOutput" ) + MetaFile() )
     REFLECT_ARRAY(  m_ProjectInputPaths,            "ProjectInputPaths",            MetaOptional() + MetaPath() )
     REFLECT_ARRAY(  m_ProjectInputPathsExclude,     "ProjectInputPathsExclude",     MetaOptional() + MetaPath() )
+    REFLECT(        m_ProjectInputPathsRecurse,     "ProjectInputPathsRecurse",     MetaOptional() )
     REFLECT_ARRAY(  m_ProjectFiles,                 "ProjectFiles",                 MetaOptional() + MetaFile() )
     REFLECT_ARRAY(  m_ProjectFilesToExclude,        "ProjectFilesToExclude",        MetaOptional() + MetaFile() )
     REFLECT_ARRAY(  m_ProjectPatternToExclude,      "ProjectPatternToExclude",      MetaOptional() + MetaFile() )
@@ -184,7 +185,7 @@ VCXProjectNode::VCXProjectNode()
                                               m_ProjectInputPathsExclude,
                                               m_ProjectFilesToExclude,
                                               m_ProjectPatternToExclude,
-                                              true, // Recursive
+                                              m_ProjectInputPathsRecurse, // Recursive
                                               false, // Don't include read-only status in hash
                                               &m_ProjectAllowedFileExtensions,
                                               "ProjectInputPaths",

--- a/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/VCXProjectNode.h
@@ -129,6 +129,7 @@ private:
     // Exposed
     Array< AString >    m_ProjectInputPaths;
     Array< AString >    m_ProjectInputPathsExclude;
+    bool                m_ProjectInputPathsRecurse = true;
     Array< AString >    m_ProjectFiles;
     Array< AString >    m_ProjectFilesToExclude;
     Array< AString >    m_ProjectPatternToExclude;

--- a/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
@@ -32,6 +32,7 @@ REFLECT_END( XCodeProjectConfig )
 REFLECT_NODE_BEGIN( XCodeProjectNode, Node, MetaName( "ProjectOutput" ) + MetaFile() )
     REFLECT_ARRAY( m_ProjectInputPaths,             "ProjectInputPaths",            MetaOptional() + MetaPath() )
     REFLECT_ARRAY( m_ProjectInputPathsExclude,      "ProjectInputPathsExclude",     MetaOptional() + MetaPath() )
+    REFLECT(       m_ProjectInputPathsRecurse,      "ProjectInputPathsRecurse",     MetaOptional() )
     REFLECT_ARRAY( m_ProjectFiles,                  "ProjectFiles",                 MetaOptional() + MetaFile() )
     REFLECT_ARRAY( m_ProjectFilesToExclude,         "ProjectFilesToExclude",        MetaOptional() + MetaFile() )
     REFLECT_ARRAY( m_PatternToExclude,              "ProjectPatternToExclude",      MetaOptional() + MetaFile())
@@ -114,7 +115,7 @@ XCodeProjectNode::XCodeProjectNode()
                                               m_ProjectInputPathsExclude,
                                               m_ProjectFilesToExclude,
                                               m_PatternToExclude,
-                                              true, // Resursive
+                                              m_ProjectInputPathsRecurse, // Resursive
                                               false, // Don't include read-only status in hash
                                               &m_ProjectAllowedFileExtensions,
                                               "ProjectInputPaths",

--- a/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.h
@@ -52,6 +52,7 @@ private:
 
     Array< AString >    m_ProjectInputPaths;
     Array< AString >    m_ProjectInputPathsExclude;
+    bool                m_ProjectInputPathsRecurse = true;
     Array< AString >    m_ProjectFiles;
     Array< AString >    m_ProjectFilesToExclude;
     Array< AString >    m_PatternToExclude;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/fbuild.bff
@@ -1,0 +1,24 @@
+
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+VCXProject( 'Default' )
+{
+    .ProjectOutput              = '$Out$/Test/ProjectGeneration/VCXProj_InputPaths/Default.vcxproj'
+
+    .ProjectInputPaths          = '$_CURRENT_BFF_DIR_$/source'
+}
+
+VCXProject( 'NoRecurse' )
+{
+    .ProjectOutput              = '$Out$/Test/ProjectGeneration/VCXProj_InputPaths/NoRecurse.vcxproj'
+
+    .ProjectInputPaths          = '$_CURRENT_BFF_DIR_$/source'
+    .ProjectInputPathsRecurse   = false
+}
+
+Alias( 'All' )
+{
+    .Targets                    = { 'Default', 'NoRecurse' }
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/source/root_item.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/source/root_item.cpp
@@ -1,0 +1,1 @@
+\\ Dummy file

--- a/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/source/subdir/subdir_item.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/source/subdir/subdir_item.cpp
@@ -1,0 +1,1 @@
+\\ Dummy file

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestProjectGeneration.cpp
@@ -7,6 +7,7 @@
 
 // FBuildCore
 #include "Tools/FBuild/FBuildCore/FBuild.h"
+#include "Tools/FBuild/FBuildCore/Graph/DirectoryListNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
 #include "Tools/FBuild/FBuildCore/Graph/VCXProjectNode.h"
 #include "Tools/FBuild/FBuildCore/Helpers/ProjectGeneratorBase.h"
@@ -42,6 +43,7 @@ private:
     void VCXProj_Folders() const;
     void VCXProj_ProjectRelativePaths() const;
     void VCXProj_ProjectRelativePaths2() const;
+    void VCXProj_InputPaths() const;
 
     // Solution
     void Solution_Empty() const;
@@ -81,6 +83,7 @@ REGISTER_TESTS_BEGIN( TestProjectGeneration )
     REGISTER_TEST( VCXProj_Folders )
     REGISTER_TEST( VCXProj_ProjectRelativePaths )
     REGISTER_TEST( VCXProj_ProjectRelativePaths2 )
+    REGISTER_TEST( VCXProj_InputPaths )
     REGISTER_TEST( Solution_Empty )
     REGISTER_TEST( Solution_SolutionRelativePaths )
     REGISTER_TEST( Solution_BuildAndDeploy_None )
@@ -1088,6 +1091,59 @@ void TestProjectGeneration::VCXProj_ProjectRelativePaths2() const
         TEST_ASSERT( filter.Replace( "<Filter Include=\"Generated\">", "" ) == 1 );
         TEST_ASSERT( filter.Replace( "<Filter Include=\"Generated\\SubDir\">", "" ) == 1 );
         TEST_ASSERT( filter.Find( "<Filter Include=" ) == nullptr );
+    }
+}
+
+// VCXProj_InputPaths
+//------------------------------------------------------------------------------
+void TestProjectGeneration::VCXProj_InputPaths() const
+{
+    // Initialize
+    FBuildTestOptions options;
+    options.m_ConfigFile = "Tools/FBuild/FBuildTest/Data/TestProjectGeneration/VCXProj_InputPaths/fbuild.bff";
+    FBuildForTest fBuild(options);
+    TEST_ASSERT(fBuild.Initialize());
+
+    // Delete files from previous builds
+    EnsureFileDoesNotExist("../tmp/Test/ProjectGeneration/VCXProj_InputPaths/Default.vcxproj");
+    EnsureFileDoesNotExist("../tmp/Test/ProjectGeneration/VCXProj_InputPaths/NoRecurse.vcxproj");
+
+    // Do build
+    TEST_ASSERT(fBuild.Build("All"));
+
+    // Find VCXProject nodes
+    Array< const Node* > nodes;
+    fBuild.GetNodesOfType(Node::VCXPROJECT_NODE, nodes);
+    TEST_ASSERT( nodes.GetSize() == 2 );
+
+    for ( const Node * projNode : nodes )
+    {
+        const Dependencies & deps = projNode->GetStaticDependencies();
+        TEST_ASSERT( deps.GetSize() == 1 );
+        TEST_ASSERT( deps[0].GetNode()->GetType() == Node::Type::DIRECTORY_LIST_NODE );
+        const DirectoryListNode * dirNode = deps[0].GetNode()->CastTo<DirectoryListNode>();
+        bool rootItemFound = false;
+        bool subdirItemFound = false;
+        for ( const FileIO::FileInfo & info : dirNode->GetFiles() )
+        {
+            rootItemFound |= info.m_Name.EndsWith("root_item.cpp");
+            subdirItemFound |= info.m_Name.EndsWith("subdir_item.cpp");
+        }
+
+        if ( projNode->GetName().EndsWith("Default.vcxproj") )
+        {
+            TEST_ASSERT( dirNode->GetFiles().GetSize() == 2 );
+            TEST_ASSERT( rootItemFound && subdirItemFound );
+        }
+        else if ( projNode->GetName().EndsWith("NoRecurse.vcxproj") )
+        {
+            TEST_ASSERT( dirNode->GetFiles().GetSize() == 1 );
+            TEST_ASSERT( rootItemFound && !subdirItemFound );
+        }
+        else
+        {
+            TEST_ASSERTM( false, "Unknown project found" );
+        }
     }
 }
 


### PR DESCRIPTION
# Description:
This PR implements support for non-recursive .ProjectInputPaths in VCXProject and XCodeProject. The user can opt into this behavior by setting the new .ProjectInputPathsRecurse property to false.

Please provide details for the change or fix:
Motivations for this change are presented and assessed in #948.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux** ; I have only had opportunity to test Windows MSVC/ Clang
- [X] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [X] **Includes documentation**
