### PR TITLE
Add worker cmdline -preferhostname for the broker filename to be the hostname instead of the IP Address

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.cpp
@@ -27,7 +27,8 @@ static const float sBrokerageIPAddressUpdateTime = ( 5 * 60.0f );
 
 // CONSTRUCTOR
 //------------------------------------------------------------------------------
-WorkerBrokerageServer::WorkerBrokerageServer()
+WorkerBrokerageServer::WorkerBrokerageServer( bool preferHostName )
+    : m_PreferHostName( preferHostName )
 {
     m_TimerLastUpdate.Start();
     m_TimerLastIPUpdate.Start();
@@ -226,7 +227,7 @@ void WorkerBrokerageServer::UpdateBrokerageFilePath()
 {
     if ( !m_BrokerageRoots.IsEmpty() )
     {
-        if ( !m_IPAddress.IsEmpty() )
+        if ( !m_PreferHostName && !m_IPAddress.IsEmpty() )
         {
             m_BrokerageFilePath.Format( "%s%s", m_BrokerageRoots[0].Get(), m_IPAddress.Get() );
         }

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.h
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerBrokerageServer.h
@@ -18,7 +18,7 @@
 class WorkerBrokerageServer : public WorkerBrokerage
 {
 public:
-    WorkerBrokerageServer();
+    WorkerBrokerageServer( bool preferHostName );
     ~WorkerBrokerageServer();
 
     void SetAvailability( bool available );
@@ -33,6 +33,7 @@ protected:
     Timer               m_TimerLastCleanBroker;
     uint64_t            m_SettingsWriteTime = 0; // FileTime of settings time when last changed
     bool                m_Available = false;
+    bool                m_PreferHostName = false;
     AString             m_BrokerageFilePath;
     AString             m_IPAddress;
     AString             m_DomainName;

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
@@ -32,7 +32,8 @@ FBuildWorkerOptions::FBuildWorkerOptions() :
     m_WorkMode( WorkerSettings::WHEN_IDLE ),
     m_MinimumFreeMemoryMiB( 0 ),
     m_ConsoleMode( false ),
-    m_PeriodicRestart( false )
+    m_PeriodicRestart( false ),
+    m_PreferHostName( false )
 {
     #ifdef __LINUX__
         m_ConsoleMode = true; // Only console mode supported on Linux
@@ -144,6 +145,11 @@ bool FBuildWorkerOptions::ProcessCommandLine( const AString & commandLine )
                 continue;
             }
         #endif
+        else if ( token == "-preferhostname" )
+        {
+            m_PreferHostName = true;
+            continue;
+        }
 
         ShowUsageError();
         return false;
@@ -181,6 +187,8 @@ void FBuildWorkerOptions::ShowUsageError()
                        "        (Windows) Don't spawn a sub-process worker copy.\n"
                        " -periodicrestart\n"
                        "        Worker will restart every 4 hours.\n"
+                       " -preferhostname\n"
+                       "        Broker filename will be the hostname instead of the IP Address.\n"
                        "---------------------------------------------------------------------------\n"
                        ;
 

--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.h
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.h
@@ -41,6 +41,7 @@ public:
 
     // Other
     bool m_PeriodicRestart;
+    bool m_PreferHostName;
 
 private:
     void ShowUsageError();

--- a/Code/Tools/FBuild/FBuildWorker/Main.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Main.cpp
@@ -126,7 +126,7 @@ int Main( const AString & args )
     // start the worker and wait for it to be closed
     int ret;
     {
-        Worker worker( args, options.m_ConsoleMode, options.m_PeriodicRestart );
+        Worker worker( args, options.m_ConsoleMode, options.m_PeriodicRestart, options.m_PreferHostName );
         if ( options.m_OverrideCPUAllocation )
         {
             WorkerSettings::Get().SetNumCPUsToUse( options.m_CPUAllocation );

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
@@ -41,12 +41,13 @@
 
 // CONSTRUCTOR
 //------------------------------------------------------------------------------
-Worker::Worker( const AString & args, bool consoleMode, bool periodicRestart )
+Worker::Worker( const AString & args, bool consoleMode, bool periodicRestart, bool preferHostName )
     : m_ConsoleMode( consoleMode )
     , m_PeriodicRestart( periodicRestart )
     , m_MainWindow( nullptr )
     , m_ConnectionPool( nullptr )
     , m_NetworkStartupHelper( nullptr )
+    , m_WorkerBrokerage( preferHostName )
     , m_BaseArgs( args )
     , m_LastWriteTime( 0 )
     , m_WantToQuit( false )

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.h
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.h
@@ -27,7 +27,7 @@ class WorkerSettings;
 class Worker : public Singleton<Worker>
 {
 public:
-    explicit Worker( const AString & args, bool consoleMode, bool periodicRestart );
+    explicit Worker( const AString & args, bool consoleMode, bool periodicRestart, bool preferHostName );
     ~Worker();
 
     int32_t Work();


### PR DESCRIPTION
# Description:

Add worker cmdline -preferhostname for the broker filename to be the hostname instead of the IP Address.

As in some cases, there can be multiple adapters on a particular machine that could resolve to an unreachable IP. For instance, I had a virtual one for Hyper-V.

This change leaves the resolve to windows and fixes my use case, but a change that would allow selecting the adapter used by the worker could also work.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [X] **Includes documentation**
