### PR TITLE
Add support for C++ Dynamic Debugging introduced in Visual Studio 17.14 Preview 2

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/ICache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/ICache.cpp
@@ -16,7 +16,7 @@
                                     AString & outCacheId )
 {
     // cache version - bump if cache format is changed
-    const char cacheVersion( 'G' );
+    const char cacheVersion( 'H' );
 
     // format example: 2377DE32AB045A2D_FED872A1_AB62FEAA23498AAC-32A2B04375A2D7DE.7
     outCacheId.Format( "%016" PRIX64 "_%08X_%016" PRIX64 "-%016" PRIX64 ".%c",

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1036,13 +1036,16 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
         // 3) pch files can't be built from preprocessed output (disabled acceleration), so can't be distributed
         // 4) user only wants preprocessor step executed
         // 5) Distribution of /analyze is not currently supported due to preprocessor/_PREFAST_ inconsistencies
-        // 6) Source mappings are not currently forwarded so can only compiled locally
+        // 6) Distribution of /dynamicdeopt is not currently supported because old remote workers won't know to
+        //    return the extra obj files.
+        // 7) Source mappings are not currently forwarded so can only compiled locally
         if ( !usingCLR && !usingPreprocessorOnly )
         {
             if ( isDistributableCompiler &&
                  !usingWinRT &&
                  !( flags.IsCreatingPCH() )&&
                  !( flags.IsUsingStaticAnalysisMSVC() ) &&
+                 !( flags.IsUsingDynamicDeopt() ) &&
                  !hasSourceMapping )
             {
                 flags.Set( CompilerFlags::FLAG_CAN_BE_DISTRIBUTED );

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1024,6 +1024,10 @@ bool ObjectNode::ProcessIncludesWithPreProcessor( Job * job )
                     flags.Set( CompilerFlags::FLAG_STATIC_ANALYSIS_MSVC );
                 }
             }
+            else if ( IsStartOfCompilerArg_MSVC( token, "dynamicdeopt" ) )
+            {
+                flags.Set( CompilerFlags::FLAG_DYNAMIC_DEOPT );
+            }
         }
 
         // 1) clr code cannot be distributed due to a compiler bug where the preprocessed using
@@ -1324,6 +1328,20 @@ void ObjectNode::GetGCNOPath( AString & gcnoFileName ) const
     const char * extPos = m_Name.FindLast( '.' ); // Only last extension removed
     gcnoFileName.Assign( m_Name.Get(), extPos ? extPos : m_Name.GetEnd() );
     gcnoFileName += ".gcno";
+}
+
+// GetAltObjPath
+//------------------------------------------------------------------------------
+void ObjectNode::GetAltObjPath( AString& altObjName ) const
+{
+    ASSERT( IsUsingDynamicDeopt() );
+
+    const AString & sourceName = m_PCHObjectFileName.IsEmpty() ? m_Name : m_PCHObjectFileName;
+
+    // TODO:B The suffix ('.alt') can be manually specified with /dynamicdeopt:suffix
+    const char * extPos = sourceName.FindLast( '.' ); // Only last extension removed
+    altObjName.Assign( sourceName.Get(), extPos ? extPos : sourceName.GetEnd() );
+    altObjName += ".alt.obj";
 }
 
 // GetObjExtension
@@ -1711,6 +1729,15 @@ void ObjectNode::GetExtraCacheFilePaths( const Job * job, Array< AString > & out
         AStackString<> gcnoFileName;
         GetGCNOPath( gcnoFileName );
         outFileNames.Append( gcnoFileName );
+    }
+
+    // MSVC dynamic deoptimization adds extra files
+    if ( objectNode->m_CompilerFlags.IsUsingDynamicDeopt() )
+    {
+        // .alt.obj
+        AStackString<> altObjName;
+        GetAltObjPath( altObjName );
+        outFileNames.Append( altObjName );
     }
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -77,6 +77,7 @@ public:
         bool IsWarningsAsErrorsClangGCC() const     { return ( ( m_Flags & FLAG_WARNINGS_AS_ERRORS_CLANGGCC ) != 0 ); }
         bool IsClangCl() const                      { return ( ( m_Flags & FLAG_CLANG_CL ) != 0 ); }
         bool IsUsingGcovCoverage() const            { return ( ( m_Flags & FLAG_GCOV_COVERAGE ) != 0 ); }
