### PR TITLE
Fix spam when no workers are discovered

### DIFF
--- a/Code/Core/CoreTest/Tests/TestMemInfo.cpp
+++ b/Code/Core/CoreTest/Tests/TestMemInfo.cpp
@@ -6,6 +6,7 @@
 #include "TestFramework/TestGroup.h"
 
 // Core
+#include "Core/Containers/UniquePtr.h"
 #include "Core/Mem/MemInfo.h"
 
 // TestMemInfo
@@ -15,32 +16,49 @@ class TestMemInfo : public TestGroup
 private:
     DECLARE_TESTS
 
-    void GetInfo() const;
+    void GetSystemInfo() const;
+    void GetProcessInfo() const;
 };
 
 // Register Tests
 //------------------------------------------------------------------------------
 REGISTER_TESTS_BEGIN( TestMemInfo )
-    REGISTER_TEST( GetInfo )
+    REGISTER_TEST( GetSystemInfo )
+    REGISTER_TEST( GetProcessInfo )
 REGISTER_TESTS_END
 
-// GetInfo
 //------------------------------------------------------------------------------
-void TestMemInfo::GetInfo() const
+void TestMemInfo::GetSystemInfo() const
 {
     SystemMemInfo info;
     MemInfo::GetSystemInfo( info );
 
     // Assume we should have at least 1 GiB physical memory
-    TEST_ASSERT( info.mTotalPhysMiB > 1024 );
+    TEST_ASSERT( info.m_TotalPhysMiB > 1024 );
 
     // Assume at least some physical memory is available when test is run
-    TEST_ASSERT( info.mAvailPhysMiB > 1 );
+    TEST_ASSERT( info.m_AvailPhysMiB > 1 );
 
     // Available can't be more than physical and should never be equal
     // as that would assume the OS and all running processes use zero
     // memory
-    TEST_ASSERT( info.mAvailPhysMiB < info.mTotalPhysMiB );
+    TEST_ASSERT( info.m_AvailPhysMiB < info.m_TotalPhysMiB );
+}
+
+//------------------------------------------------------------------------------
+void TestMemInfo::GetProcessInfo() const
+{
+    static const size_t sizesInBytes[] = { 1 * 1024 * 1024,
+                                           16 * 1024 * 1024,
+                                           128 * 1024 * 1024 };
+
+    // Allocate some memory to ensure at least that much is reported as used
+    UniquePtr<char, FreeDeletor> mem;
+    for ( const size_t sizeInBytes : sizesInBytes )
+    {
+        mem.Replace( static_cast<char *>( ALLOC( sizeInBytes ) ) );
+        ASSERT( MemInfo::GetProcessInfo() >= MemInfo::ConvertBytesToMiB( sizeInBytes ) );
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Core/Mem/MemInfo.h
+++ b/Code/Core/Mem/MemInfo.h
@@ -12,8 +12,8 @@ class SystemMemInfo
 {
 public:
     // Physical memory
-    uint32_t mTotalPhysMiB = 0; // Usable by OS (<= physically installed)
-    uint32_t mAvailPhysMiB = 0; // Free
+    uint32_t m_TotalPhysMiB = 0; // Usable by OS (<= physically installed)
+    uint32_t m_AvailPhysMiB = 0; // Free
 };
 
 // MemInfo
@@ -24,8 +24,10 @@ public:
     // Obtain information about the system
     static void GetSystemInfo( SystemMemInfo & outInfo );
 
-protected:
-    // Internal helpers
+    // Obtain information about th current process
+    static uint32_t GetProcessInfo();
+
+    // Helpers
     static uint32_t ConvertBytesToMiB( uint64_t bytes );
 };
 

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -67,15 +67,11 @@ private:
                                   const uint64_t processCreationTime );
     [[nodiscard]] static uint64_t GetProcessCreationTime( const void * hProc ); // HANDLE
     void Read( void * handle, AString & buffer );
-#elif defined( __APPLE__ )
+#elif defined( __LINUX__ ) || defined( __APPLE__ )
     void Read( int32_t stdOutHandle,
                int32_t stdErrHandle,
                AString & inoutOutBuffer,
                AString & inoutErrBuffer );
-#else
-    void Read( int handle, AString & buffer );
-#endif
-#if defined( __LINUX__ ) || defined( __APPLE__ )
     void ReadCommon( int32_t handle, AString & inoutBuffer );
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/SettingsNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/SettingsNode.cpp
@@ -270,7 +270,7 @@ bool SettingsNode::InitializeConcurrencyGroups( const BFFToken * iter,
         if ( group.GetMemoryBasedLimit() > 0 )
         {
             // Determine system memory based limit, but always allow 1 job
-            memoryLimit = ( sysMeminfo.mTotalPhysMiB / group.GetMemoryBasedLimit() );
+            memoryLimit = ( sysMeminfo.m_TotalPhysMiB / group.GetMemoryBasedLimit() );
             memoryLimit = Math::Max( memoryLimit, 1U );
         }
 

--- a/Code/Tools/FBuild/FBuildCore/Helpers/BuildProfiler.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/BuildProfiler.h
@@ -86,8 +86,9 @@ protected:
         int64_t m_Time = 0;
 
         // Memory
-        uint32_t m_TotalMemoryMiB = 0;
         uint32_t m_JobMemoryMiB = 0;
+        uint32_t m_ProcessMiB = 0;
+        uint32_t m_SystemMiB = 0;
 
         // Network
         uint16_t m_NumConnections = 0;

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.cpp
@@ -282,10 +282,11 @@ void Client::ThreadFunc()
 void Client::FindPotentialWorkers()
 {
     // TODO:B Allow list of workers to be updated after startup
-    if ( m_WorkerPool.IsEmpty() == false )
+    if ( m_WorkerDiscoveryDone == true )
     {
         return;
     }
+    m_WorkerDiscoveryDone = true;
 
     // Worker list from Settings takes priority over discovery
     if ( m_StaticWorkerList.IsEmpty() == false )

--- a/Code/Tools/FBuild/FBuildCore/Protocol/Client.h
+++ b/Code/Tools/FBuild/FBuildCore/Protocol/Client.h
@@ -63,6 +63,7 @@ private:
     void CommunicateJobAvailability();
 
     // Worker pool
+    bool m_WorkerDiscoveryDone = false;
     Array<AString> m_StaticWorkerList; // optional explicit list to use (overrides discovery)
     Array<UniquePtr<ClientWorkerInfo>> m_WorkerPool; // workers to potentially connect to
     uint32_t m_NextWorkerIndex = 0; // next worker we will attempt to connect to


### PR DESCRIPTION
 - When using the brokerage, we were using the results to know if we had performed the discovery already (the intent being to do discovery only once). If no workers were discovered, we would constantly retry and continually emit spam about not finding any workers.
 - Instead of trying to infer if discovery has been done, we keep an explicit bool now.
 - In the future, the plan is to check for new workers during the build, but more work is required to do that, including merging worker lists and doing that relatively infrequently.
 - The spam behavior was accidentally introduced while fixing a network deadlock, but never shipped in any version.
