### PR TITLE
Fix Unity build with UseRelativePaths_Experimental

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -359,7 +359,7 @@ UnityNode::~UnityNode()
     AStackString includeBasePath;
     if ( m_UseRelativePaths_Experimental )
     {
-        includeBasePath = FBuild::Get().GetOptions().GetWorkingDir();
+        includeBasePath = m_OutputPath;
         PathUtils::EnsureTrailingSlash( includeBasePath );
     }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestUnity.cpp
@@ -919,13 +919,13 @@ void TestUnity::CacheUsingRelativePaths() const
         }
 
         // Check __FILE__ paths are relative
-        // Slash direction changed in Clang 18.x.x from forward slash to backslash
-        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_1(./Subdir/Header.h)FILE_MACRO_END_1" ) ||
-                     buffer.Find( "FILE_MACRO_START_1(.\\Subdir/Header.h)FILE_MACRO_END_1" ) );
 #if defined( __WINDOWS__ )
-        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_2(.\\File.cpp)FILE_MACRO_END_2" ) );
+        TEST_ASSERT(
+            buffer.Find( "FILE_MACRO_START_1(..\\out\\..\\Code\\Subdir/Header.h)FILE_MACRO_END_1" ) );
+        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_2(..\\out\\..\\Code\\File.cpp)FILE_MACRO_END_2" ) );
 #else
-        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_2(./File.cpp)FILE_MACRO_END_2" ) );
+        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_1(./Subdir/Header.h)FILE_MACRO_END_1" ) );
+        TEST_ASSERT( buffer.Find( "FILE_MACRO_START_2(../out/../Code/File.cpp)FILE_MACRO_END_2" ) );
 #endif
     }
 


### PR DESCRIPTION
# Description:
The following BFF fails to compile without this fix:
```
  Unity('test_unity')
  {
    .UnityOutputPath = 'out_unity'
    .UnityOutputPattern = 'test_unity.cpp'
    .UnityInputFiles = 'cpps/source.cpp'
    .UseRelativePaths_Experimental = true
  }

  ObjectList ('test_obj')
  {
    .Compiler = '/usr/bin/clang++'
    .CompilerOptions = '-o %2 -c %1'
    .CompilerOutputPath = 'out_obj'
    .CompilerInputUnity = 'test_unity'
  }
```

The issues is that the formed `test_unity.cpp` looks like this:
```
// Auto-generated Unity file - do not modify

#pragma message( "cpps/source.cpp" )
#include "cpps/source.cpp"
```
And  `FBuild test_obj` fails with:
```
5> Uni: test_unity                                             
2> Obj: /tmp/out_obj/test_unity.o
2> Failed to build Object. Error: 1 (0x01) Target: '/tmp/out_obj/test_unity.o'
2> PROBLEM: /tmp/out_obj/test_unity.o
/tmp/out_unity/test_unity.cpp:3:9: warning: cpps/source.cpp [-W#pragma-messages]
    3 | #pragma message( "cpps/source.cpp" )
      |         ^
/tmp/out_unity/test_unity.cpp:4:10: fatal error: 'cpps/source.cpp' file not found
    4 | #include "cpps/source.cpp"
      |          ^~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
FBuild: Error: BUILD FAILED: test_obj                          
Time: 0.040s
```

With the fix the generated `test_unity.cpp` looks like this:
```
// Auto-generated Unity file - do not modify

#pragma message( "../cpps/source.cpp" )
#include "../cpps/source.cpp"
```
And compiles fine:
```
4> Uni: test_unity                                             
9> Obj: /tmp/out_obj/test_unity.o
9> WARNING: /tmp/out_obj/test_unity.o
/tmp/out_unity/test_unity.cpp:3:9: warning: ../cpps/source.cpp [-W#pragma-messages]
    3 | #pragma message( "../cpps/source.cpp" )
      |         ^
1 warning generated.
FBuild: OK: test_obj                                           
Time: 0.080s
```


# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
