### PR TITLE
[Improvement] Improve fbd load/save performance

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -73,7 +73,11 @@ ExecNode::ExecNode()
     }
 
     // .ConcurrencyGroupName
-    if ( !InitializeConcurrencyGroup( nodeGraph, iter, function, m_ConcurrencyGroupName ) )
+    if ( !InitializeConcurrencyGroup( nodeGraph,
+                                      iter,
+                                      function,
+                                      m_ConcurrencyGroupName,
+                                      m_ConcurrencyGroupIndex ) )
     {
         return false; // InitializeConcurrencyGroup will have emitted an error
     }
@@ -261,6 +265,12 @@ ExecNode::~ExecNode()
     RecordStampFromBuiltFile();
 
     return BuildResult::eOk;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t ExecNode::GetConcurrencyGroupIndex() const
+{
+    return m_ConcurrencyGroupIndex;
 }
 
 // EmitCompilationMessage

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -29,6 +29,7 @@ private:
     virtual bool DoDynamicDependencies( NodeGraph & nodeGraph ) override;
     virtual bool DetermineNeedToBuildStatic() const override;
     virtual BuildResult DoBuild( Job * job ) override;
+    virtual uint8_t GetConcurrencyGroupIndex() const override;
 
     const FileNode * GetExecutable() const { return m_StaticDependencies[ 0 ].GetNode()->CastTo<FileNode>(); }
     void GetFullArgs( AString & fullArgs ) const;
@@ -57,6 +58,7 @@ private:
 
     // Internal State
     uint32_t m_NumExecInputFiles;
+    uint8_t m_ConcurrencyGroupIndex = 0;
     mutable const char * m_EnvironmentString = nullptr;
 };
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -79,7 +79,11 @@ LinkerNode::LinkerNode()
     }
 
     // .ConcurrencyGroupName
-    if ( !InitializeConcurrencyGroup( nodeGraph, iter, function, m_ConcurrencyGroupName ) )
+    if ( !InitializeConcurrencyGroup( nodeGraph,
+                                      iter,
+                                      function,
+                                      m_ConcurrencyGroupName,
+                                      m_ConcurrencyGroupIndex ) )
     {
         return false; // InitializeConcurrencyGroup will have emitted an error
     }
@@ -396,6 +400,12 @@ LinkerNode::~LinkerNode()
     RecordStampFromBuiltFile();
 
     return BuildResult::eOk;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t LinkerNode::GetConcurrencyGroupIndex() const
+{
+    return m_ConcurrencyGroupIndex;
 }
 
 // DoPreLinkCleanup

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
@@ -52,6 +52,7 @@ protected:
     friend class TestLinker;
 
     virtual BuildResult DoBuild( Job * job ) override;
+    virtual uint8_t GetConcurrencyGroupIndex() const override;
 
     bool DoPreLinkCleanup() const;
 
@@ -107,6 +108,7 @@ protected:
     bool m_LinkerLinkObjects = false;
     bool m_LinkerAllowResponseFile;
     bool m_LinkerForceResponseFile;
+    uint8_t m_ConcurrencyGroupIndex = 0; // Internal; placed here to use padding
     AString m_LinkerStampExe;
     AString m_LinkerStampExeArgs;
     Array<AString> m_PreBuildDependencyNames;

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -1080,6 +1080,12 @@ void Node::ReplaceDummyName( const AString & newName )
     NodeGraph::CleanPath( path, outFixedPath );
 }
 
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t Node::GetConcurrencyGroupIndex() const
+{
+    return 0; // Default is the unconstrained group zero
+}
+
 // CalcNameHash
 //------------------------------------------------------------------------------
 /*static*/ uint32_t Node::CalcNameHash( const AString & name )
