### PR TITLE
Files which are each other's substrings are sorted in Unity builds

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -133,10 +133,25 @@ bool UnityNode::UnityFileAndOrigin::operator < ( const UnityFileAndOrigin & othe
     }
 
     // Sort by name in directory
-    const size_t sortLen = Math::Min( GetName().GetLength() - m_LastSlashIndex, other.GetName().GetLength() - other.m_LastSlashIndex );
+    const size_t filenameLen = GetName().GetLength() - m_LastSlashIndex;
+    const size_t otherFilenameLen = other.GetName().GetLength() - other.m_LastSlashIndex;
+    const size_t sortLen = Math::Min( filenameLen, otherFilenameLen );
     const char * a = GetName().Get() + m_LastSlashIndex;
     const char * b = other.GetName().Get() + other.m_LastSlashIndex;
-    return ( AString::StrNCmpI( a, b, sortLen ) < 0 );
+    const int32_t sortOrder = AString::StrNCmpI( a, b, sortLen );
+
+    if ( sortOrder != 0 )
+    {
+        return ( sortOrder < 0 );
+    }
+
+    if ( filenameLen != otherFilenameLen ) {
+        return ( filenameLen < otherFilenameLen ); // Shorter path goes first, like for directories
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 // CONSTRUCTOR

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -145,7 +145,8 @@ bool UnityNode::UnityFileAndOrigin::operator < ( const UnityFileAndOrigin & othe
         return ( sortOrder < 0 );
     }
 
-    if ( filenameLen != otherFilenameLen ) {
+    if ( filenameLen != otherFilenameLen )
+    {
         return ( filenameLen < otherFilenameLen ); // Shorter path goes first, like for directories
     }
     else

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
@@ -800,6 +800,10 @@ void TestUnity::SortFiles() const
     SORT( "b.cpp", "A.cpp" );
     TEST( "A.cpp", "b.cpp" );
 
+    // Files whose paths are each other's substrings are sorted
+    SORT( "a/a.cpp", "a/a.c", "a/a.cp" );
+    TEST( "a/a.c", "a/a.cp", "a/a.cpp" );
+
     // Files in same dir
     SORT( "a/B.cpp", "a/a.cpp" );
     TEST( "a/a.cpp", "a/B.cpp" );


### PR DESCRIPTION
# Description:

Without this change Unity builds will not sort files where one is a prefix of another. For instance for the following set of files
```
/file.hpp
/file.h
/file
```
The order will be indeterminate as Unity builds would only check for equality up to the length of the shortest filename when comparing pairs of filenames.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation**