+        bool IsUsingDynamicDeopt() const            { return ( ( m_Flags & FLAG_DYNAMIC_DEOPT ) != 0 ); }
 
         enum Flag : uint32_t
         {
@@ -105,6 +106,7 @@ public:
             FLAG_WARNINGS_AS_ERRORS_CLANGGCC    = 0x1000000,
             FLAG_CLANG_CL                       = 0x2000000,
             FLAG_GCOV_COVERAGE                  = 0x4000000,
+            FLAG_DYNAMIC_DEOPT                  = 0x8000000,
         };
 
         void Set( Flag flag )       { m_Flags |= flag; }
@@ -145,6 +147,7 @@ public:
     bool IsOrbisWavePSSLC() const           { return m_CompilerFlags.IsOrbisWavePSSLC(); }
     bool IsWarningsAsErrorsClangGCC() const { return m_CompilerFlags.IsWarningsAsErrorsClangGCC(); }
     bool IsUsingGcovCoverage() const        { return m_CompilerFlags.IsUsingGcovCoverage(); }
+    bool IsUsingDynamicDeopt() const        { return m_CompilerFlags.IsUsingDynamicDeopt(); }
 
     virtual void SaveRemote( IOStream & stream ) const override;
     static Node * LoadRemote( IOStream & stream );
@@ -160,6 +163,7 @@ public:
     void GetPDBName( AString & pdbName ) const;
     void GetNativeAnalysisXMLPath( AString& outXMLFileName ) const;
     void GetGCNOPath( AString & gcnoFileName ) const;
+    void GetAltObjPath( AString& altObjName ) const;
 
     const char * GetObjExtension() const;
 

--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -69,7 +69,6 @@ Compiler( 'Compiler-VS2022-x64' )
     .ExtraFiles = { '$Root$/c1.dll'
                     '$Root$/c1xx.dll',
                     '$Root$/c2.dll',
-                    '$Root$/c2dd.dll' // Added in 17.14
                     '$Root$/msobj140.dll'
                     '$Root$/mspdb140.dll'
                     '$Root$/mspdbcore.dll'

--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -69,6 +69,7 @@ Compiler( 'Compiler-VS2022-x64' )
     .ExtraFiles = { '$Root$/c1.dll'
                     '$Root$/c1xx.dll',
                     '$Root$/c2.dll',
+                    '$Root$/c2dd.dll' // Added in 17.14
                     '$Root$/msobj140.dll'
                     '$Root$/mspdb140.dll'
                     '$Root$/mspdbcore.dll'


### PR DESCRIPTION
# Description:
Add support for C++ Dynamic Debugging introduced in Visual Studio 17.14 Preview 2.
I'm a developer from Microsoft Visual C++ team. We are working on the [C++ Dynamic Debugging](https://aka.ms/vcdd)  feature which was [announced](https://aka.ms/dynamicdebugging) recently.
We worked with various build engines to add support for this feature. This PR allows FastBuild to support various files introduced by the feature. This initial change disables distributed build if the feature is enabled to keep backward compatibility (old remote worker won't copy the extra files back).
If you have any questions, we can discuss the details here or via email.

# Checklist:

The pull request:
- [ x ] **Is created against the Dev branch**
- [ x ] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
I built on Windows only.
Does the validation pipeline build on other platforms? The added code is C++ standard conformant and doesn't rely on a specific OS or compiler to compile. So, I don't expect any build issue.
- [ ] **Has accompanying tests**
The feature requires 17.14 Preview 2. Looks that the test environment used by the repo only has 17.10.
We tested the change in an internal fork. Let me know how you want to proceed.
- [ x ] **Passes existing tests**
- [ x ] **Keeps Windows, OSX and Linux at parity**
- [ x ] **Follows the code style**
- [ ] **Includes documentation**
We can discuss how we want to document this support.