@@ -1189,7 +1195,8 @@ bool Node::InitializePreBuildDependencies( NodeGraph & nodeGraph, const BFFToken
 bool Node::InitializeConcurrencyGroup( NodeGraph & nodeGraph,
                                        const BFFToken * iter,
                                        const Function * function,
-                                       const AString & concurrencyGroupName )
+                                       const AString & concurrencyGroupName,
+                                       uint8_t & outConcurrencyGroupIndex )
 {
     // If no ConcurrencyGroup is specified, feature is not in use
     if ( concurrencyGroupName.IsEmpty() )
@@ -1213,7 +1220,7 @@ bool Node::InitializeConcurrencyGroup( NodeGraph & nodeGraph,
     }
 
     // Store the inndex
-    m_ConcurrencyGroupIndex = group->GetIndex();
+    outConcurrencyGroupIndex = group->GetIndex();
     return true;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -185,7 +185,7 @@ public:
     virtual const AString & GetPrettyName() const { return GetName(); }
 
     bool IsHidden() const { return m_Hidden; }
-    uint8_t GetConcurrencyGroupIndex() const { return m_ConcurrencyGroupIndex; }
+    virtual uint8_t GetConcurrencyGroupIndex() const;
 
     const Dependencies & GetPreBuildDependencies() const { return m_PreBuildDependencies; }
     const Dependencies & GetStaticDependencies() const { return m_StaticDependencies; }
@@ -258,7 +258,8 @@ protected:
     bool InitializeConcurrencyGroup( NodeGraph & nodeGraph,
                                      const BFFToken * iter,
                                      const Function * function,
-                                     const AString & concurrencyGroupName );
+                                     const AString & concurrencyGroupName,
+                                     uint8_t & outConcurrencyGroupIndex );
 
     static const char * GetEnvironmentString( const Array<AString> & envVars,
                                               const char *& inoutCachedEnvString );
@@ -275,8 +276,7 @@ protected:
     uint64_t m_Stamp = 0; // "Stamp" representing this node for dependency comparisons
     uint8_t m_ControlFlags = FLAG_NONE; // Control build behavior special cases - Set by constructor
     bool m_Hidden = false; // Hidden from -showtargets?
-    uint8_t m_ConcurrencyGroupIndex = 0; // Concurrency group, or 0 if not set
-    // Note: Unused 1 byte here
+    // Note: Unused 2 bytes here
     uint32_t m_RecursiveCost = 0; // Recursive cost used during task ordering
     Node * m_Next = nullptr; // Node map in-place linked list pointer
     uint32_t m_NameHash; // Hash of mName

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 181;
+    inline static const uint8_t kCurrentVersion = 182;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -98,7 +98,11 @@ ObjectListNode::ObjectListNode()
     }
 
     // .ConcurrencyGroupName
-    if ( !InitializeConcurrencyGroup( nodeGraph, iter, function, m_ConcurrencyGroupName ) )
+    if ( !InitializeConcurrencyGroup( nodeGraph,
+                                      iter,
+                                      function,
+                                      m_ConcurrencyGroupName,
+                                      m_ConcurrencyGroupIndex ) )
     {
         return false; // InitializeConcurrencyGroup will have emitted an error
     }
