### PR TITLE
Add the "FASTBuild Support" VS Code extension to the "3rd Party Downloads and Extensions" docs

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/download.html
+++ b/Code/Tools/FBuild/Documentation/docs/download.html
@@ -75,6 +75,7 @@ Syntax Highlighting
         <ul>
             <li><a href='https://github.com/dummyunit/vim-fastbuild'>vim-fastbuild</a> - Syntax highlighting for vim by dummyunit</li>    
             <li><a href="https://packagecontrol.io/packages/FASTBuild">FASTBuild-Sublime</a> - Syntax highlighting for Sublime Text 3 by Manuzor</li>
+            <li><a href="https://marketplace.visualstudio.com/items?itemName=HarrisonT.fastbuild-support">FASTBuild Support</a> - Syntax highlighting, go-to definition, find references, hover to see variable values, show syntax errors, and more for Visual Studio Code by Harrison Ting</li>
         </ul>
     </div>
 


### PR DESCRIPTION
# Description:

Add my "FASTBuild Support" Visual Studio Code extension to the "3rd Party Downloads and Extensions" docs.

No pressure to add my extension to the list, but I figured that I'd suggest it since folks I've shared it with to seem to find it valuable.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation**
