### PR TITLE
[Improvement][Linux] Reduce process spawning overhead

### DIFF
--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -67,15 +67,11 @@ private:
                                   const uint64_t processCreationTime );
     [[nodiscard]] static uint64_t GetProcessCreationTime( const void * hProc ); // HANDLE
     void Read( void * handle, AString & buffer );
-#elif defined( __APPLE__ )
+#elif defined( __LINUX__ ) || defined( __APPLE__ )
     void Read( int32_t stdOutHandle,
                int32_t stdErrHandle,
                AString & inoutOutBuffer,
                AString & inoutErrBuffer );
-#else
-    void Read( int handle, AString & buffer );
-#endif
-#if defined( __LINUX__ ) || defined( __APPLE__ )
     void ReadCommon( int32_t handle, AString & inoutBuffer );
 #endif
 


### PR DESCRIPTION
 - unify logic to read pipes with new OSX logic that avoids unnecessary waking in all cases and reduced the potential for stalls under heavy load.
 - the scope of improvement seen on OSX won't be seen on Linux in most cases due to larger pipe buffers on Linux, but some scenarios may will benefit
