### PR TITLE
Fix clang-cl cache according to https://github.com/fastbuild/fastbuild/issues/1015

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/ICache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/ICache.cpp
@@ -16,7 +16,7 @@
                                     AString & outCacheId )
 {
     // cache version - bump if cache format is changed
-    const char cacheVersion( 'E' );
+    const char cacheVersion( 'F' );
 
     // format example: 2377DE32AB045A2D_FED872A1_AB62FEAA23498AAC-32A2B04375A2D7DE.7
     outCacheId.Format( "%016" PRIX64 "_%08X_%016" PRIX64 "-%016" PRIX64 ".%c",

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1639,7 +1639,7 @@ void ObjectNode::GetExtraCacheFilePaths( const Job * job, Array< AString > & out
     const ObjectNode * objectNode = node->CastTo< ObjectNode >();
 
     // MSVC precompiled headers have an extra file
-    if ( objectNode->m_CompilerFlags.IsCreatingPCH() && objectNode->m_CompilerFlags.IsMSVC() )
+    if ( objectNode->m_CompilerFlags.IsCreatingPCH() && (objectNode->m_CompilerFlags.IsMSVC() || objectNode->m_CompilerFlags.IsClangCl()) )
     {
         // .pch.obj
         outFileNames.Append( m_PCHObjectFileName );

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestPrecompiledHeaders.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestPrecompiledHeaders.cpp
@@ -746,8 +746,10 @@ void TestPrecompiledHeaders::PrecompiledHeaderCacheAnalyze_MSVC() const
 
         AStackString<> obj( "../tmp/Test/PrecompiledHeaders/Clang-Windows/PCHUser.obj" );
         AStackString<> pch( "../tmp/Test/PrecompiledHeaders/Clang-Windows/PrecompiledHeader.pch" );
+        AStackString<> pch_obj( "../tmp/Test/PrecompiledHeaders/Clang-Windows/PrecompiledHeader.pch.obj" );
         EnsureFileDoesNotExist( obj );
         EnsureFileDoesNotExist( pch );
+        EnsureFileDoesNotExist( pch_obj );
 
         FBuild fBuild( options );
         TEST_ASSERT( fBuild.Initialize( nullptr ) );
@@ -759,6 +761,7 @@ void TestPrecompiledHeaders::PrecompiledHeaderCacheAnalyze_MSVC() const
 
         EnsureFileExists( obj );
         EnsureFileExists( pch );
+        EnsureFileExists( pch_obj );
 
         // Check stats
         //              Seen,   Built,  Type


### PR DESCRIPTION
Fix cache for clang-cl compiler

# Description:

This is a fix of the problem described in https://github.com/fastbuild/fastbuild/issues/1015

# Checklist:

The pull request:
- [ ] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**

**NOTE:** Compilation checked on Windows only