### PR TITLE
clang tidy support proof of concept

### DIFF
--- a/Code/Core/FileIO/PathUtils.cpp
+++ b/Code/Core/FileIO/PathUtils.cpp
@@ -6,6 +6,10 @@
 #include "PathUtils.h"
 #include "Core/Strings/AStackString.h"
 
+#if defined( __WINDOWS__ )
+#include <windows.h>
+#endif
+
 // Exists
 //------------------------------------------------------------------------------
 /*static*/ bool PathUtils::IsFolderPath( const AString & path )
@@ -290,4 +294,21 @@
     outRelativeFileName += pathB;
 }
 
+// GetFullPath
+//------------------------------------------------------------------------------
+/*static*/ AString PathUtils::GetFullPath( const AString & fileName )
+{
+#if defined( __WINDOWS__ )
+    char fullPath[MAX_PATH] = { 0 };
+    uint32_t size = GetFullPathName( fileName.Get(), MAX_PATH, fullPath, nullptr );
+    if (size == 0)
+    {
+        return AString{};
+    }
+
+    return AString{ fullPath, fullPath + size };
+#else
+#error TODO
+#endif
+}
 //------------------------------------------------------------------------------

--- a/Code/Core/FileIO/PathUtils.h
+++ b/Code/Core/FileIO/PathUtils.h
@@ -51,6 +51,7 @@ public:
     static void GetRelativePath( const AString & basePath,
                                  const AString & fileName,
                                  AString & outRelativeFileName );
