### PR TITLE
Fix minimum new alignment

### DIFF
--- a/Code/Core/Mem/MemTracker.cpp
+++ b/Code/Core/Mem/MemTracker.cpp
@@ -34,7 +34,7 @@
 THREAD_LOCAL uint32_t g_MemTrackerDisabledOnThisThread( 0 );
 
     // Defines
-    #define ALLOCATION_HASH_SHIFT       ( 0x2 )         // shift off lower bits
+    #define ALLOCATION_HASH_SHIFT       ( 0x4 )         // shift off lower bits for 16 byte alignment
     #define ALLOCATION_HASH_SIZE        ( 0x100000 )    // one megabyte
     #define ALLOCATION_HASH_MASK        ( 0x0FFFFF )    // mask off upper bits
 

--- a/Code/Core/Mem/SmallBlockAllocator.cpp
+++ b/Code/Core/Mem/SmallBlockAllocator.cpp
@@ -42,6 +42,10 @@
 //------------------------------------------------------------------------------
 NO_INLINE void SmallBlockAllocator::InitBuckets()
 {
+    // Our small block allocator alignment should satisfy the alignment needs
+    // of new when called without an alignment argument
+    static_assert( BUCKET_ALIGNMENT == __STDCPP_DEFAULT_NEW_ALIGNMENT__ );
+
     ASSERT( s_BucketMemoryStart == MEM_BUCKETS_NOT_INITIALIZED );
 
     // Reserve the address space for the buckets to manage

--- a/Code/Core/Mem/SmallBlockAllocator.h
+++ b/Code/Core/Mem/SmallBlockAllocator.h
@@ -41,13 +41,7 @@ protected:
     static void InitBuckets();
 
     static const size_t BUCKET_MAX_ALLOC_SIZE = 256;
-#if defined( __clang__ )
-    // Last seen in Apple LLVM version 10.0.0 (clang-1000.11.45.5) but exists in
-    // other versions as well
     static const size_t BUCKET_ALIGNMENT = 16;
-#else
-    static const size_t BUCKET_ALIGNMENT = sizeof( void * );
-#endif
     static const size_t BUCKET_NUM_BUCKETS = ( BUCKET_MAX_ALLOC_SIZE / BUCKET_ALIGNMENT );
     static const size_t BUCKET_ADDRESSSPACE_SIZE = ( 200 * 1024 * 1024 );
     static const size_t BUCKET_NUM_PAGES = ( BUCKET_ADDRESSSPACE_SIZE / MemPoolBlock::kMemPoolBlockPageSize );


### PR DESCRIPTION
 - Ensure 16 byte minimum alignment for new
 - Update MemTracker lookup to assume 16 byte minimum alignment. We can still get 8 byte aligned pointers from alloc (at least on Windows) but those are ok to alias as the hashmap must deal with collisions anyway. The "shift" was also previously set for 4 byte alignment instead of 8 (left over from old 32 bit support)
