### PR TITLE
[Improvement] Greatly improve OSX process management

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -25,6 +25,7 @@
     #include <errno.h>
     #include <fcntl.h>
     #include <signal.h>
+    #include <spawn.h>
     #include <stdio.h>
     #include <stdlib.h>
     #include <string.h>
@@ -370,6 +371,42 @@ bool Process::Spawn( const char * executable,
     }
     envVector.Append( nullptr ); // env must be terminated with a nullptr
 
+    char * const * argV = const_cast<char * const *>( argVector.Begin() );
+    char * const * envV = const_cast<char * const *>( environment ? envVector.Begin() : nullptr );
+
+    // Use posix_spawn when available and safe to improve process spawning
+    // performance.
+    // TODO:B Test on Linux and allow use there
+    #if defined( __APPLE__ )
+    if ( CanUsePosixSpawn( workingDir ) )
+    {
+        return SpawnUsingPosixSpawn( stdOutPipeFDs,
+                                     stdErrPipeFDs,
+                                     executable,
+                                     argV,
+                                     workingDir,
+                                     envV );
+    }
+    #endif
+
+    return SpawnUsingFork( stdOutPipeFDs,
+                           stdErrPipeFDs,
+                           executable,
+                           argV,
+                           workingDir,
+                           envV );
+#endif
+}
+
+//------------------------------------------------------------------------------
+#if defined( __LINUX__ ) || defined( __APPLE__ )
+bool Process::SpawnUsingFork( int32_t stdOutPipeFDs[ 2 ],
+                              int32_t stdErrPipeFDs[ 2 ],
+                              const char * executable,
+                              char * const * argV,
+                              const char * workingDir,
+                              char * const * envV )
+{
     // fork the process
     const pid_t childProcessPid = fork();
     if ( childProcessPid == -1 )
@@ -406,10 +443,8 @@ bool Process::Spawn( const char * executable,
         }
 
         // transfer execution to new executable
-        char * const * argV = (char * const *)argVector.Begin();
-        if ( environment )
+        if ( envV )
         {
-            char * const * envV = (char * const *)envVector.Begin();
             execve( executable, argV, envV );
         }
         else
@@ -435,10 +470,112 @@ bool Process::Spawn( const char * executable,
         m_HasAlreadyWaitTerminated = false;
         return true;
     }
-#else
-    #error Unknown platform
-#endif
 }
