### PR TITLE
Add support for vs2022 to Github Actions CI

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -14,11 +14,17 @@ jobs:
       matrix:
         include:
           - cfg: Build & Tests
+            vs: 2022
+            os: windows-2022
+          - cfg: Build & Tests
             vs: 2019
             os: windows-2019
           - cfg: Build & Tests
             vs: 2017
             os: windows-2019
+          - cfg: Analyze
+            vs: 2022
+            os: windows-2022
           - cfg: Analyze
             vs: 2019
             os: windows-2019
@@ -31,9 +37,18 @@ jobs:
 
       - uses: ./.github/actions/DownloadFBuild
 
-      - name: Configure fbuild.bff
+      - name: Print embedded clang version from vs2019
+        if: matrix.os == 'windows-2019'
         run: |
           'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\LLVM\x64\bin\clang.exe' --version
+
+      - name: Print embedded clang version from vs2022
+        if: matrix.os == 'windows-2022'
+        run: |
+          'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\LLVM\x64\bin\clang.exe' --version
+
+      - name: Configure fbuild.bff
+        run: |
           # Inject "#define CI_BUILD" into root configs to activate CI logic.
           sed -i -e "1i\\
           #define CI_BUILD

--- a/Code/Core/Containers/Array.h
+++ b/Code/Core/Containers/Array.h
@@ -357,7 +357,7 @@ template < class U >
 T * Array< T >::Find( const U & obj ) const
 {
     T * pos = m_Begin;
-    T * endPos = pos + m_Size;
+    const T * endPos = pos + m_Size;
     while ( pos < endPos )
     {
         if ( *pos == obj )
@@ -452,7 +452,7 @@ template < class T >
 template < class U >
 void Array< T >::Append( const Array< U > & other )
 {
-    U* endPos = other.End();
+    const U* endPos = other.End();
     for ( U* it = other.Begin(); it != endPos; ++it )
     {
         Append( *it );

--- a/External/SDK/Clang/Clang.bff
+++ b/External/SDK/Clang/Clang.bff
@@ -51,7 +51,11 @@
 #endif
 #if __WINDOWS__
     #if CI_BUILD
-        #define USING_CLANG_11
+        #if USING_VS2022
+            #define USING_CLANG_17
+        #else
+            #define USING_CLANG_11
+        #endif
     #endif
     #if USING_CLANG_8
         #include "Windows/Clang8.bff"

--- a/External/SDK/Clang/Windows/Clang17.bff
+++ b/External/SDK/Clang/Windows/Clang17.bff
@@ -13,9 +13,9 @@
     .Clang17_BasePath   = '$_CURRENT_BFF_DIR_$/17.0.1'
     .Clang17_Version    = '17.0.1'
 #else
-    #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/LLVM/x64/bin/clang-cl.exe" )
+    #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/LLVM/x64/bin/clang-cl.exe" )
         // Installed with VS2022
-        .Clang17_BasePath = 'C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/LLVM/x64'
+        .Clang17_BasePath = 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/LLVM/x64'
         .Clang17_Version    = '17.x.x'
     #else
         #if file_exists( "C:/Program Files/LLVM/bin/clang-cl.exe" )

--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -38,11 +38,11 @@
             //
             // Use Visual Studio 2022 Enterprise installation (used by GitHub Actions)
             //
-            #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.38.33130/bin/Hostx64/x64/cl.exe" )
-                // v17.8.3
+            #if file_exists( "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe" )
+                // v17.10.3
                 .VS2022_BasePath        = 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC'
-                .VS2022_Version         = '14.38.33130'
-                .VS2022_MSC_VER         = '1938'
+                .VS2022_Version         = '14.40.33807'
+                .VS2022_MSC_VER         = '1940'
             #else
                 //
                 // Failed


### PR DESCRIPTION
# Description:

This fixes the paths so the Github Actions CI also run the builds, tests, and analyze with vs2022.

Note that it relies on the fix #1049

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [X] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation**
