### PR TITLE
Add option and envvar for overriding the FBuildWorker IP Address

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/environmentvariables.html
+++ b/Code/Tools/FBuild/Documentation/docs/environmentvariables.html
@@ -44,6 +44,10 @@
     <td>Set location of the Brokerage Path for distributed compilation.</td>
   </tr>
   <tr>
+    <td><a href="#FASTBUILD_WORKER_IP_ADDRESS">FASTBUILD_WORKER_IP_ADDRESS</a></td>
+    <td>Set the IP address for FBuildWorker to advertise as.</td>
+  </tr>
+  <tr>
     <td><a href="#FASTBUILD_WORKERS">FASTBUILD_WORKERS</a></td>
     <td>Set the list of workers explicitly.</td>
   </tr>
@@ -76,6 +80,11 @@ executables being spawned from the temp directory.</p>
 <p>FBuildWorkers signal their availability by writing a token to the "Brokerage Path".
 The location of the brokerage path can be set via the FASTBUILD_BROKERAGE_PATH.</p>
 </div>
+
+    <div class='newsitemheader' id="FASTBUILD_WORKER_IP_ADDRESS">FASTBUILD_WORKER_IP_ADDRESS</div>
+    <div class='newsitembody'>
+<p>If set, this is the IP address used by FBuildWorker to advertise as on the worker brokerage.</p>
+    </div>
 
     <div class='newsitemheader' id="FASTBUILD_WORKERS">FASTBUILD_WORKERS</div>
     <div class='newsitembody'>

--- a/Code/Tools/FBuild/Documentation/docs/options.html
+++ b/Code/Tools/FBuild/Documentation/docs/options.html
@@ -693,9 +693,14 @@ runs in UI-less mode)</p>
 be reproduced in the debugger.</p>
 </div>
 
+    <div class='newsitemheader' id="ipaddress">-ipaddress=&lt;IP_ADDRESS&gt;</div>
+    <div class='newsitembody'>
+<p>Override the IP address used by FBuildWorker to advertise itself via the worker brokerage.</p>
+</div>
+
     <div class='newsitemheader' id="minfreememory">-minfreememory</div>
     <div class='newsitembody'>