+#endif
+
+//------------------------------------------------------------------------------
+#if defined( __APPLE__ )
+// Safe use of posix_spawn requires posix_spawn_file_actions_addchdir_np if
+// the working dir needs to be set
+bool Process::CanUsePosixSpawn( const char * workingDir ) const
+{
+    // OSX
+    #if defined( __aarch64__ )
+    // ARM is OSX 11 or later and has posix_spawn_file_actions_addchdir_np
+    (void)workingDir;
+    return true;
+    #else
+    // If we don't actually need to set the working dir, we don't need the action
+    // TODO: We could dynamically check for the symbol
+    return ( workingDir == nullptr );
+    #endif
+}
+#endif
+
+//------------------------------------------------------------------------------
+#if defined( __APPLE__ )
+bool Process::SpawnUsingPosixSpawn( int32_t stdOutPipeFDs[ 2 ],
+                                    int32_t stdErrPipeFDs[ 2 ],
+                                    const char * executable,
+                                    char * const * argV,
+                                    const char * workingDir,
+                                    char * const * envV )
+{
+    ASSERT( CanUsePosixSpawn( workingDir ) ); // Should not get here if not safe
+
+    // Create spawn actions
+    posix_spawn_file_actions_t spawnFileActions;
+    VERIFY( posix_spawn_file_actions_init( &spawnFileActions ) == 0 );
+
+    // Child will dup2 pipes
+    VERIFY( posix_spawn_file_actions_adddup2( &spawnFileActions, stdOutPipeFDs[ 1 ], STDOUT_FILENO ) == 0 );
+    VERIFY( posix_spawn_file_actions_adddup2( &spawnFileActions, stdErrPipeFDs[ 1 ], STDERR_FILENO ) == 0 );
+
+    // Child will close the original pipes we don't want inherited, but will
+    // keep dup2'd handles
+    VERIFY( posix_spawn_file_actions_addclose( &spawnFileActions, stdOutPipeFDs[ 0 ] ) == 0 );
+    VERIFY( posix_spawn_file_actions_addclose( &spawnFileActions, stdOutPipeFDs[ 1 ] ) == 0 );
+    VERIFY( posix_spawn_file_actions_addclose( &spawnFileActions, stdErrPipeFDs[ 0 ] ) == 0 );
+    VERIFY( posix_spawn_file_actions_addclose( &spawnFileActions, stdErrPipeFDs[ 1 ] ) == 0 );
+
+    // Child will set working dir if needed
+    if ( workingDir )
+    {
+    #if defined( __OSX__ ) && defined( __aarch64__ )
+        // OSX ARM has at least OSX 11.0 which has posix_spawn_file_actions_addchdir_np
+        VERIFY( posix_spawn_file_actions_addchdir_np( &spawnFileActions, workingDir ) == 0 );
+    #else
+        // We should not be calling this function if we want to set a working dir
+        // but can't safely do so using posix_spawn_file_actions_addchdir_np
+        ASSERT( false );
+    #endif
+    }
+
+    // Create spawn attributes
+    posix_spawnattr_t spawnAttributes;
+    VERIFY( posix_spawnattr_init( &spawnAttributes ) == 0 );
+
+    // Child will put itself into its own process group.
+    // This allows us to send signals to the group to implement KillProcessTree.
+    VERIFY( posix_spawnattr_setpgroup( &spawnAttributes, 0 ) == 0 );
+    const int16_t flags = POSIX_SPAWN_SETPGROUP;
+    VERIFY( posix_spawnattr_setflags( &spawnAttributes, flags ) == 0 );
+
+    // Spawn process
+    pid_t childProcessPid = -1;
+    const int32_t result = posix_spawn( &childProcessPid,
+                                        executable,
+                                        &spawnFileActions,
+                                        &spawnAttributes,
+                                        argV,
+                                        envV );
+
+    // Free attributes and actions
+    VERIFY( posix_spawnattr_destroy( &spawnAttributes ) == 0 );
+    VERIFY( posix_spawn_file_actions_destroy( &spawnFileActions ) == 0 );
+
+    // Close write pipes (we never write anything)
+    VERIFY( close( stdOutPipeFDs[ 1 ] ) == 0 );
+    VERIFY( close( stdErrPipeFDs[ 1 ] ) == 0 );
+
+    if ( result != 0 )
+    {
+        // Close read pipes
+        VERIFY( close( stdOutPipeFDs[ 0 ] ) == 0 );
+        VERIFY( close( stdErrPipeFDs[ 0 ] ) == 0 );
+        return false; // Failed to spawn
+    }
+
+    // Keep pipes for reading child process
+    m_StdOutRead = stdOutPipeFDs[ 0 ];
+    m_StdErrRead = stdErrPipeFDs[ 0 ];
+    m_ChildPID = static_cast<int32_t>( childProcessPid );
+
+    m_Started = true;
+    m_HasAlreadyWaitTerminated = false;
+    return true;
+}
+#endif
 
 // IsRunning
 //----------------------------------------------------------
