### PR TITLE
Treat STATUS_CONTROL_C_EXIT as a system error

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2406,6 +2406,7 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
     #if defined( __WINDOWS__ )
         // If remote PC is shutdown by user, compiler can be terminated
         if ( ( (uint32_t)result == 0x40010004 ) || // DBG_TERMINATE_PROCESS
+             ( (uint32_t)result == 0xC000013A ) || // STATUS_CONTROL_C_EXIT - Occurs if remote user forcibly ended the process
              ( (uint32_t)result == 0xC0000142 ) )  // STATUS_DLL_INIT_FAILED - Occurs if remote PC is stuck on force reboot dialog during shutdown
         {
             job->OnSystemError(); // task will be retried on another worker


### PR DESCRIPTION
# Description:

Please provide details for the change or fix:
 - When a remote Windows user closes their session, the FB worker can be killed in many ways, and sometimes the application exits with `STATUS_CONTROL_C_EXIT`. We treat this similarly to `DBG_TERMINATE_PROCESS`.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
