### PR TITLE
Work-around for linker crash

### DIFF
--- a/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestLinker.cpp
@@ -320,8 +320,18 @@ void TestLinker::IncrementalLinking_MSVC() const
 
         const AStackString output( GetRecordedOutput().Get() + sizeOfRecordedOutput );
 
-        // Should see incremental linking messages..
-        TEST_ASSERT( output.Find( "modules have changed since prior linking" ) );
+        if ( output.Find( "FBuild: Warning: Linker crashed (LNK1000), retrying" ) )
+        {
+            // MSVC linker crashes as of v14.44.35207
+            // When we retry it works, but we don't get the normal output which means
+            // we can't test things as thoroughly as we'd like
+            // TODO:B - Re-instate this test when linker crash is fixed
+        }
+        else
+        {
+            // Should see incremental linking messages..
+            TEST_ASSERT( output.Find( "modules have changed since prior linking" ) );
+        }
 
         // .. but should not be a full link
         TEST_ASSERT( output.Find( "performing full link" ) == nullptr );


### PR DESCRIPTION
 - the latest MSVC linker crashes during the IncrementalLinking_MSVC test
 - detect the crash/retry and adjust assertions temporarily to avoid test failures