@@ -758,10 +895,12 @@ void Process::Read( int32_t stdOutHandle,
 {
     PROFILE_FUNCTION;
 
-    // Break periodically when there is no data so caller can check timeout
+    // Break periodically so caller can:
+    // - check timeouts (if used)
+    // - terminate process if cancelling
     timeval timeout;
     timeout.tv_sec = 0;
-    timeout.tv_usec = 16000; // 16ms
+    timeout.tv_usec = 500 * 1000; // 500ms
 
     // any data available in either handle?
     fd_set fdSet;

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -43,6 +43,24 @@ public:
     [[nodiscard]] static uint32_t GetCurrentId();
 
 private:
+#if defined( __APPLE__ ) || defined( __LINUX__ )
+    [[nodiscard]] bool SpawnUsingFork( int32_t stdOutPipeFDs[ 2 ],
+                                       int32_t stdErrPipeFDs[ 2 ],
+                                       const char * executable,
+                                       char * const * argV,
+                                       const char * workingDir,
+                                       char * const * envV );
+#endif
+#if defined( __APPLE__ )
+    [[nodiscard]] bool CanUsePosixSpawn( const char * workingDir ) const;
+    [[nodiscard]] bool SpawnUsingPosixSpawn( int32_t stdOutPipeFDs[ 2 ],
+                                             int32_t stdErrPipeFDs[ 2 ],
+                                             const char * executable,
+                                             char * const * argV,
+                                             const char * workingDir,
+                                             char * const * envV );
+#endif
+
 #if defined( __WINDOWS__ )
     void KillProcessTreeInternal( const void * hProc, // HANDLE
                                   const uint32_t processID,

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -49,8 +49,16 @@ private:
                                   const uint64_t processCreationTime );
     [[nodiscard]] static uint64_t GetProcessCreationTime( const void * hProc ); // HANDLE
     void Read( void * handle, AString & buffer );
+#elif defined( __APPLE__ )
+    void Read( int32_t stdOutHandle,
+               int32_t stdErrHandle,
+               AString & inoutOutBuffer,
+               AString & inoutErrBuffer );
 #else
     void Read( int handle, AString & buffer );
+#endif
+#if defined( __LINUX__ ) || defined( __APPLE__ )
+    void ReadCommon( int32_t handle, AString & inoutBuffer );
 #endif
 
     void Terminate();

--- a/External/SDK/Clang/OSX/Clang12.bff
+++ b/External/SDK/Clang/OSX/Clang12.bff
@@ -77,6 +77,7 @@ Compiler( 'Compiler-Clang12' )
     .Platform                       = 'x64OSX'
     .CompilerOptions                + ' -arch x86_64 -mmacosx-version-min=10.7'
     .CompilerOptionsC               + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .PCHOptions                     + ' -arch x86_64 -mmacosx-version-min=10.7'
     .LinkerOptions                  + ' -arch x86_64 -mmacosx-version-min=10.7'
 ]
 
@@ -88,6 +89,7 @@ Compiler( 'Compiler-Clang12' )
     .Platform                       = 'ARMOSX'
     .CompilerOptions                + ' -arch arm64 -mmacosx-version-min=11.0'
     .CompilerOptionsC               + ' -arch arm64 -mmacosx-version-min=11.0'
+    .PCHOptions                     + ' -arch arm64 -mmacosx-version-min=11.0'
     .LinkerOptions                  + ' -arch arm64 -mmacosx-version-min=11.0'
 ]
 

--- a/External/SDK/Clang/OSX/Clang12.bff
+++ b/External/SDK/Clang/OSX/Clang12.bff
@@ -31,7 +31,6 @@ Compiler( 'Compiler-Clang12' )
                                     + ' -g'             // Generate debug info
                                     + ' -D__OSX__'      // Platform define
                                     + ' -D__APPLE__'    // Platform define
-                                    + ' -mmacosx-version-min=10.7'
 
                                     // Include paths
                                     + ' -I./'
@@ -61,7 +60,6 @@ Compiler( 'Compiler-Clang12' )
     .LinkerOptions                  = '"%1" -o "%2" -g'
                                     + ' -Wl,-fatal_warnings'
                                     + ' -Wl,-dead_strip'
-                                    + ' -mmacosx-version-min=10.7'
 
     // File Extensions
     .LibExtension                   = '.a'
@@ -77,9 +75,9 @@ Compiler( 'Compiler-Clang12' )
 
     // Intel 64-bit
     .Platform                       = 'x64OSX'
-    .CompilerOptions                + ' -arch x86_64'
-    .CompilerOptionsC               + ' -arch x86_64'
-    .LinkerOptions                  + ' -arch x86_64'
+    .CompilerOptions                + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .CompilerOptionsC               + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .LinkerOptions                  + ' -arch x86_64 -mmacosx-version-min=10.7'
 ]
 
 .ToolChain_Clang_ARMOSX =
