### PR TITLE
Fix JobQueueRemote::ReadResults error handling.

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/JobQueueRemote.cpp
@@ -483,6 +483,7 @@ void JobQueueRemote::FinishedProcessingJob( Job * job, Node::BuildResult result 
     {
         job->Error( "Error reading file: '%s'", fileNames[ problemFileIndex ].Get() );
         FLOG_ERROR( "Error reading file: '%s'", fileNames[ problemFileIndex ].Get() );
+        return false;
     }
 
     // Compress result


### PR DESCRIPTION
# Description:

- Prior to [`466a542`](https://github.com/fastbuild/fastbuild/commit/466a542c3be2e42ae2063234d9787f356002b9f8) `JobQueueRemote::ReadResults` would [return early](https://github.com/fastbuild/fastbuild/commit/466a542c3be2e42ae2063234d9787f356002b9f8#diff-87b2490a001cfb6e450a672dd355ba2261b510de59dfaeeb420fd8f2ce328047L465) if filesystem errors occurred. This PR reinstates the behaviour.
- Shortly after bumping to `v1.15` we encountered various problems related to corrupted output on remote workers (see snippet below). In the process of diffing which code-change may have caused this I noticed that this particular function was missing an early return. Currently we've reverted to using `v1.14` with no issues. Doubt that this PR fixes the corruption but felt like making sure it was upstreamed regardless as it seems to be an oversight.

```
27>ld.lld: error: /build/games/Games/Engine/Plugins/[redacted]/Intermediate/Build/Linux/x64/UnrealEditor/Development/[redacted]/amd_l_defaults.c.o:1: unknown directive: 8z
  >>> 8z27>Execution failed. Error: 1 (0x01) Target: '/build/games/Games/Engine/Plugins/[redacted]/Binaries/Linux/libUnrealEditor-EmbarkRBD.so'
```

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [x] **Includes documentation** (n/a)
