### PR TITLE
Fix solution version written in the sln when using vs2022, so explorer shows vs2022 icon and vs version selector opens vs2022 and not vs2019

### DIFF
--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -175,7 +175,7 @@ Compiler( 'Compiler-VS2022-x64' )
 [
     .VS_Version                     = .VS2022_Version
     .VS_Version_HumanReadable       = '2022'
-    .VS_SolutionVersion             = '16.0.28701.123'
+    .VS_SolutionVersion             = '17'
     .MSC_VER                        = .VS2022_MSC_VER
     .VS_ToolchainPath               = .VS2022_ToolchainPath
     .ToolChain_VS_Windows_X64       = .ToolChain_VS2022_Windows_X64


### PR DESCRIPTION
Same as in VS2017.bff and VS2019.bff, we only write the major version in the field