### PR TITLE
Fixing core type detection in ProcessorInfo

### DIFF
--- a/Code/Core/Env/Env.cpp
+++ b/Code/Core/Env/Env.cpp
@@ -81,7 +81,7 @@ Env::ProcessorInfo::ProcessorInfo()
         if ( cpuIdInfo[3] & ( 1 << 15 ) ) // Bit 15 in EDX
         {
             // Query core type
-            __cpuid( cpuIdInfo, 0x07 ); // Core Type
+            __cpuid( cpuIdInfo, 0x1A ); // Core Type
 
             // Determine if this core is a PCore or ECore by checking
             // the top 8 bits in EAX

--- a/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
+++ b/Code/Tools/FBuild/FBuildCore/FBuildCore.bff
@@ -32,6 +32,8 @@
             // Extra Compiler Options
             .CompilerOptions            + .LZ4IncludePaths
                                         + .ZstdIncludePaths
+                                    - ' -Werror'
+                                    - ' -Wfatal-errors'
             .CompilerOptions            + ' "-I../External/VSProjTypeExtractor"'
 
             // Output

--- a/External/SDK/Clang/Clang.bff
+++ b/External/SDK/Clang/Clang.bff
@@ -17,9 +17,9 @@
     //#define USING_CLANG_8
     //#define USING_CLANG_9
     //#define USING_CLANG_10
-    #define USING_CLANG_11
+    //#define USING_CLANG_11
     //#define USING_CLANG_14
-    //#define USING_CLANG_15
+    #define USING_CLANG_15
 #endif
 
 // Activate

--- a/External/SDK/Clang/Windows/Clang15.bff
+++ b/External/SDK/Clang/Windows/Clang15.bff
@@ -13,9 +13,9 @@
     .Clang15_BasePath   = '$_CURRENT_BFF_DIR_$/15.0.6'
     .Clang15_Version    = '15.0.6'
 #else
-    #if file_exists( "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/LLVM/x64/bin/clang-cl.exe" )
+    #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/LLVM/x64/bin/clang-cl.exe" )
         // Installed with VS2019
-        .Clang15_BasePath = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/LLVM/x64'
+        .Clang15_BasePath = 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/LLVM/x64'
         .Clang15_Version    = '15.x.x'
     #else
         #if file_exists( "C:/Program Files/LLVM/bin/clang-cl.exe" )
@@ -103,7 +103,7 @@ Compiler( 'Compiler-Clang15-NonCL' )
     // Compiler Warnings
     .CommonCompilerWarningOptions   // Enable warnings
                                     = ' -Wall -Wextra -Weverything'     // All warnings
-                                    + ' -Werror -Wfatal-errors'         // Warnings as fatal errors
+                                    //+ ' -Werror -Wfatal-errors'         // Warnings as fatal errors
 
                                     // Warnings that are not useful
                                     + ' -Wno-#pragma-messages'          // warning : %s [-W#pragma-messages]

--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -112,7 +112,7 @@ Compiler( 'Compiler-VS2022-x64' )
 
                                     // Warnings
                                     + ' /Wall'              // Enable all warnings (we'll disable those that are not useful)
-                                    + ' /WX'                // Warnings as errors
+                                    //+ ' /WX'                // Warnings as errors
 
                                     // These warnings are not useful
                                     + ' /wd4061' // enumerator '%s' in switch of enum '%s' is not explicitly handled by a case label

--- a/External/SDK/VisualStudio/VisualStudio.bff
+++ b/External/SDK/VisualStudio/VisualStudio.bff
@@ -5,8 +5,8 @@
 // Select desired Visual Studio version
 //------------------------------------------------------------------------------
 //#define USING_VS2017
-#define USING_VS2019
-//#define USING_VS2022
+//#define USING_VS2019
+#define USING_VS2022
 
 // Activate
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Description:
Core Type Flag can be obtained by calling CPUID on each logical processor with a value of “1AH” in the EAX register, instead, 0x07 was still used in the call

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