@@ -88,9 +86,9 @@ Compiler( 'Compiler-Clang12' )
 
     // Apple ARM Silicon
     .Platform                       = 'ARMOSX'
-    .CompilerOptions                + ' -arch arm64'
-    .CompilerOptionsC               + ' -arch arm64'
-    .LinkerOptions                  + ' -arch arm64'
+    .CompilerOptions                + ' -arch arm64 -mmacosx-version-min=11.0'
+    .CompilerOptionsC               + ' -arch arm64 -mmacosx-version-min=11.0'
+    .LinkerOptions                  + ' -arch arm64 -mmacosx-version-min=11.0'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -75,6 +75,7 @@ Compiler( 'Compiler-Clang12' )
     .Platform                       = 'x64OSX'
     .CompilerOptions                + ' -arch x86_64 -mmacosx-version-min=10.7'
     .CompilerOptionsC               + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .PCHOptions                     + ' -arch x86_64 -mmacosx-version-min=10.7'
     .LinkerOptions                  + ' -arch x86_64 -mmacosx-version-min=10.7'
 ]
 
@@ -86,6 +87,7 @@ Compiler( 'Compiler-Clang12' )
     .Platform                       = 'ARMOSX'
     .CompilerOptions                + ' -arch arm64 -mmacosx-version-min=11.0'
     .CompilerOptionsC               + ' -arch arm64 -mmacosx-version-min=11.0'
+    .PCHOptions                     + ' -arch arm64 -mmacosx-version-min=11.0'
     .LinkerOptions                  + ' -arch arm64 -mmacosx-version-min=11.0'
 ]
 

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -29,7 +29,6 @@ Compiler( 'Compiler-Clang12' )
                                     + ' -g'             // Generate debug info
                                     + ' -D__OSX__'      // Platform define
                                     + ' -D__APPLE__'    // Platform define
-                                    + ' -mmacosx-version-min=10.7'
 
                                     // Include paths
                                     + ' -I./'
@@ -59,7 +58,6 @@ Compiler( 'Compiler-Clang12' )
     .LinkerOptions                  = '"%1" -o "%2" -g'
                                     + ' -Wl,-fatal_warnings'
                                     + ' -Wl,-dead_strip'
-                                    + ' -mmacosx-version-min=10.7'
 
     // File Extensions
     .LibExtension                   = '.a'
@@ -75,9 +73,9 @@ Compiler( 'Compiler-Clang12' )
 
     // Intel 64-bit
     .Platform                       = 'x64OSX'
-    .CompilerOptions                + ' -arch x86_64'
-    .CompilerOptionsC               + ' -arch x86_64'
-    .LinkerOptions                  + ' -arch x86_64'
+    .CompilerOptions                + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .CompilerOptionsC               + ' -arch x86_64 -mmacosx-version-min=10.7'
+    .LinkerOptions                  + ' -arch x86_64 -mmacosx-version-min=10.7'
 ]
 
 .ToolChain_Clang_ARMOSX =
@@ -86,9 +84,9 @@ Compiler( 'Compiler-Clang12' )
 
     // Apple ARM Silicon
     .Platform                       = 'ARMOSX'
-    .CompilerOptions                + ' -arch arm64'
-    .CompilerOptionsC               + ' -arch arm64'
-    .LinkerOptions                  + ' -arch arm64'
+    .CompilerOptions                + ' -arch arm64 -mmacosx-version-min=11.0'
+    .CompilerOptionsC               + ' -arch arm64 -mmacosx-version-min=11.0'
+    .LinkerOptions                  + ' -arch arm64 -mmacosx-version-min=11.0'
 ]
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
 - Rework how we wait for pipes to have data to avoid busy sleeps that either waste CPU cycles or don't drain buffers quickly enough (on OSX buffer are small and cannot be resized).
 - Use posix_spawn when possible on OSX to significantly reduce process spawning overhead. On arm macs it can always be used. On Intel macs it can be used if the working directory does not need to be set.
 - This logic can be extended to Linux as well, and potentially to more cases on OSX if dynamic dispatch is implemented to obtain the chdir action if the user is running a newer OS.
