### PR TITLE
Shutdown cost tracking improvements

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/BuildProfiler.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/BuildProfiler.h
@@ -17,6 +17,7 @@
 
 // Forward Declarations
 //------------------------------------------------------------------------------
+class FBuild;
 class FBuildOptions;
 class Job;
 
@@ -48,12 +49,19 @@ public:
                        const char * stepName,
                        const char * targetName );
 
+    // Capture data from FBuild that we have pointers to so that it can
+    // be safely destroyed (along with BuildProfiler)
+    // Must be called before SaveJSON()
+    void Capture( const FBuild & fBuild );
+
     // Write the profiling info in Chrome tracing format
-    bool SaveJSON( const FBuildOptions & options, const char * fileName );
+    static bool SaveJSON( const char * fileName );
 
 protected:
     static uint32_t MetricsThreadWrapper( void * userData );
     void MetricsUpdate();
+
+    void Serialize( const FBuildOptions & options );
 
     // Items processed during the build
     class Event
@@ -109,6 +117,11 @@ protected:
     Array<Event> m_Events;
     Array<Metrics> m_Metrics;
     Array<WorkerInfo> m_WorkerInfo;
+
+    // Static data for use after teardown
+    static int64_t s_CaptureStart;
+    static int64_t s_CaptureEnd;
+    static AString s_Buffer; // Final JSON to write to disk
 };
 
 // BuildProfilerScope

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -357,7 +357,8 @@ void FBuildForTest::SerializeDepGraphToText( const char * nodeName, AString & ou
     // Output -profile info if enabled
     if ( m_Options.m_Profile )
     {
-        VERIFY( BuildProfiler::Get().SaveJSON( m_Options, "fbuild_profile.json" ) );
+        BuildProfiler::Get().Capture( *this );
+        VERIFY( BuildProfiler::Get().SaveJSON( "fbuild_profile.json" ) );
     }
 
     return result;


### PR DESCRIPTION
[Fix] Total build "Time: X.XXXs" captures missing shutdown costs
[Fix] -profile option includes missing shutdown costs
[Fix] -profile write failure return code correctly returned when using -wrapper mode
