### PR TITLE
Bff parsing optimizations

### DIFF
--- a/Code/Core/Reflection/PropertyType.h
+++ b/Code/Core/Reflection/PropertyType.h
@@ -77,7 +77,7 @@ inline PropertyType GetPropertyType( const AString * )
     return PT_ASTRING;
 }
 template <class T>
-inline PropertyType GetPropertyArrayType( const Array<T> * )
+inline PropertyType GetPropertyType( const Array<T> * )
 {
     return GetPropertyType( static_cast<T *>( nullptr ) );
 }

--- a/Code/Core/Reflection/ReflectedProperty.cpp
+++ b/Code/Core/Reflection/ReflectedProperty.cpp
@@ -107,26 +107,29 @@ GETSET_PROPERTY( int16_t, int16_t )
 GETSET_PROPERTY( int32_t, int32_t )
 GETSET_PROPERTY( int64_t, int64_t )
 GETSET_PROPERTY( bool, bool )
-GETSET_PROPERTY( AString, const AString & )
 
-#define GETSET_PROPERTY_ARRAY( valueType ) \
-    void ReflectedProperty::GetProperty( const void * object, Array<valueType> * value ) const \
+#define GETSET_PROPERTY_REF( valueType ) \
+    void ReflectedProperty::GetProperty( const void * object, valueType * value ) const \
     { \
         ASSERT( (PropertyType)m_Type == GetPropertyType( (valueType *)nullptr ) ); \
-        ASSERT( m_IsArray ); \
-        ( *value ) = *(const Array<valueType> *)( (size_t)object + m_Offset ); \
+        ( *value ) = *(const valueType *)( (size_t)object + m_Offset ); \
     } \
-    void ReflectedProperty::SetProperty( void * object, const Array<valueType> & value ) const \
+    void ReflectedProperty::SetProperty( void * object, const valueType & value ) const \
     { \
         ASSERT( (PropertyType)m_Type == GetPropertyType( (valueType *)nullptr ) ); \
-        ASSERT( m_IsArray ); \
-        *( (Array<valueType> *)( (size_t)object + m_Offset ) ) = value; \
+        *( (valueType *)( (size_t)object + m_Offset ) ) = value; \
+    } \
+    void ReflectedProperty::SetProperty( void * object, valueType && value ) const \
+    { \
+        ASSERT( (PropertyType)m_Type == GetPropertyType( (valueType *)nullptr ) ); \
+        *( (valueType *)( (size_t)object + m_Offset ) ) = Move( value ); \
     }
 
-GETSET_PROPERTY_ARRAY( AString )
+GETSET_PROPERTY_REF( AString )
+GETSET_PROPERTY_REF( Array<AString> )
 
 #undef GETSET_PROPERTY
-#undef GETSET_PROPERTY_ARRAY
+#undef GETSET_PROPERTY_REF
 
 // AddMetaData
 //------------------------------------------------------------------------------

--- a/Code/Core/Reflection/ReflectedProperty.h
+++ b/Code/Core/Reflection/ReflectedProperty.h
@@ -103,16 +103,17 @@ public:
     GETSET_PROPERTY( int32_t, int32_t )
     GETSET_PROPERTY( int64_t, int64_t )
     GETSET_PROPERTY( bool, bool )
-    GETSET_PROPERTY( AString, const AString & )
 
-#define GETSET_PROPERTY_ARRAY( valueType ) \
-        void GetProperty( const void * object, Array<valueType> * value ) const; \
-        void SetProperty( void * object, const Array<valueType> & value ) const;
+#define GETSET_PROPERTY_REF( valueType ) \
+        void GetProperty( const void * object, valueType * value ) const; \
+        void SetProperty( void * object, const valueType & value ) const; \
+        void SetProperty( void * object, valueType && value ) const;
 
-    GETSET_PROPERTY_ARRAY( AString )
+    GETSET_PROPERTY_REF( AString )
+    GETSET_PROPERTY_REF( Array<AString> )
 
 #undef GETSET_PROPERTY
-#undef GETSET_PROPERTY_ARRAY
+#undef GETSET_PROPERTY_REF
 
     void AddMetaData( const IMetaData * metaDataChain );
 

--- a/Code/Core/Reflection/ReflectionMacros.h
+++ b/Code/Core/Reflection/ReflectionMacros.h
@@ -130,7 +130,7 @@ class ReflectionInfo;
             ADD_PROPERTY_METADATA( metaData )
 
 #define REFLECT_ARRAY( member, memberName, metaData ) \
-            AddPropertyArray( offsetof( objectType, member ), memberName, GetPropertyArrayType( static_cast<decltype( objectType::member ) *>( nullptr ) ) ); \
+            AddPropertyArray( offsetof( objectType, member ), memberName, GetPropertyType( static_cast<decltype( objectType::member ) *>( nullptr ) ) ); \
             ADD_PROPERTY_METADATA( metaData )
 
 #define REFLECT_STRUCT( member, memberName, structType, metaData ) \

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -1309,7 +1309,7 @@ bool Function::PopulateArrayOfStrings( NodeGraph & nodeGraph, const BFFToken * i
         }
     }
 
