### PR TITLE
[Improvement] Improve fdb load/save time slightly by removing redundant properties

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 182;
+    inline static const uint8_t kCurrentVersion = 183;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -813,8 +813,6 @@ ObjectNode * ObjectListNode::CreateObjectNode( NodeGraph & nodeGraph,
         node->m_DeoptimizeWritableFiles = m_DeoptimizeWritableFiles;
         node->m_DeoptimizeWritableFilesWithToken = m_DeoptimizeWritableFilesWithToken;
     }
-    node->m_AllowDistribution = m_AllowDistribution;
-    node->m_AllowCaching = m_AllowCaching;
     node->m_CompilerForceUsing = m_CompilerForceUsing;
     node->m_PreBuildDependencyNames = m_PreBuildDependencyNames;
     node->m_PrecompiledHeader = m_PrecompiledHeaderName;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -43,6 +43,9 @@ public:
     const AString & GetCompilerOptions() const { return m_CompilerOptions; }
     const AString & GetCompiler() const { return m_Compiler; }
 
+    [[nodiscard]] bool IsCachingAllowed() const { return m_AllowCaching; }
+    [[nodiscard]] bool IsDistributionAllowed() const { return m_AllowDistribution; }
+
     void GetObjectFileName( const AString & fileName, const AString & baseDir, AString & objFile );
 
     void EnumerateInputFiles( void ( *callback )( const AString & inputFile, const AString & baseDir, void * userData ), void * userData ) const;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -75,8 +75,6 @@ REFLECT_NODE_BEGIN( ObjectNode, Node, MetaNone() )
     REFLECT( m_PCHObjectFileName,                   "PCHObjectFileName",                MetaOptional() + MetaFile() )
     REFLECT( m_DeoptimizeWritableFiles,             "DeoptimizeWritableFiles",          MetaOptional() )
     REFLECT( m_DeoptimizeWritableFilesWithToken,    "DeoptimizeWritableFilesWithToken", MetaOptional() )
-    REFLECT( m_AllowDistribution,                   "AllowDistribution",                MetaOptional() )
-    REFLECT( m_AllowCaching,                        "AllowCaching",                     MetaOptional() )
     REFLECT_ARRAY( m_CompilerForceUsing,            "CompilerForceUsing",               MetaOptional() + MetaFile() )
 
     // Preprocessor
@@ -238,7 +236,7 @@ ObjectNode::~ObjectNode()
     bool useDeoptimization = ShouldUseDeoptimization();
 
     const bool useCache = ShouldUseCache();
-    const bool useDist = m_CompilerFlags.IsDistributable() && m_AllowDistribution && FBuild::Get().GetOptions().m_AllowDistributed;
+    const bool useDist = IsDistributionAllowed();
     const bool useSimpleDist = GetCompiler()->SimpleDistributionMode();
     bool usePreProcessor = !useSimpleDist && ( useCache || useDist || IsGCC() || IsSNC() || IsClang() || IsClangCl() || IsCodeWarriorWii() || IsGreenHillsWiiU() || IsVBCC() || IsOrbisWavePSSLC() );
     if ( GetDedicatedPreprocessor() )
@@ -461,7 +459,7 @@ Node::BuildResult ObjectNode::DoBuildWithPreProcessor( Job * job, bool useDeopti
 
             // Cache miss
             const bool belowMemoryLimit = ( ( Job::GetTotalLocalDataMemoryUsage() / MEGABYTE ) < FBuild::Get().GetSettings()->GetDistributableJobMemoryLimitMiB() );
-            const bool canDistribute = belowMemoryLimit && m_CompilerFlags.IsDistributable() && m_AllowDistribution && FBuild::Get().GetOptions().m_AllowDistributed;
+            const bool canDistribute = belowMemoryLimit && IsDistributionAllowed();
             if ( canDistribute == false )
             {
                 // can't distribute, so generating preprocessed output is useless
@@ -519,7 +517,7 @@ Node::BuildResult ObjectNode::DoBuildWithPreProcessor( Job * job, bool useDeopti
     }
 
     // can we do the rest of the work remotely?
-    const bool canDistribute = useSimpleDist || ( m_CompilerFlags.IsDistributable() && m_AllowDistribution && FBuild::Get().GetOptions().m_AllowDistributed );
+    const bool canDistribute = useSimpleDist || IsDistributionAllowed();
     const bool belowMemoryLimit = ( ( Job::GetTotalLocalDataMemoryUsage() / MEGABYTE ) < FBuild::Get().GetSettings()->GetDistributableJobMemoryLimitMiB() );
     if ( canDistribute && belowMemoryLimit )
     {
@@ -2730,7 +2728,7 @@ bool ObjectNode::ShouldUseDeoptimization() const
 bool ObjectNode::ShouldUseCache() const
 {
     bool useCache = IsCacheable() &&
-                    m_AllowCaching &&
+                    m_OwnerObjectList->IsCachingAllowed() &&
                     ( FBuild::Get().GetOptions().m_UseCacheRead ||
                       FBuild::Get().GetOptions().m_UseCacheWrite );
     if ( IsIsolatedFromUnity() )
@@ -2754,6 +2752,14 @@ bool ObjectNode::ShouldUseCache() const
         }
     }
     return useCache;
+}
+
+//------------------------------------------------------------------------------
+bool ObjectNode::IsDistributionAllowed() const
+{
+    return m_CompilerFlags.IsDistributable() &&
+           m_OwnerObjectList->IsDistributionAllowed() &&
+           FBuild::Get().GetOptions().m_AllowDistributed;
 }
 
 // GetResponseFileMode

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -243,6 +243,7 @@ private:
     bool ShouldUseDeoptimization() const;
     friend class ClientToWorkerConnection;
     bool ShouldUseCache() const;
+    [[nodiscard]] bool IsDistributionAllowed() const;
     ArgsResponseFileMode GetResponseFileMode() const;
     bool GetVBCCPreprocessedOutput( ConstMemoryStream & outStream ) const;
 
@@ -293,8 +294,6 @@ private:
     AString m_PCHObjectFileName;
     bool m_DeoptimizeWritableFiles = false;
     bool m_DeoptimizeWritableFilesWithToken = false;
-    bool m_AllowDistribution = true;
-    bool m_AllowCaching = true;
     Array<AString> m_CompilerForceUsing;
     AString m_Preprocessor;
     AString m_PreprocessorOptions;


### PR DESCRIPTION
[Improvement] Improve fdb load/save time slightly by removing redundant properties
 - "AllowDistribution" and "AllowCaching" are flags that don't trigger recompilation and as such can be trivially obtained directly from the OwnerObjectList, avoiding the need to serialize them for every ObjectNode