-<p>[Windows Only] Override the default minimum memory limit (in MiB) from the default of 1024 (1 GiB). When a worked has less memory available
+<p>[Windows Only] Override the default minimum memory limit (in MiB) from the default of 1024 (1 GiB). When a worker has less memory available
 than this amount it will not accept work.</p>
 </div>
             minfreememory

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.cpp
@@ -74,7 +74,6 @@ void WorkerBrokerageServer::SetAvailability( bool available )
 
             // Check IP last update time and determine if host name or IP address has changed
             if ( m_HostName.IsEmpty() ||
-                 m_IPAddress.IsEmpty() ||
                  ( m_TimerLastIPUpdate.GetElapsed() >= sBrokerageIPAddressUpdateTime ) )
             {
                 AStackString<> hostName;
@@ -86,17 +85,23 @@ void WorkerBrokerageServer::SetAvailability( bool available )
                 Network::GetDomainName( domainName );
 
                 // Resolve host name to ip address
-                const uint32_t ip = Network::GetHostIPFromName( hostName );
-                if ( ( ip != 0 ) && ( ip != 0x0100007f ) )
-                {
-                    TCPConnectionPool::GetAddressAsString( ip, ipAddress );
+                if ( m_IPAddress.IsEmpty() ) {
+                    const uint32_t ip = Network::GetHostIPFromName( hostName );
+                    if ( ( ip != 0 ) && ( ip != 0x0100007f ) )
+                    {
+                        TCPConnectionPool::GetAddressAsString( ip, ipAddress );
+                    }
                 }
 
-                if ( ( hostName != m_HostName ) || ( domainName != m_DomainName ) || ( ipAddress != m_IPAddress ) )
+                if ( ( hostName != m_HostName ) || ( domainName != m_DomainName ) )
                 {
                     m_HostName = hostName;
                     m_DomainName = domainName;
-                    m_IPAddress = ipAddress;
+
+                    if ( !ipAddress.IsEmpty() )
+                    {
+                        m_IPAddress = ipAddress;
+                    }
 
                     // Remove existing brokerage file, as filename is being updated
                     FileIO::FileDelete( m_BrokerageFilePath.Get() );

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.h
@@ -24,6 +24,9 @@ public:
     void SetAvailability( bool available );
 
     const AString & GetHostName() const { return m_HostName; }
+    const AString & GetIPAddress() const { return m_IPAddress; }
+    void SetIPAddress( const AString & ipAddress ) { m_IPAddress = ipAddress; }
+
 
 protected:
     void UpdateBrokerageFilePath();

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
@@ -120,6 +120,11 @@ bool FBuildWorkerOptions::ProcessCommandLine( const AString & commandLine )
             m_PeriodicRestart = true;
             continue;
         }
+        else if ( token.BeginsWith( "-ipaddress=" ) )
+        {
+            m_OverrideIPAddress = AString( token.Get() + 11 );
+            continue;
+        }
         #if defined( __WINDOWS__ )
             else if ( token.BeginsWith( "-minfreememory=" ) )
             {
@@ -183,6 +188,8 @@ void FBuildWorkerOptions::ShowUsageError()
                        "        (Windows) Don't spawn a sub-process worker copy.\n"
                        " -periodicrestart\n"
                        "        Worker will restart every 4 hours.\n"
+                       " -ipaddress=<ipaddress>\n"
+                       "        Worker will advertise as this specific IP address.\n"
                        "---------------------------------------------------------------------------\n"
                        ;
 

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.h
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.h
@@ -9,10 +9,7 @@
 
 // Core
 #include "Core/Env/Types.h"
-
-// Forward Declaration
-//------------------------------------------------------------------------------
-class AString;
+#include "Core/Strings/AString.h"
 
 // FBuildWorkerOptions
 //------------------------------------------------------------------------------
@@ -28,6 +25,8 @@ public:
         bool m_IsSubprocess;    // Process is child? (Internal)
         bool m_UseSubprocess;   // Should we launch a sub-process?
     #endif
+
+    AString m_OverrideIPAddress; // IP Address to advertise as on worker brokerage
 
     // resource usage
     bool m_OverrideCPUAllocation;

--- a/Code/Tools/FBuild/FBuildWorker/Main.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Main.cpp
@@ -127,6 +127,18 @@ int Main( const AString & args )
     int ret;
     {
         Worker worker( args, options.m_ConsoleMode, options.m_PeriodicRestart );
+
+        AStackString<> ipAddressEnvOverride;
+        if ( !options.m_OverrideIPAddress.IsEmpty() )
+        {
+            worker.SetIPAddressOverride( options.m_OverrideIPAddress );
+        }
+        else if ( Env::GetEnvVariable( "FASTBUILD_WORKER_IP_ADDRESS", ipAddressEnvOverride ) &&
+                  !ipAddressEnvOverride.IsEmpty() )
+        {
+            worker.SetIPAddressOverride( ipAddressEnvOverride );
+        }
+
         if ( options.m_OverrideCPUAllocation )
         {
             WorkerSettings::Get().SetNumCPUsToUse( options.m_CPUAllocation );

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
@@ -130,7 +130,9 @@ int32_t Worker::Work()
     {
         // Create UI
         m_MainWindow = FNEW( WorkerWindow() );
-        m_MainWindow->SetStatus( m_WorkerBrokerage.GetHostName(), AStackString<>( "Idle" ) );
+        m_MainWindow->SetStatus( m_WorkerBrokerage.GetHostName(),
+                                 m_WorkerBrokerage.GetIPAddress(),
+                                 AStackString<>( "Idle" ) );
     }
 
     // spawn work thread
@@ -398,7 +400,9 @@ void Worker::UpdateUI()
     }
     else
     {
-        m_MainWindow->SetStatus( m_WorkerBrokerage.GetHostName(), status );
+        m_MainWindow->SetStatus( m_WorkerBrokerage.GetHostName(),
+                                 m_WorkerBrokerage.GetIPAddress(),
+                                 status );
     }
 
     if ( InConsoleMode() == false )

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.h
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.h
@@ -33,8 +33,10 @@ public:
     int32_t Work();
 
     void SetWantToQuit() { m_WantToQuit = true; }
+    void SetIPAddressOverride( const AString & ipAddress ) { m_WorkerBrokerage.SetIPAddress( ipAddress ); }
 
-private:
+
+ private:
     static uint32_t WorkThreadWrapper( void * userData );
     uint32_t WorkThread();
 

--- a/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.cpp
@@ -192,13 +192,17 @@ WorkerWindow::~WorkerWindow()
 
 // SetStatus
 //------------------------------------------------------------------------------
-void WorkerWindow::SetStatus( const AString & hostName, const AString & statusText )
+void WorkerWindow::SetStatus( const AString & hostName, const AString & ipAddress, const AString & statusText )
 {
     AStackString< 512 > text;
     text.Format( "FBuildWorker %s", FBUILD_VERSION_STRING );
     if ( !hostName.IsEmpty() )
     {
         text.AppendFormat( " | \"%s\"", hostName.Get() );
+    }
+    if ( !ipAddress.IsEmpty() )
+    {
+        text.AppendFormat( " (%s)", ipAddress.Get() );
     }
     if ( !statusText.IsEmpty() )
     {

--- a/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.h
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/WorkerWindow.h
@@ -34,7 +34,7 @@ public:
     // Show/Update UI (blocks)
     void Work();
 
-    void SetStatus( const AString & hostName, const AString & statusText );
+    void SetStatus( const AString & hostName, const AString & ipAddress, const AString & statusText );
     void SetWorkerState( size_t index, const AString & hostName, const AString & status );
 
     const OSMenu * GetMenu() const { return m_Menu; }


### PR DESCRIPTION
# Description:

 - See [issue 814](https://github.com/fastbuild/fastbuild/issues/814) _Loopback IP issue with Windows 10 and Hyper-V_
 - Under Windows, FBuildWorker will often choose the Hyper-V virtual ethernet address, if e.g. WSL is installed, and cause local addresses to be used as the IP address advertised to FBuild instances checking for workers in a brokerage path, where successful connections cannot be made. 
 - The added command line option (`-ipaddress`) and environment variable (`FASTBUILD_WORKER_IP_ADDRESS`) overrides the IP address discovered by FBuildWorker, so that it can advertise a desired IP address on the worker brokerage. The IP address is also is shown in the UI window title alongside the host name used on the brokerage.

# Checklist:

The pull request:
- [ v ] **Is created against the Dev branch**
- [ v ] **Is self-contained**
- [ ? ] **Compiles on Windows, OSX and Linux**
  - Windows compiles successfully.
  - Linux under Windows with WSL seems to run into a link issue with the Fuzzer library binary, at least on my Ubuntu 20.04 container. I've had similar issues with 22.04, although I had to hack to use Clang-11 with `clang-10` not being available. This also happens without my change, so it looks like there's an issue with my Linux compiler set up.
  - Unfortunately I have no access to a Mac OSX machine to verify this change under OSX either. 
  - The change itself does not introduce any usages of platform-specific code to my knowledge, the existing platform abstractions are used for e.g. getting the environment variable value. 
- [ X ] **Has accompanying tests** 
  - There are no existing tests that test FBuildWorker and the Brokerage classes. Testing the `WorkerBrokerageServer` class would require decoupling from e.g. Network API calls that call real system APIs for e.g. `getaddrinfo()`. This would be a much larger architectural change, and weighing up against size of the changes to the brokerage class to add an IP address string override, I would suggest such a change would be more suited for a separate future change to improve its testability. 
  - This change does not otherwise modify any of the other FBuild core libraries.
- [ v ] **Passes existing tests**
- [ ? ] **Keeps Windows, OSX and Linux at parity**
  - Build issues prevent this from being verified, but given the use of platform abstractions for e.g. retrieving environment variables, this change should maintain parity across those platforms.
- [ v ] **Follows the code style**
- [ v ] **Includes documentation**
