### PR TITLE
Add new UseDeterministicPaths_Experimental flag to CompilerNode

### DIFF
--- a/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
+++ b/Code/Tools/FBuild/Documentation/docs/functions/compiler.html
@@ -54,6 +54,7 @@ distribution, caching and more.
   // Temporary Options
   .UseLightCache_Experimental   // (optional) Enable experimental "light" caching mode (default: false)
   .UseRelativePaths_Experimental// (optional) Enable experimental relative path use (default: false)
+  .UseDeterministicPaths_Experimental// (optional) Enable experimental deterministic path use (default: false)
   .SourceMapping_Experimental   // (optional) Use Clang's -fdebug-source-map option to remap source files
   .ClangFixupUnity_Disable      // (optional) Disable preprocessor fixup for Unity files (default: false)
 }
@@ -399,6 +400,11 @@ Compiler( 'Compiler-x64Intel' )
     <p><font color=red>NOTE:</font> This feature is incomplete and should not be used.</p>
 
   	<p><hr></p>
+
+    <p><b>.UseDeterministicPaths_Experimental</b> - Boolean - (Optional)</p>
+    <p>When set, temporary directories created to store preprocessed sources have deterministic paths, helping ensure compiler outputs are deterministic.</p>
+
+    <p><hr></p>
 
   <p><b>.SourceMapping_Experimental</b> - String - (Optional)</p>
   <p>Provides a new root to remap source file paths to so they are recorded in the debugging information as if they were stored under the new root. For example, if $_WORKING_DIR_$ is "/path/to/original", a source file "src/main.cpp" would normally be recorded as being stored under "/path/to/original/src/main.cpp", but with .SourceMapping_Experimental='/another/root' it would be recorded as "/another/root/src/main.cpp" instead.</p>

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -33,6 +33,7 @@ REFLECT_NODE_BEGIN( CompilerNode, Node, MetaNone() )
     REFLECT_ARRAY( m_Environment,   "Environment",          MetaOptional() )
     REFLECT( m_UseLightCache,       "UseLightCache_Experimental", MetaOptional() )
     REFLECT( m_UseRelativePaths,    "UseRelativePaths_Experimental", MetaOptional() )
+    REFLECT( m_UseDeterministicPaths, "UseDeterministicPaths_Experimental", MetaOptional() )
     REFLECT( m_SourceMapping,       "SourceMapping_Experimental", MetaOptional() )
 
     // Internal
@@ -56,6 +57,7 @@ CompilerNode::CompilerNode()
     , m_SimpleDistributionMode( false )
     , m_UseLightCache( false )
     , m_UseRelativePaths( false )
+    , m_UseDeterministicPaths( false )
     , m_EnvironmentString( nullptr )
 {
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.h
@@ -30,6 +30,7 @@ public:
     inline bool SimpleDistributionMode() const { return m_SimpleDistributionMode; }
     inline bool GetUseLightCache() const { return m_UseLightCache; }
     inline bool GetUseRelativePaths() const { return m_UseRelativePaths; }
+    inline bool GetUseDeterministicPaths() const { return m_UseDeterministicPaths; }
     inline bool CanBeDistributed() const { return m_AllowDistribution; }
     inline bool CanUseResponseFile() const { return m_AllowResponseFile; }
     inline bool ShouldForceResponseFileUse() const { return m_ForceResponseFile; }
@@ -85,6 +86,7 @@ private:
     bool                    m_SimpleDistributionMode;
     bool                    m_UseLightCache;
     bool                    m_UseRelativePaths;
+    bool                    m_UseDeterministicPaths;
     ToolManifest            m_Manifest;
     Array< AString >        m_Environment;
     AString                 m_SourceMapping;

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -64,7 +64,7 @@ public:
     }
     inline ~NodeGraphHeader() = default;
 
-    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 176 };
+    enum : uint8_t { NODE_GRAPH_CURRENT_VERSION = 177 };
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == NODE_GRAPH_CURRENT_VERSION; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1382,26 +1382,7 @@ const AString & ObjectNode::GetCacheName( Job * job ) const
 
     // hash the build "environment"
     // TODO:B Exclude preprocessor control defines (the preprocessed input has considered those already)
-    uint32_t commandLineKey;
-    {
-        Args args;
-        const bool useDeoptimization = false;
-        const bool showIncludes = false;
-        const bool useSourceMapping = false; // Source mapping compiler flags contain local paths, so we treat them specially
-        const bool finalize = false; // Don't write args to response file
-        BuildArgs( job, args, PASS_COMPILE_PREPROCESSED, useDeoptimization, showIncludes, useSourceMapping, finalize );
-
-        if ( job->IsLocal() )
-        {
-            // Append the source mapping destination only, so different machines with different
-            // working directory local paths compute consistent keys.
-            const AString & sourceMapping = job->GetNode()->CastTo<ObjectNode>()->GetCompiler()->GetSourceMapping();
-            args.AddDelimiter();
-            args += sourceMapping;
-        }
-
-        commandLineKey = xxHash::Calc32( args.GetRawArgs().Get(), args.GetRawArgs().GetLength() );
-    }
+    uint32_t commandLineKey = GetCommandLineKey( job );
     ASSERT( commandLineKey );
 
     // ToolChain hash
