### PR TITLE
Upgraded sort code to use QuickSort instead of ShellSort.

### DIFF
--- a/Code/Core/Containers/Array.h
+++ b/Code/Core/Containers/Array.h
@@ -53,10 +53,10 @@ public:
     void                        Swap( Array< T > & other );
 
     // sorting
-    void                        Sort() { ShellSort( m_Begin, m_Begin + m_Size, AscendingCompare() ); }
-    void                        SortDeref() { ShellSort( m_Begin, m_Begin + m_Size, AscendingCompareDeref() ); }
+    void                        Sort() { QuickSort( m_Begin, m_Begin + m_Size, AscendingCompare() ); }
+    void                        SortDeref() { QuickSort( m_Begin, m_Begin + m_Size, AscendingCompareDeref() ); }
     template < class COMPARER >
-    void                        Sort( const COMPARER & comp ) { ShellSort( m_Begin, m_Begin + m_Size, comp ); }
+    void                        Sort( const COMPARER & comp ) { QuickSort( m_Begin, m_Begin + m_Size, comp ); }
 
     // find
     template < class U >

--- a/Code/Core/Containers/Sort.h
+++ b/Code/Core/Containers/Sort.h
@@ -30,37 +30,80 @@ public:
     }
 };
 
-// ShellSort
+template < class T > 
+static inline void   SortSwap( T & a, T & b )      { T tmp( a ); a = b; b = tmp; }
+static inline size_t SortMin( size_t a, size_t b ) { return a < b ? a : b; }
+
+// QuickSort
 //------------------------------------------------------------------------------
 template < class T, class COMPARE >
-void ShellSort( T * begin, T * end, const COMPARE & compare )
+void QuickSort( T * begin, T * end, const COMPARE & less )
 {
-    const size_t numItems = (size_t)( end - begin );
-    size_t increment = 3;
-    while ( increment > 0 )
+    struct Stack { T *arr, *end; } stack[ 64 ], range = { begin, end };
+    int depth = 0;
+
+    for (;;)
     {
-        for ( size_t i = 0; i < numItems; i++ )
+        // Sort small runs with O(n^2) insertion sort, large with O(log n) quick sort.
+        size_t count = size_t( range.end - range.arr );
+        if ( count <= 16 || depth >= 63 )
         {
-            size_t j = i;
-            T temp( begin[ i ] );
-            while ( ( j >= increment ) && ( compare( temp, begin[ j - increment ] ) ) )
+            for ( size_t i = 1; i < count; i++ )
             {
-                begin[ j ] = begin[ j - increment ];
-                j = j - increment;
+                T tmp( range.arr[ i ] );
+                size_t j = i;
+                while ( j > 0 && less( tmp, range.arr[ j - 1 ] ) )
+                {
+                    range.arr[ j ] = range.arr[ j - 1 ];
+                    j--;
+                }
+                range.arr[ j ] = tmp;
             }
-            begin[ j ] = temp;
-        }
-        if ( increment / 2 != 0 )
-        {
-            increment = increment / 2;
-        }
-        else if ( increment == 1 )
-        {
-            increment = 0;
-        }
-        else
-        {
-            increment = 1;
+
+            // Pop new range off stack.
+            if ( depth <= 0 )
+                break;
+            range = stack[ --depth ];
+        } else {
+            // Pick median-of-3 as pivot.
+            T *a = range.arr, *b = range.arr + ( count >> 1 ), *c = range.end - 1;
+            if ( less( *c, *a ) ) SortSwap( *a, *c );
+            if ( less( *b, *c ) ) SortSwap( *c, *b );
+            if ( less( *c, *a ) ) SortSwap( *a, *c );
+            T pivot(*c);
+
+            // Partition into (eq, lt, gt, eq). (Bentley/McIlroy, "Engineering a Sort Function", 1993)
+            size_t i = 0, j = count - 1, ieq = 0, jeq = count - 1;
+            for (;;)
+            {
+                while ( i <= j && !less( pivot, range.arr[ i ] ) )
+                {
+                    if ( !less( range.arr[ i ], pivot ) )
+                        SortSwap( range.arr[ ieq++ ], range.arr[ i ] );
+                    i++;
+                }
+                while ( j >= i && !less( range.arr[ j ], pivot ) )
+                {
+                    if (!less( pivot, range.arr[ j ] ) )
+                        SortSwap( range.arr[ jeq-- ], range.arr[ j ] );
+                    j--;
+                }
+                if (i > j)
+                    break;
+                SortSwap( range.arr[ i++ ], range.arr[ j-- ] );
+            }
+
+            // Move elements equal to the pivot back into the middle.
+            size_t s = SortMin( ieq, i - ieq );
+            for (size_t l = 0, h = i - s; s; s--)
+                SortSwap( range.arr[ l++ ], range.arr[ h++ ] );
+            s = SortMin( jeq - j, count - 1 - jeq );
+            for (size_t l = i, h = count - s; s; s--)
+                SortSwap( range.arr[ l++ ], range.arr[ h++ ] );
+
+            // Save one half for later and recurse into the other.
+            stack[ depth++ ] = { range.arr + count - ( jeq - j ), range.end };
+            range = { range.arr, range.arr + ( i - ieq ) };
         }
     }
 }


### PR DESCRIPTION
Jobs in FASTBuild are sorted using _ShellSort_, which has execution time of O(n^2). When 'n' is large, which can happen on builds containing thousands of jobs, the time taken to perform the sorting quickly becomes notable, sometimes taking over 30 seconds to complete.

Data can be sorted quickly using an O(n log n) algorithm such as _QuickSort_ (C. A. R. Hoare, 1961). QuickSort uses a divide-and-conquer strategy to recursively split the problem into smaller tasks. This implementation uses an explicit stack to avoid function-call overhead and bound stack depth in case of adverse inputs (degrading to a slower sort under the rare case of overflow), chooses median-of-three as its partition function to maintain recursion balance, and handles repeated equal values well.

Other options such as deferring to the _libc qsort_ or _STL std::sort_ were not considered due to the pre-existing coding style of the FASTBuild codebase. Switching algorithms to a distributive sort such as Radix Sort was discounted to maintain API compatibility.
