### PR TITLE
Add -dbfile <path> option to set dependency database file explicitly

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/options.html
+++ b/Code/Tools/FBuild/Documentation/docs/options.html
@@ -64,12 +64,16 @@
     <td>Generate JSON compilation database for the specified targets.</td>
   </tr>
   <tr>
-    <td><a href="#config">-config [path]</a></td>
+    <td><a href="#config">-config &lt;path&gt;</a></td>
     <td>Explicitly specify the config file to use.</td>
   </tr>
   <tr>
     <td><a href="#continueafterdbmove">-continueafterdbmove</a></td>
     <td>Allow build to continue after a DB move.</td>
+  </tr>
+  <tr>
+    <td><a href="#dbfile">-dbfile &lt;path&gt;</a></td>
+    <td>Explicitly specify the dependency database file to use.</td>
   </tr>
   <tr>
     <td><a href="#debug_fbuild">-debug</a></td>
@@ -327,20 +331,26 @@ information and performance metrics. This can be used to assist troubleshooting.
 <p>Instead of building specified targets generate a <a href="https://clang.llvm.org/docs/JSONCompilationDatabase.html">JSON compilation database</a> for them. Resulting compilation database will include entries for all source files from ObjectList and Library nodes that are dependencies of the specified targets.</p>
 </div>
 
-    <div class='newsitemheader' id="config">-config [path]</div>
+    <div class='newsitemheader' id="config">-config &lt;path&gt;</div>
     <div class='newsitembody'>
 <p>Explicitly specify the config file to use.  By default, FASTBuild looks for "fbuild.bff" in the current directory.  This options allows a file to be explicitly
 specified instead.</p>
 </div>
 
-    <div class='newsitemheader' id="continueafterdbmove">--continueafterdbmove</div>
+    <div class='newsitemheader' id="continueafterdbmove">-continueafterdbmove</div>
     <div class='newsitembody'>
 <p>Allow build to continue after a DB move.</p>
 <p>FASTBuild's database is tied to the directory in which it was created and cannot be moved. If a move is detected, an error will be emitted. -continueafterdbmove allows the build
 to continue after this error has been emitted, ignoring and replacing the DB file.</p>
 </div>
 
-    <div class='newsitemheader' id="debug_fbuild">-debug</div>
+    <div class='newsitemheader' id="dbfile">-dbfile &lt;path&gt;</div>
+    <div class='newsitembody'>
+<p>Explicitly specify the dependency database file to use. By default, FASTBuild will load and save its dependency database in the same directory as the config file
+(with a ".platform.fdb" suffix). This option allows the file to be explicitly specified instead.</p>
+</div>
+
+<div class='newsitemheader' id="debug_fbuild">-debug</div>
     <div class='newsitembody'>
 <p>[Windows Only] Display a message box on startup to allow a debugger to be attached. Can be useful if triaging problems with FASTBuild that can't
 be reproduced in the debugger.</p>

--- a/Code/Tools/FBuild/FBuildCore/FBuild.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuild.cpp
@@ -154,18 +154,26 @@ bool FBuild::Initialize( const char * nodeGraphDBFile )
     }
     else
     {
-        m_DependencyGraphFile = bffFile;
-        if ( m_DependencyGraphFile.EndsWithI( ".bff" ) )
+        if ( m_Options.m_DBFile.IsEmpty() )
         {
-            m_DependencyGraphFile.SetLength( m_DependencyGraphFile.GetLength() - 4 );
+            m_DependencyGraphFile = bffFile;
+            if ( m_DependencyGraphFile.EndsWithI( ".bff" ) )
+            {
+                m_DependencyGraphFile.SetLength( m_DependencyGraphFile.GetLength() - 4 );
+            }
+            #if defined( __WINDOWS__ )
+                m_DependencyGraphFile += ".windows.fdb";
+            #elif defined( __OSX__ )
+                m_DependencyGraphFile += ".osx.fdb";
+            #elif defined( __LINUX__ )
+                m_DependencyGraphFile += ".linux.fdb";
+            #endif
         }
-        #if defined( __WINDOWS__ )
-            m_DependencyGraphFile += ".windows.fdb";
-        #elif defined( __OSX__ )
-            m_DependencyGraphFile += ".osx.fdb";
-        #elif defined( __LINUX__ )
-            m_DependencyGraphFile += ".linux.fdb";
-        #endif
+        else
+        {
+            // DB filename explicitly set on command line
+            m_DependencyGraphFile = m_Options.m_DBFile;
+        }
     }
 
     SmallBlockAllocator::SetSingleThreadedMode( true );

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -222,6 +222,25 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
                 m_Args += '"';
                 continue;
             }