@@ -356,6 +360,12 @@ ObjectListNode::~ObjectListNode() = default;
 /*virtual*/ bool ObjectListNode::IsAFile() const
 {
     return false;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t ObjectListNode::GetConcurrencyGroupIndex() const
+{
+    return m_ConcurrencyGroupIndex;
 }
 
 // GatherDynamicDependencies
@@ -813,8 +823,6 @@ ObjectNode * ObjectListNode::CreateObjectNode( NodeGraph & nodeGraph,
     node->m_CompilerFlags = flags;
     node->m_PreprocessorFlags = preprocessorFlags;
     node->m_OwnerObjectList = this;
-    node->m_ConcurrencyGroupName = m_ConcurrencyGroupName;
-    node->m_ConcurrencyGroupIndex = m_ConcurrencyGroupIndex;
 
     if ( !node->Initialize( nodeGraph, iter, function ) )
     {

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -32,6 +32,7 @@ public:
     static Node::Type GetTypeS() { return Node::OBJECT_LIST_NODE; }
 
     virtual bool IsAFile() const override;
+    virtual uint8_t GetConcurrencyGroupIndex() const override;
 
     const char * GetObjExtension() const;
 
@@ -96,6 +97,7 @@ protected:
     bool m_DeoptimizeWritableFilesWithToken = false;
     bool m_AllowDistribution = true;
     bool m_AllowCaching = true;
+    uint8_t m_ConcurrencyGroupIndex = 0; // Internal; placed here to use padding
     AString m_PCHInputFile;
     AString m_PCHOutputFile;
     AString m_PCHOptions;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -25,6 +25,7 @@
 #include "Tools/FBuild/FBuildCore/Graph/CompilerNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeGraph.h"
 #include "Tools/FBuild/FBuildCore/Graph/NodeProxy.h"
+#include "Tools/FBuild/FBuildCore/Graph/ObjectListNode.h"
 #include "Tools/FBuild/FBuildCore/Graph/SettingsNode.h"
 #include "Tools/FBuild/FBuildCore/Helpers/Args.h"
 #include "Tools/FBuild/FBuildCore/Helpers/BuildProfiler.h"
@@ -77,7 +78,6 @@ REFLECT_NODE_BEGIN( ObjectNode, Node, MetaNone() )
     REFLECT( m_AllowDistribution,                   "AllowDistribution",                MetaOptional() )
     REFLECT( m_AllowCaching,                        "AllowCaching",                     MetaOptional() )
     REFLECT_ARRAY( m_CompilerForceUsing,            "CompilerForceUsing",               MetaOptional() + MetaFile() )
-    REFLECT( m_ConcurrencyGroupName,                "ConcurrencyGroupName",             MetaOptional() )
 
     // Preprocessor
     REFLECT( m_Preprocessor,                        "Preprocessor",                     MetaOptional() + MetaFile() + MetaAllowNonFile())
@@ -91,7 +91,6 @@ REFLECT_NODE_BEGIN( ObjectNode, Node, MetaNone() )
     REFLECT( m_PreprocessorFlags.m_Flags,           "PreprocessorFlags",                MetaHidden() )
     REFLECT( m_PCHCacheKey,                         "PCHCacheKey",                      MetaHidden() + MetaIgnoreForComparison() )
     REFLECT( m_OwnerObjectList,                     "OwnerObjectList",                  MetaHidden() )
-    REFLECT( m_ConcurrencyGroupIndex,               "ConcurrencyGroupIndex",            MetaHidden() )
 REFLECT_END( ObjectNode )
 
 // CONSTRUCTOR
@@ -115,7 +114,7 @@ ObjectNode::ObjectNode()
         return false; // InitializePreBuildDependencies will have emitted an error
     }
 
-    // NOTE: ConcurrencyGroup set directly by ObjectList or Library
+    // NOTE: ConcurrencyGroup stored in mOwnerObjectList
 
     // .Compiler
     CompilerNode * compiler( nullptr );
@@ -334,6 +333,13 @@ ObjectNode::~ObjectNode()
     // to prevent unnecessary rebuilds of object that depend on this one, if this
     // is a precompiled header object.
     m_PCHCacheKey = oldNode.CastTo<ObjectNode>()->m_PCHCacheKey;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t ObjectNode::GetConcurrencyGroupIndex() const
+{
+    // ObjectNodes inherit their concurrency group value from their owner
+    return m_OwnerObjectList->GetConcurrencyGroupIndex();
 }
 
 // DoBuildMSCL_NoCache

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -194,6 +194,8 @@ private:
 
     virtual void Migrate( const Node & oldNode ) override;
 
+    virtual uint8_t GetConcurrencyGroupIndex() const override;
+
     BuildResult DoBuildMSCL_NoCache( Job * job, bool useDeoptimization );
     BuildResult DoBuildWithPreProcessor( Job * job, bool useDeoptimization, bool useCache, bool useSimpleDist );
     BuildResult DoBuildWithPreProcessor2( Job * job,
@@ -297,7 +299,6 @@ private:
     AString m_Preprocessor;
     AString m_PreprocessorOptions;
     Array<AString> m_PreBuildDependencyNames;
-    AString m_ConcurrencyGroupName;
 
     // Internal State
     AString m_PrecompiledHeader;

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
@@ -71,7 +71,11 @@ TestNode::TestNode()
     }
 
     // .ConcurrencyGroupName
-    if ( !InitializeConcurrencyGroup( nodeGraph, iter, function, m_ConcurrencyGroupName ) )
+    if ( !InitializeConcurrencyGroup( nodeGraph,
+                                      iter,
+                                      function,
+                                      m_ConcurrencyGroupName,
+                                      m_ConcurrencyGroupIndex ) )
     {
         return false; // InitializeConcurrencyGroup will have emitted an error
     }
@@ -261,6 +265,12 @@ const char * TestNode::GetEnvironmentString() const
     RecordStampFromBuiltFile();
 
     return BuildResult::eOk;
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ uint8_t TestNode::GetConcurrencyGroupIndex() const
+{
+    return m_ConcurrencyGroupIndex;
 }
 
 // EmitCompilationMessage

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.h
@@ -28,6 +28,7 @@ public:
 private:
     virtual bool DoDynamicDependencies( NodeGraph & nodeGraph ) override;
     virtual BuildResult DoBuild( Job * job ) override;
+    virtual uint8_t GetConcurrencyGroupIndex() const override;
 
     void EmitCompilationMessage( const char * workingDir ) const;
 
@@ -49,6 +50,7 @@ private:
 
     // Internal State
     uint32_t m_NumTestInputFiles;
+    uint8_t m_ConcurrencyGroupIndex = 0;
     mutable const char * m_EnvironmentString;
 };
 


### PR DESCRIPTION
 - remove ConcurrencyGroup params from ObjectNode
 - ObjectNodes can retrieve these properties from their m_OwnerObjectList now
[Note] DB version changed