-    property.SetProperty( base, strings );
+    property.SetProperty( base, Move( strings ) );
     return true;
 }
 
@@ -1353,7 +1353,7 @@ bool Function::PopulateString( NodeGraph & nodeGraph, const BFFToken * iter, voi
         }
 
         // String to String
-        property.SetProperty( base, strings[ 0 ] );
+        property.SetProperty( base, Move( strings[ 0 ] ) );
         return true;
     }
 

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
@@ -32,6 +32,7 @@ public:
     bool m_AllowUnityNodes = false;
     bool m_AllowRemoveDirNodes = false;
     bool m_AllowCompilerNodes = false;
+    bool m_RemoveDuplicates = false;
 };
 
 // Function
@@ -124,14 +125,23 @@ public:
                              const AString & nodeName,
                              Dependencies & nodes,
                              const GetNodeListOptions & options = GetNodeListOptions() );
-    static bool GetNodeList( const BFFToken * iter,
-                             const Function * function,
-                             const char * propertyName,
-                             Node * node,
-                             Dependencies & nodes,
-                             const GetNodeListOptions & options = GetNodeListOptions() );
 
 protected:
+    static bool GetNodeListInternal( NodeGraph & nodeGraph,
+                                     const BFFToken * iter,
+                                     const Function * function,
+                                     const char * propertyName,
+                                     const AString & nodeName,
+                                     Dependencies & nodes,
+                                     const GetNodeListOptions & options );
+    static bool GetNodeListInternal( NodeGraph & nodeGraph,
+                                     const BFFToken * iter,
+                                     const Function * function,
+                                     const char * propertyName,
+                                     Node * node,
+                                     Dependencies & nodes,
+                                     const GetNodeListOptions & options );
+
     AString m_Name;
     mutable bool m_Seen; // track for unique enforcement
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
@@ -36,6 +36,7 @@ AliasNode::AliasNode()
     options.m_AllowUnityNodes = true;
     options.m_AllowRemoveDirNodes = true;
     options.m_AllowCompilerNodes = true;
+    options.m_RemoveDuplicates = true;
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".Targets", m_Targets, targets, options ) )
     {
         return false; // GetNodeList will have emitted an error

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -60,6 +60,7 @@
 
 // Static Data
 //------------------------------------------------------------------------------
+/*static*/ uint32_t Node::s_SecondaryTag = 0;
 // clang-format off
 /*static*/ const char * const Node::s_NodeTypeNames[] =
 {
@@ -1174,6 +1175,7 @@ bool Node::InitializePreBuildDependencies( NodeGraph & nodeGraph, const BFFToken
     options.m_AllowUnityNodes = true;
     options.m_AllowRemoveDirNodes = true;
     options.m_AllowCompilerNodes = true;
+    options.m_RemoveDuplicates = true;
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".PreBuildDependencies", preBuildDependencyNames, m_PreBuildDependencies, options ) )
     {
         return false; // GetNodeList will have emitted an error

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -178,7 +178,7 @@ public:
 
     static void StartSecondaryTagSweep() { s_SecondaryTag++; }
     void SetSecondaryTag() { m_SecondaryTag = s_SecondaryTag; }
-    [[nodiscard]] bool HasSecondaryTag() const { return (m_SecondaryTag == s_SecondaryTag); }
+    [[nodiscard]] bool HasSecondaryTag() const { return ( m_SecondaryTag == s_SecondaryTag ); }
 
     const AString & GetName() const { return m_Name; }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -176,6 +176,10 @@ public:
     void SetBuildPassTag( uint32_t pass ) const { m_BuildPassTag = pass; }
     uint32_t GetBuildPassTag() const { return m_BuildPassTag; }
 
+    static void StartSecondaryTagSweep() { s_SecondaryTag++; }
+    void SetSecondaryTag() { m_SecondaryTag = s_SecondaryTag; }
+    [[nodiscard]] bool HasSecondaryTag() const { return (m_SecondaryTag == s_SecondaryTag); }
+
     const AString & GetName() const { return m_Name; }
 
     virtual const AString & GetPrettyName() const { return GetName(); }
@@ -280,12 +284,14 @@ protected:
     uint32_t m_ProcessingTime = 0; // Time spent on this node during this build
     uint32_t m_CachingTime = 0; // Time spent caching this node
     mutable uint32_t m_ProgressAccumulator = 0; // Used to estimate build progress percentage
+    uint32_t m_SecondaryTag = 0;
 
     Dependencies m_PreBuildDependencies;
     Dependencies m_StaticDependencies;
     Dependencies m_DynamicDependencies;
 
     // Static Data
+    static uint32_t s_SecondaryTag;
     static const char * const s_NodeTypeNames[];
 };
 


### PR DESCRIPTION
[Improvement] Improve bff parsing speed by eliminating redundant PreBuildDependencies and Alias Targets
 - When flattening aliases to their final lists, recursion can result in large redundancies in some cases. By marking the nodes as we sweep them, we can avoid traversing redundant sub-hierarchies so that we end up with a unique list.
[Improvement] Improve bff parsing performance by avoiding string copies
 - When setting the final String or ArrayOfStrings property, we can move the strings instead of copying them