@@ -1421,6 +1402,29 @@ const AString & ObjectNode::GetCacheName( Job * job ) const
     job->SetCacheName(cacheName);
 
     return job->GetCacheName();
+}
+
+// GetCommandLineKey
+//------------------------------------------------------------------------------
+uint32_t ObjectNode::GetCommandLineKey( Job * job ) const
+{
+    Args args;
+    const bool useDeoptimization = false;
+    const bool showIncludes = false;
+    const bool useSourceMapping = false; // Source mapping compiler flags contain local paths, so we treat them specially
+    const bool finalize = false; // Don't write args to response file
+    BuildArgs( job, args, PASS_COMPILE_PREPROCESSED, useDeoptimization, showIncludes, useSourceMapping, finalize );
+
+    if ( job->IsLocal() )
+    {
+        // Append the source mapping destination only, so different machines with different
+        // working directory local paths compute consistent keys.
+        const AString& sourceMapping = job->GetNode()->CastTo<ObjectNode>()->GetCompiler()->GetSourceMapping();
+        args.AddDelimiter();
+        args += sourceMapping;
+    }
+
+    return xxHash::Calc32( args.GetRawArgs().Get(), args.GetRawArgs().GetLength() );
 }
 
 // RetrieveFromCache
@@ -2199,7 +2203,22 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
         dataToWriteSize = c.GetResultSize();
     }
 
-    WorkerThread::GetTempFileDirectory( tmpDirectory );
+    const CompilerNode * compiler = job->GetNode()->CastTo<ObjectNode>()->GetCompiler();
+    if ( ( compiler != nullptr ) && ( compiler->GetUseDeterministicPaths() ) )
+    {
+        VERIFY( FBuild::GetTempDir( tmpDirectory ) );
+        #if defined( __WINDOWS__ )
+            tmpDirectory += ".fbuild.tmp\\";
+        #else
+            tmpDirectory += "_fbuild.tmp/";
+        #endif
+        tmpDirectory.AppendFormat( "%08X-", GetCommandLineKey( job ) );
+    }
+    else
+    {
+        WorkerThread::GetTempFileDirectory( tmpDirectory );
+    }
+
     tmpDirectory.AppendFormat( "%08X%c", sourceNameHash, NATIVE_SLASH );
     if ( FileIO::DirectoryCreate( tmpDirectory ) == false )
     {

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -1382,7 +1382,7 @@ const AString & ObjectNode::GetCacheName( Job * job ) const
 
     // hash the build "environment"
     // TODO:B Exclude preprocessor control defines (the preprocessed input has considered those already)
-    uint32_t commandLineKey = GetCommandLineKey( job );
+    const uint32_t commandLineKey = GetCommandLineKey( job );
     ASSERT( commandLineKey );
 
     // ToolChain hash

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -205,6 +205,7 @@ private:
     bool ProcessIncludesWithPreProcessor( Job * job );
 
     const AString & GetCacheName( Job * job ) const;
+    uint32_t GetCommandLineKey( Job * job ) const;
     bool RetrieveFromCache( Job * job );
     void WriteToCache_FromDisk( Job * job );
     void WriteToCache_FromUncompressedData( Job * job,

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestDistributed.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestDistributed.cpp
@@ -306,7 +306,7 @@ void TestDistributed::ErrorsAreCorrectlyReported_Clang() const
     TEST_ASSERT( false == fBuild.Build( "ErrorsAreCorrectlyReported-Clang" ) );
 
     // Check that error is returned
-    TEST_ASSERT( GetRecordedOutput().Find( "fatal error: expected ';' at end of declaration" ) );
+    TEST_ASSERT( GetRecordedOutput().Find( "error: expected ';' at end of declaration" ) );
 }
 
 // WarningsAreCorrectlyReported_MSVC


### PR DESCRIPTION
# Description:

This PR is a first step towards supporting deterministic builds.

The key issue that this change solves is the source filenames that Clang and other compilers embed in object files. When building a preprocessed file, FASTBuild used to create a temporary directory with a name that depended on the CPU core that was executing the build step, resulting in different build outputs across runs. With this change, the user can ask for those temporary directories to have a deterministic name that is based on the hash of the compiler command line.

No new tests are added because it wasn't clear how to test this functionality in an automated way.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [X] **Includes documentation**