+            else if ( thisArg == "-dbfile" )
+            {
+                const int32_t pathIndex = ( i + 1 );
+                if ( pathIndex >= argc )
+                {
+                    OUTPUT( "FBuild: Error: Missing <path> for '-dbfile' argument\n" );
+                    OUTPUT( "Try \"%s -help\"\n", programName.Get() );
+                    return OPTIONS_ERROR;
+                }
+                m_DBFile = argv[ pathIndex ];
+                i++; // skip extra arg we've consumed
+
+                // add to args we might pass to subprocess
+                m_Args += ' ';
+                m_Args += '"'; // surround db file with quotes to avoid problems with spaces in the path
+                m_Args += m_DBFile;
+                m_Args += '"';
+                continue;
+            }
             #if defined( __WINDOWS__ )
                 else if ( thisArg == "-debug" )
                 {
@@ -624,6 +643,7 @@ void FBuildOptions::DisplayHelp( const AString & programName ) const
             " -config <path>    Explicitly specify the config file to use.\n"
             " -continueafterdbmove\n"
             "       Allow builds after a DB move.\n"
+            " -dbfile <path>    Explicitly specify the dependency database file to use.\n"
             " -debug            (Windows) Break at startup, to attach debugger.\n"
             " -dist             Allow distributed compilation.\n"
             " -distverbose      Print detailed info for distributed compilation.\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -99,6 +99,7 @@ public:
     bool        m_FixupErrorPaths                   = false;
     bool        m_ForceDBMigration_Debug            = false; // Force migration even if bff has not changed (for tests)
     bool        m_ContinueAfterDBMove               = false;
+    AString     m_DBFile;
 
     uint32_t    m_NumWorkerThreads                  = 0; // True default detected in constructor
     AString     m_ConfigFile;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestGraph/DatabaseLocation/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestGraph/DatabaseLocation/fbuild.bff
@@ -1,0 +1,16 @@
+//
+// DatabaseLocation
+//
+//------------------------------------------------------------------------------
+
+// Use the standard test environment
+//------------------------------------------------------------------------------
+#include "../../testcommon.bff"
+Using( .StandardEnvironment )
+Settings {}
+
+TextFile( 'TestTarget' )
+{
+    .TextFileOutput         = '$Out$/Test/Graph/DatabaseLocation/test.txt'
+    .TextFileInputStrings   = { 'Test content' }
+}

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -345,6 +345,13 @@ void FBuildForTest::SerializeDepGraphToText( const char * nodeName, AString & ou
     m_DependencyGraph->SerializeToText( deps, outBuffer );
 }
 
+// GetDependencyGraphFile
+//------------------------------------------------------------------------------
+const char * FBuildForTest::GetDependencyGraphFile() const
+{
+    return m_DependencyGraphFile.Get();
+}
+
 // Build
 //------------------------------------------------------------------------------
 /*virtual*/ bool FBuildForTest::Build( Node * nodeToBuild )

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
@@ -94,6 +94,8 @@ public:
 
     void SerializeDepGraphToText( const char * nodeName, AString & outBuffer ) const;
 
+    const char * GetDependencyGraphFile() const;
+
     using FBuild::Build;
     virtual bool Build( Node * nodeToBuild ) override;
 };

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestGraph.cpp
@@ -1018,15 +1018,15 @@ void TestGraph::DBLocation() const
     AString dbFileDefaultLocation( "Tools/FBuild/FBuildTest/Data/TestGraph/DatabaseLocation/" );
     AString dbFileExplicitLocation( "../tmp/Test/Graph/DatabaseLocation/GraphDB.fdb" );
 
-    EnsureFileDoesNotExist( dbFileDefaultLocation );
-    EnsureFileDoesNotExist( dbFileExplicitLocation );
-
     // Build a target and let serialization save to default location
     {
         FBuildForTest fBuild( options );
         TEST_ASSERT( fBuild.Initialize() );
-        TEST_ASSERT( fBuild.Build( "TestTarget" ) );
+
         AString dbFile( fBuild.GetDependencyGraphFile() );
+        EnsureFileDoesNotExist( dbFile );
+
+        TEST_ASSERT( fBuild.Build( "TestTarget" ) );
         TEST_ASSERT( PathUtils::PathBeginsWith( dbFile, dbFileDefaultLocation ) );
     }
 
@@ -1036,8 +1036,11 @@ void TestGraph::DBLocation() const
 
         FBuildForTest fBuild( options );
         TEST_ASSERT( fBuild.Initialize() );
-        TEST_ASSERT( fBuild.Build( "TestTarget" ) );
+
         AString dbFile( fBuild.GetDependencyGraphFile() );
+        EnsureFileDoesNotExist( dbFile );
+
+        TEST_ASSERT( fBuild.Build( "TestTarget" ) );
         TEST_ASSERT( PathUtils::ArePathsEqual( dbFile, dbFileExplicitLocation ) );
     }
 }


### PR DESCRIPTION
# Description:
This PR adds a new -dbfile <path> command line option to allow the user to set the binary dependency database file explicitly.

Please provide details for the change or fix:
If is often desirable to keep the source tree free of intermediate/ "build" files. This new option allows the user to store the dependency database file in temp or output hierarchies instead (see #960).

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux** (sorry no chance to test on OSX and Linux)
- [X] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [X] **Includes documentation**