+    static AString GetFullPath( const AString& fileName );
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriverBase.cpp
+++ b/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriverBase.cpp
@@ -134,6 +134,13 @@ void CompilerDriverBase::Init( const ObjectNode * objectNode,
 {
 }
 
+// AddPreliminaryArgs_Common
+//------------------------------------------------------------------------------
+/*virtual*/ void CompilerDriverBase::AddPreliminaryArgs( bool /*isLocal*/,
+                                                         Args & /*outFullArgs*/ ) const
+{
+}
+
 // StripTokenWithArg
 //------------------------------------------------------------------------------
 /*static*/ bool CompilerDriverBase::StripTokenWithArg( const char * tokenToCheckFor,

--- a/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriverBase.h
+++ b/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriverBase.h
@@ -53,6 +53,7 @@ public:
     virtual void AddAdditionalArgs_Preprocessor( Args & outFullArgs ) const;
     virtual void AddAdditionalArgs_Common( bool isLocal,
                                            Args & outFullArgs ) const;
+    virtual void AddPreliminaryArgs( bool isLocal, Args & outFullArgs ) const;
 
     // Locally modify args before passing to remote worker
     virtual bool ProcessArg_PreparePreprocessedForRemote( const AString & token,

--- a/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_ClangTidy.cpp
+++ b/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_ClangTidy.cpp
@@ -1,0 +1,94 @@
+// CompilerDriver_ClangTidy.cpp
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "CompilerDriver_ClangTidy.h"
+
+// FBuild
+#include "Tools/FBuild/FBuildCore/FBuild.h"
+#include "Tools/FBuild/FBuildCore/Graph/CompilerNode.h"
+#include "Tools/FBuild/FBuildCore/Graph/ObjectNode.h"
+#include "Tools/FBuild/FBuildCore/Helpers/Args.h"
+#include "Tools/FBuild/FBuildCore/WorkerPool/Job.h"
+
+// CONSTRUCTOR
+//------------------------------------------------------------------------------
+CompilerDriver_ClangTidy::CompilerDriver_ClangTidy() = default;
+
+// DESTRUCTOR
+//------------------------------------------------------------------------------
+CompilerDriver_ClangTidy::~CompilerDriver_ClangTidy() = default;
+
+// ProcessArg_PreprocessorOnly
+//------------------------------------------------------------------------------
+/*virtual*/ bool CompilerDriver_ClangTidy::ProcessArg_PreprocessorOnly( const AString & /*token*/,
+                                                                       size_t & /*index*/,
+                                                                       const AString & /*nextToken*/,
+                                                                       Args & /*outFullArgs*/ ) const
+{
+    ASSERT(false); // ClangTidy can't be used as a preprocessor
+    return false;
+}
+
+// ProcessArg_Common
+//------------------------------------------------------------------------------
+/*virtual*/ bool CompilerDriver_ClangTidy::ProcessArg_Common( const AString & token,
+                                                             size_t & index,
+                                                             Args & outFullArgs ) const
+{
+    if ( StripToken("--config-file=", token, true) )
+    {
+        return true;
+    }
+
+    // Strip -fdiagnostics-color options because we are going to override them
+    if ( m_ForceColoredDiagnostics )
+    {
+        if ( StripToken( "-fdiagnostics-color", token, true ) ||
+             StripToken( "-fno-diagnostics-color", token ) )
+        {
+            return true;
+        }
+    }
+
+    return CompilerDriverBase::ProcessArg_Common( token, index, outFullArgs );
+}
+
+// AddAdditionalArgs_Preprocessor
+//------------------------------------------------------------------------------
+/*virtual*/ void CompilerDriver_ClangTidy::AddAdditionalArgs_Preprocessor( Args & /*outFullArgs*/) const
+{
+    ASSERT(false); // ClangTidy can't be used as a preprocessor
+}
+
+// AddAdditionalArgs_Common
+//------------------------------------------------------------------------------
+/*virtual*/ void CompilerDriver_ClangTidy::AddAdditionalArgs_Common( bool /*isLocal*/,
+                                                                    Args & outFullArgs ) const
+{
+    if ( m_ForceColoredDiagnostics )
+    {
+        outFullArgs += " -fdiagnostics-color=always";
+    }
+}
+
+// AddPreliminaryArgs
+//------------------------------------------------------------------------------
+/*virtual*/ void CompilerDriver_ClangTidy::AddPreliminaryArgs( bool /*isLocal*/,
+                                                         Args & outFullArgs ) const
+{
+    // clang-tidy accepts two sets of arguments, its linter arguments and optional
+    // compilation arguments forwarded to the underlying clang instance
+    // typical usage is:
+    // $ clang-tidy [linter_arguments...] -- [clang_arguments...]
+    // --config-file being a linter argument we rely on, we make sure it is always
+    // passed before clang arguments
+
+    outFullArgs += "--config-file=";
+    outFullArgs += m_OverrideSourceFile;
+    outFullArgs += ".config.yaml";
+    outFullArgs.AddDelimiter();
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_ClangTidy.h
+++ b/Code/Tools/FBuild/FBuildCore/ExeDrivers/Compiler/CompilerDriver_ClangTidy.h
@@ -1,0 +1,40 @@
+// CompilerDriver_ClangTidy.h
+//------------------------------------------------------------------------------
+#pragma once
+
+// Includes
+//------------------------------------------------------------------------------
+#include "CompilerDriverBase.h"
+
+// Core
+#include "Core/Containers/Array.h"
+#include "Core/Env/Assert.h"
+#include "Core/Process/Process.h"
+
+// Forward Declarations
+//------------------------------------------------------------------------------
+
+// CompilerDriver_ClangTidy
+//------------------------------------------------------------------------------
+class CompilerDriver_ClangTidy : public CompilerDriverBase
+{
+public:
+    CompilerDriver_ClangTidy();
+    virtual ~CompilerDriver_ClangTidy() override;
+
+    virtual bool ProcessArg_PreprocessorOnly( const AString & token,
+                                              size_t & index,
+                                              const AString & nextToken,
+                                              Args & outFullArgs ) const override;
+    virtual bool ProcessArg_Common( const AString & token,
+                                    size_t & index,
+                                    Args & outFullArgs ) const override;
+
+    virtual void AddAdditionalArgs_Preprocessor( Args & outFullArgs ) const override;
+    virtual void AddAdditionalArgs_Common( bool isLocal,
+                                           Args & outFullArgs ) const override;
+    virtual void AddPreliminaryArgs( bool isLocal,
+                                     Args& outFullArgs) const override;
+};
+
+//------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -198,6 +198,14 @@ bool CompilerNode::InitializeCompilerFamily( const BFFToken * iter, const Functi
             return true;
         }
 
+        // Clang-tidy
+        if ( compiler.EndsWithI( "clang-tidy.exe" ) ||
+            compiler.EndsWithI( "clang-tidy" ) )
+        {
+            m_CompilerFamilyEnum = CLANG_TIDY;
+            return true;
+        }
+
         // GCC
         if ( compiler.EndsWithI( "gcc.exe" ) ||
              compiler.EndsWithI( "gcc" ) ||
@@ -307,6 +315,11 @@ bool CompilerNode::InitializeCompilerFamily( const BFFToken * iter, const Functi
     if ( m_CompilerFamilyString.EqualsI( "clang-cl" ) )
     {
         m_CompilerFamilyEnum = CLANG_CL;
+        return true;
+    }
+    if ( m_CompilerFamilyString.EqualsI( "clang-tidy" ) )
+    {
+        m_CompilerFamilyEnum = CLANG_TIDY;
         return true;
     }
     if ( m_CompilerFamilyString.EqualsI( "snc" ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -55,6 +55,7 @@ public:
         ORBIS_WAVE_PSSLC= 10,
         CSHARP          = 11,
         CLANG_CL        = 12,
+        CLANG_TIDY      = 13,
     };
     CompilerFamily GetCompilerFamily() const { return static_cast<CompilerFamily>( m_CompilerFamilyEnum ); }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
@@ -66,6 +66,14 @@ void FileNode::HandleWarningsClangCl( Job * job, const AString & name, const ASt
     return HandleWarnings( job, name, data, clangWarningString );
 }
 
+// HandleWarningsClangTidy
+//------------------------------------------------------------------------------
+void FileNode::HandleWarningsClangTidy( Job* job, const AString& name, const AString& data )
+{
+    constexpr const char* clangTidyWarningString = " warning:";
+    return HandleWarnings( job, name, data, clangTidyWarningString );
+}
+
 // HandleWarnings
 //------------------------------------------------------------------------------
 void FileNode::HandleWarnings( Job * job, const AString & name, const AString & data, const char * warningString )

--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.cpp
@@ -7,6 +7,8 @@
 #include "Tools/FBuild/FBuildCore/FBuild.h"
 #include "Tools/FBuild/FBuildCore/FLog.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
+#include "Tools/FBuild/FBuildCore/WorkerPool/Job.h"
+#include "Tools/FBuild/FBuildCore/Helpers/Compressor.h"
 
 // Core
 #include "Core/FileIO/FileIO.h"
@@ -66,12 +68,189 @@ void FileNode::HandleWarningsClangCl( Job * job, const AString & name, const ASt
     return HandleWarnings( job, name, data, clangWarningString );
 }
 
+struct StringRoamer
+{
+    size_t index = 0;
+    size_t length = 0;
+    const char* position = nullptr;
+
+    bool ReadChar()
+    {
+        if (index >= length)
+        {
+            return false;
+        }
+        ++position;
+        ++index;
+        return true;
+    }
+};
+
+// FindLineInSourceFile - Takes as parameter the preprocessed data and the error line number in the preprocessed file. Return the error line number in the source file.
+//------------------------------------------------------------------------------
+static void FindLineInSourceFile( Array<uint32_t> & lineNumbersPreprocessedFile, StringRoamer preprocessedDataRoamer, Array<uint32_t> & lineNumbersSourceFile )
+{
+    uint32_t currentLine = 1;
+    uint32_t lastIncludeLine = 1;
+    uint32_t numberOfLastInclude = 0;
+
+    for (uint32_t lineNumber : lineNumbersPreprocessedFile)
+    {
+        while (currentLine < lineNumber)
+        {
+            char c = *(preprocessedDataRoamer.position);
+            if (c == '\n')
+            {
+                currentLine++;
+            }
+            else if (c == '#')
+            {
+                if (preprocessedDataRoamer.ReadChar()) 
+                {
+                    c = *(preprocessedDataRoamer.position);
+                }
+                else
+                {
+                    FLOG_ERROR("Could not find the error line number in preprocessed file");
+                    return;
+                }
+                // Avoid #pragma and # in instructions
+                if (c == ' ')
+                {
+                    lastIncludeLine = currentLine;
+                    // Skip the empty space
+                    if (preprocessedDataRoamer.ReadChar())
+                    {
+                        c = *(preprocessedDataRoamer.position);
+                    }
+                    else
+                    {
+                        FLOG_ERROR("Could not find the error line number in preprocessed file");
+                        return;
+                    }
+                    // Find the number after the #
+                    numberOfLastInclude = 0;
+                    while (c != ' ')
+                    {
+                        // Do the conversion from char to uint
+                        numberOfLastInclude = numberOfLastInclude * 10 + (c - '0');
+                        if (preprocessedDataRoamer.ReadChar())
+                        {
+                            c = *(preprocessedDataRoamer.position);
+                        }
+                        else
+                        {
+                            FLOG_ERROR("Could not find the error line number in preprocessed file");
+                            return;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // Normal character part of token
+            }
+            if (!preprocessedDataRoamer.ReadChar())
+            {
+                FLOG_ERROR("Could not find the error line number in preprocessed file");
+                return;
+            }
+        }
+        lineNumbersSourceFile.Append(lineNumber - (lastIncludeLine + 1) + numberOfLastInclude);
+    }
+
+    return;
+}
+
 // HandleWarningsClangTidy
 //------------------------------------------------------------------------------
 void FileNode::HandleWarningsClangTidy( Job* job, const AString& name, const AString& data )
 {
+    AString newWarningMessage;
+    // Avoid the client who wants to print remote work to process again the error line number
+    // This part of the function workaround this issue : https://github.com/llvm/llvm-project/issues/62405
+    if ( ( job->GetDistributionState() == Job::DIST_NONE || job->GetDistributionState() == Job::DIST_BUILDING_LOCALLY ) )
+    {
+        // Get preprocessed file data in a buffer
+        const char* preprocessedData = static_cast<const char*>( job->GetData() );
+        size_t preprocessedDataSize = job->GetDataSize() - job->GetExtraDataSize();
+
+        // Handle compressed data
+        Compressor c; // scoped here so we can access decompression buffer
+        if ( job->IsDataCompressed() )
+        {
+            VERIFY( c.Decompress( preprocessedData ) );
+            preprocessedData = static_cast<const char*>( c.GetResult() );
+            preprocessedDataSize = c.GetResultSize() - job->GetExtraDataSize();
+        }
+
+        // Parse the warning message to get the error line numbers in preprocessed file
+        // The warning message looks like this : "path\to\the\file:errorLineNumber:errorColumnNumber: warning: description of what is wrong"
+        // There may be several concatenated warnings messages
+        // It works both on Windows and Unix systems
+        Array< AString > tokens;
+        data.Tokenize( tokens, ':' );
+        Array< uint32_t > indexes;
+        bool foundWarning = false;
+        for (uint32_t tokenIndex = 2; tokenIndex < tokens.GetSize(); tokenIndex++)
+        {
+            // The error line number is just before the "warning" string which is not at the beginning
+            if (tokens[tokenIndex].Find("warning"))
+            {
+                foundWarning = true;
+                indexes.Append(tokenIndex - 2);
+            }
+        }
+
+        if ( foundWarning )
+        {
+            // Get the error line numbers and convert them to an integer
+            Array<uint32_t> errorLineNumbersInteger;
+            for (uint32_t index : indexes) {
+                AString& errorLineNumberString = tokens[index];
+                uint32_t errorLineNumberInteger = 0;
+                if (errorLineNumberString.Scan("%d", &errorLineNumberInteger) != 1)
+                {
+                    FLOG_ERROR("Error: could not convert the error line number from AString to int");
+                    return;
+                }
+                errorLineNumbersInteger.Append(errorLineNumberInteger);
+            }
+
+            // Read buffer to calculate the error line numbers from source file
+            Array<uint32_t> lineNumbersFromSourceFile;
+            StringRoamer preprocessedDataRoamer = { 0, preprocessedDataSize, preprocessedData };
+            FindLineInSourceFile(errorLineNumbersInteger, preprocessedDataRoamer, lineNumbersFromSourceFile);
+
+            // Modify error line numbers
+            uint32_t currentIndex = 0;
+            for (uint32_t index : indexes) {
+                tokens[index].Format("%d", lineNumbersFromSourceFile[currentIndex]);
+                currentIndex++;
+            }
+
+            // Reform the warning message
+            for (uint32_t tokenIndex = 0; tokenIndex < tokens.GetSize(); tokenIndex++)
+            {
+                newWarningMessage += tokens[tokenIndex];
+                // Does not add ":" after the last element of the message
+                if (tokenIndex < tokens.GetSize() - 1)
+                {
+                    newWarningMessage += ":";
+                }
+            }
+        }
+    }
+
     constexpr const char* clangTidyWarningString = " warning:";
-    return HandleWarnings( job, name, data, clangTidyWarningString );
+    if ( newWarningMessage.IsEmpty() )
+    {
+        return HandleWarnings( job, name, data, clangTidyWarningString );
+    }
+    else 
+    {
+        return HandleWarnings( job, name, newWarningMessage, clangTidyWarningString );
+    }
 }
 
 // HandleWarnings

--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.h
@@ -22,6 +22,7 @@ public:
     static void HandleWarningsMSVC( Job * job, const AString & name, const AString & data );
     static void HandleWarningsClangCl( Job * job, const AString & name, const AString & data );
     static void HandleWarningsClangGCC( Job * job, const AString & name, const AString & data );
+    static void HandleWarningsClangTidy( Job* job, const AString& name, const AString& data );
 protected:
     friend class ObjectNode;
     virtual BuildResult DoBuild( Job * job ) override;

--- a/Code/Tools/FBuild/FBuildCore/Graph/FileNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/FileNode.h
@@ -22,7 +22,7 @@ public:
     static void HandleWarningsMSVC( Job * job, const AString & name, const AString & data );
     static void HandleWarningsClangCl( Job * job, const AString & name, const AString & data );
     static void HandleWarningsClangGCC( Job * job, const AString & name, const AString & data );
-    static void HandleWarningsClangTidy( Job* job, const AString& name, const AString& data );
+    static void HandleDiagnosticsClangTidy( Job* job, const AString& name, const AString& data );
 protected:
     friend class ObjectNode;
     virtual BuildResult DoBuild( Job * job ) override;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -102,6 +102,7 @@ protected:
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
     Array< AString >    m_PreBuildDependencyNames;
+    AString             m_ClangTidyConfigurationFile;
 
     // Internal State
     AString             m_PrecompiledHeaderName;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2231,7 +2231,7 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
 
     // On remote workers, free compressed buffer as we don't need it anymore
     // This reduces memory consumed on the remote worker.
-    if ( job->IsLocal() == false )
+    if ( !IsClangTidy() && job->IsLocal() == false )
     {
         job->OwnData( nullptr, 0, false ); // Free compressed buffer
     }
@@ -2311,6 +2311,7 @@ bool ObjectNode::BuildFinalOutput( Job * job, const Args & fullArgs ) const
                 {
                     HandleWarningsClangTidy( job, GetName(), ch.GetErr() );
                     HandleWarningsClangTidy( job, GetName(), ch.GetOut() );
+                    job->OwnData( nullptr, 0, false ); // Free compressed buffer
                 }
             }
         }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -165,6 +165,7 @@ public:
 
     const AString & GetPCHObjectName() const { return m_PCHObjectFileName; }
     const AString & GetOwnerObjectList() const { return m_OwnerObjectList; }
+    const AString & GetClangTidyConfigurationFile() const { return m_ClangTidyConfigurationFile; }
 
     void ExpandCompilerForceUsing( Args & fullArgs, const AString & pre, const AString & post ) const;
 
@@ -290,6 +291,7 @@ private:
     AString             m_Preprocessor;
     AString             m_PreprocessorOptions;
     Array< AString >    m_PreBuildDependencyNames;
+    AString             m_ClangTidyConfigurationFile;
 
     // Internal State
     AString             m_PrecompiledHeader;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -77,6 +77,7 @@ public:
         bool IsWarningsAsErrorsClangGCC() const     { return ( ( m_Flags & FLAG_WARNINGS_AS_ERRORS_CLANGGCC ) != 0 ); }
         bool IsClangCl() const                      { return ( ( m_Flags & FLAG_CLANG_CL ) != 0 ); }
         bool IsUsingGcovCoverage() const            { return ( ( m_Flags & FLAG_GCOV_COVERAGE ) != 0 ); }
+        bool IsClangTidy() const                    { return ( ( m_Flags & FLAG_CLANG_TIDY ) != 0 ); }
 
         enum Flag : uint32_t
         {
@@ -105,6 +106,7 @@ public:
             FLAG_WARNINGS_AS_ERRORS_CLANGGCC    = 0x1000000,
             FLAG_CLANG_CL                       = 0x2000000,
             FLAG_GCOV_COVERAGE                  = 0x4000000,
+            FLAG_CLANG_TIDY                     = 0x8000000,
         };
 
         void Set( Flag flag )       { m_Flags |= flag; }
@@ -133,6 +135,7 @@ public:
     bool IsSNC() const                      { return m_CompilerFlags.IsSNC(); }
     bool IsUsingCLR() const                 { return m_CompilerFlags.IsUsingCLR(); }
     bool IsClangCl() const                  { return m_CompilerFlags.IsClangCl(); }
+    bool IsClangTidy() const                { return m_CompilerFlags.IsClangTidy(); }
     bool IsUsingPDB() const                 { return m_CompilerFlags.IsUsingPDB(); }
     bool IsCodeWarriorWii() const           { return m_CompilerFlags.IsCodeWarriorWii(); }
     bool IsGreenHillsWiiU() const           { return m_CompilerFlags.IsGreenHillsWiiU(); }

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -818,6 +818,13 @@ void Client::ProcessJobResultCommon( const ConnectionInfo * connection, bool isC
                 FileNode::HandleWarningsClangCl( job, objectNode->GetName(), msgBuffer );
             }
         }
+        else if ( objectNode->IsClangTidy() )
+        {
+            if ( objectNode->IsWarningsAsErrorsMSVC() == false )
+            {
+                FileNode::HandleWarningsClangTidy( job, objectNode->GetName(), msgBuffer );
+            }
+        }
         else if ( objectNode->IsClang() || objectNode->IsGCC() )
         {
             if ( objectNode->IsWarningsAsErrorsClangGCC() == false )

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -822,7 +822,7 @@ void Client::ProcessJobResultCommon( const ConnectionInfo * connection, bool isC
         {
             if ( objectNode->IsWarningsAsErrorsMSVC() == false )
             {
-                FileNode::HandleWarningsClangTidy( job, objectNode->GetName(), msgBuffer );
+                FileNode::HandleDiagnosticsClangTidy( job, objectNode->GetName(), msgBuffer );
             }
         }
         else if ( objectNode->IsClang() || objectNode->IsGCC() )

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Protocol.h
@@ -31,7 +31,7 @@ namespace Protocol
     enum : uint16_t { PROTOCOL_PORT = 31264 }; // Arbitrarily chosen port
 
     // Protocol Version
-    enum : uint32_t { PROTOCOL_VERSION_MAJOR = 22 };    // Changes here make workers incompatible
+    enum : uint32_t { PROTOCOL_VERSION_MAJOR = 22 + 1 };    // Changes here make workers incompatible
     enum : uint8_t  { PROTOCOL_VERSION_MINOR = 3 };     // Changes must be forwards and backwards compatible
 
     enum { PROTOCOL_TEST_PORT = PROTOCOL_PORT + 1 }; // Different port for use by tests

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.cpp
@@ -175,6 +175,7 @@ void Job::Serialize( IOStream & stream )
     stream.Write( IsDataCompressed() );
 
     stream.Write( m_DataSize );
+    stream.Write( m_ExtraDataSize );
     stream.Write( m_Data, m_DataSize );
 }
 
@@ -196,6 +197,7 @@ void Job::Deserialize( IOStream & stream )
     // read extra data
     uint32_t dataSize;
     stream.Read( dataSize );
+    stream.Read( m_ExtraDataSize );
     void * data = ALLOC( dataSize );
     stream.Read( data, dataSize );
 

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/Job.h
@@ -47,6 +47,9 @@ public:
     inline void     SetUserData( void * data )  { m_UserData = data; }
     inline void *   GetUserData() const         { return m_UserData; }
 
+    inline size_t   GetExtraDataSize() const { return m_ExtraDataSize; }
+    inline void     SetExtraDataSize( uint32_t size ) { m_ExtraDataSize = size; }
+
     inline void             SetToolManifest( ToolManifest * manifest )  { m_ToolManifest = manifest; }
     inline ToolManifest *   GetToolManifest() const                     { return m_ToolManifest; }
 
@@ -107,6 +110,7 @@ public:
 private:
     uint32_t            m_JobId             = 0;
     uint32_t            m_DataSize          = 0;
+    uint32_t            m_ExtraDataSize     = 0;
     Node *              m_Node              = nullptr;
     void *              m_Data              = nullptr;
     void *              m_UserData          = nullptr;

--- a/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/.clang-tidy
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/.clang-tidy
@@ -1,0 +1,7 @@
+Checks: '-*,cppcoreguidelines-init-variables'
+WarningsAsErrors: ''
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:
+...
+

--- a/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Include.h
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Include.h
@@ -1,0 +1,11 @@
+// This header file's only purpose is to add some lines to the translation unit
+// when included, to check that diagnostics have the correct line number shown
+// when using preprocessed + clang-tidy.
+
+void foo()
+{
+}
+
+void bar()
+{
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Warning.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Warning.cpp
@@ -1,3 +1,5 @@
+#include "Include.h"
+
 // Deliberate warning
 void X()
 {

--- a/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/fbuild.bff
@@ -45,3 +45,17 @@ ObjectList( 'WarningsAreCorrectlyReported-Clang' )
     .CompilerInputFiles     = 'Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Warning.cpp'
     .CompilerOutputPath     + 'Clang/'
 }
+
+// clang-tidy
+//------------------------------------------------------------------------------
+ObjectList( 'WarningsAreCorrectlyReported-ClangTidy')
+{
+    Using(.ToolChain_Clang_Windows)
+    .Preprocessor = .Compiler
+    .PreprocessorOptions = .CompilerOptions
+    .Compiler = 'Compiler-ClangTidy'
+    .CompilerInputFiles = 'Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/Warning.cpp'
+    .CompilerOutputPath + 'ClangTidy/'
+    .ClangTidyConfigurationFile = 'Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/.clang-tidy'
+    .CompilerOptions = '--config-file=Tools/FBuild/FBuildTest/Data/TestDistributed/WarningsAreCorrectlyReported/.clang-tidy --quiet "%1" -- "%2"'
+}

--- a/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/testcommon.bff
@@ -10,6 +10,7 @@
 #include "../../../../../External/SDK/VisualStudio/VisualStudio.bff"
 #include "../../../../../External/SDK/Clang/Clang.bff"
 #include "../../../../../External/SDK/Windows/Windows.bff"
+#include "../../../../../External/SDK/Clang/Windows/Clang-tidy.bff"
 
 #if __WINDOWS__
     .VisualStudioToolChain_X64  = .ToolChain_VS_Windows_X64

--- a/External/SDK/Clang/Windows/Clang-tidy.bff
+++ b/External/SDK/Clang/Windows/Clang-tidy.bff
@@ -1,0 +1,34 @@
+// Clang-tidy
+//------------------------------------------------------------------------------
+//
+// Detect Clang-tidy
+//
+// We search in the following locations, in order of preference:
+//  1) Part of a Visual Studio installation (Program Files)
+//  2) Default install location
+//
+#if file_exists( "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/LLVM/x64/bin/clang-tidy.exe" )
+    // Installed with VS2019
+    .ClangTidy_BasePath = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/LLVM/x64'
+#else
+    #if file_exists( "C:/Program Files/LLVM/bin/clang-tidy.exe" )
+        // Default Install
+        .ClangTidy_BasePath = 'C:/Program Files/LLVM'
+    #else
+        //
+        // Failed
+        //
+        Print( '----------------------------------------------------------------------' )
+        Print( '- Unable to auto-detect Clang-tidy - please specify installation manually -' )
+        Print( '----------------------------------------------------------------------' )
+        .ClangTidy_BasePath = .Set_Path_Here    // <-- Set path here
+    #endif
+#endif
+
+// Compiler
+//------------------------------------------------------------------------------
+Compiler( 'Compiler-ClangTidy' )
+{
+    .Root                           = '$ClangTidy_BasePath$'
+    .Executable                     = '$Root$\bin\clang-tidy.exe'
+}


### PR DESCRIPTION
# Description:

As hinted in #971, we did some groundwork to get `clang-tidy` distributed on fbuild.
This is largely based on work from @lovali during her internship.

_This PR is only a proof of concept_.

On huge projects such as Unreal games, analysis time is extremely long, to the point it's not usable by developers.
We're using it in our projects, but support may be lacking, and it's not the best implementation that can be done.
I had hoped that it would be simple, but it turns out `clang-tidy` has kind of bad support for some CLI shenanigans and its user interface is not as flexible as clang's, in our case.

## Big picture
By default, `clang-tidy` is expected to run on one or more files locally, optionally ran via a launcher script (LLVM provides `run-clang-tidy.py` to this effect). It will look for a `compile-commands.json` file in a parent directory, and try to find the compilation arguments associated to the filename it received in its arguments.
It will also look for a `.clang-tidy` file containing its settings (what checks to run, etc), or receive them via CLI.

When distributing, it's more complex to rely on this behaviour and we want to pass everything we can via CLI so that each job is self-contained and does not rely on the environment.
Unfortunately, since `clang-tidy` does not handle response files correctly (it can read its own arguments via rsp, but not pass an rsp to the underlying clang process), it's a bit complicated to go through the usual fbuild behaviour. Our workaround was to have one configuration file (including compilation arguments) pre-existing for each source file to analyze, and transfer it to the worker with the job data. The advantage is that we get the analysis settings by the way.

Another issue is https://github.com/llvm/llvm-project/issues/62405, `clang-tidy` does not handle diagnostics correctly on already preprocessed source files. To workaround that we added some logic in fbuild to fix filenames and line numbers in diagnostics (not in the fastest way, but simple enough).

Other than that, it works and we hope it can be an interesting addition to fbuild, especially if the implementation/usage can be improved.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
