### PR TITLE
Sort directory list node files for determinism

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
@@ -235,6 +235,21 @@ DirectoryListNode::~DirectoryListNode() = default;
         // Transfer ownership of filtered list
         m_Files = Move( helper.GetFiles() );
         m_Directories = Move( helper.GetDirectories() );
+
+        // Sort the lists alphabetically, for determinism. Some filesystems do not guarantee
+        // the order in which files are returned during directory scans, so we sort them to
+        // make sure the order in which files appear on the list is consistent across machines
+        class FileSorter
+        {
+        public:
+            bool operator () ( const FileIO::FileInfo & a, const FileIO::FileInfo & b ) const
+            {
+                return ( a.m_Name < b.m_Name );
+            }
+        };
+
+        m_Files.Sort( FileSorter() );
+        m_Directories.Sort();
     }
 
     MakePrettyName();


### PR DESCRIPTION
# Description:

This change makes `DirectoryListNode` sort the lists of files and directories that it has found in the filesystem. Sorting these lists is important for determinism because some filesystems (in particular, Linux filesystems) do not guarantee any particular ordering when scanning the contents of a directory. The directory entries will probably be returned in the order in which they were inserted into the directory file, which can vary across machines.

This helps make `Library` target outputs deterministic, because some librarians (like GNU `ar`) will add library members in the order in which they were specified in the command line, and that order will be the order in which `DirectoryListNode` provides the filenames found in the directories listed in `.CompilerInputPath`. By sorting the filenames, different machines that wrote entries to disk in different orders will produce bit-identical library outputs.

Currently, this sorts the lists unconditionally, even if the output of the nodes that use these listings does not change based on the order. In the future, perhaps an optimization could be done where each node (like `Library` and `ObjectList` nodes) specifies that they want sorted directory listings, while others can specify that they don't care and we leave them unsorted. But typically directory scans are heavily disk I/O bound so the unconditional sort may never be a performance problem.

With the changes from #1070 , #1071 , and #1072 together - plus the use of the existing `.UseRelativePaths_Experimental` - our 250KLOC+ codebase is able to generate fully deterministic binaries on Linux across machines that use different workspace roots, while simultaneously getting cache hits across those machines.

# Checklist:

The pull request:
- [X] **Is created against the Dev branch**
- [X] **Is self-contained**
- [X] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests** (the existing `TestDirectoryList` tests already cover this functionality)
- [X] **Passes existing tests**
- [X] **Keeps Windows, OSX and Linux at parity**
- [X] **Follows the code style**
- [ ] **Includes documentation** (no documentation added, as I did not know if improvements in determinism should be mentioned explicitly outside of the usual release notes)
