### PR TITLE
Support RemoveDir nodes in Copy dependencies

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
@@ -72,8 +72,13 @@ FunctionCopy::FunctionCopy()
     }
 
     // Pre-build dependencies
+    GetNodeListOptions options;
+    options.m_AllowCopyDirNodes = true;
+    options.m_AllowUnityNodes = true;
+    options.m_AllowRemoveDirNodes = true;
+    options.m_AllowCompilerNodes = true;
     Dependencies preBuildDependencies;
-    if ( !GetNodeList( nodeGraph, funcStartIter, ".PreBuildDependencies", preBuildDependencies, false ) )
+    if ( !GetNodeList( nodeGraph, funcStartIter, ".PreBuildDependencies", preBuildDependencies, false, options ) )
     {
         return false; // GetNodeList will have emitted an error
     }


### PR DESCRIPTION
# Description:

This PR allows RemoveDir nodes to be used as dependencies of a Copy node.

Fix #1097

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
