### PR TITLE
[Improvement] FBuild and FBuildWorker are no longer "below normal" priority

### DIFF
--- a/Code/Tools/FBuild/FBuild/Main.cpp
+++ b/Code/Tools/FBuild/FBuild/Main.cpp
@@ -100,12 +100,6 @@ int Main( int argc, char * argv[] )
         return WrapperModeForWSL( options );
     }
 
-#if defined( __WINDOWS__ )
-    // TODO:MAC Implement SetPriorityClass
-    // TODO:LINUX Implement SetPriorityClass
-    VERIFY( SetPriorityClass( GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS ) );
-#endif
-
     // don't buffer output
     VERIFY( setvbuf( stdout, nullptr, _IONBF, 0 ) == 0 );
     VERIFY( setvbuf( stderr, nullptr, _IONBF, 0 ) == 0 );

--- a/Code/Tools/FBuild/FBuildWorker/Main.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Main.cpp
@@ -116,13 +116,6 @@ int Main( const AString & args )
     // TODO:LINUX SetErrorMode equivalent
 #endif
 
-#if defined( __WINDOWS__ )
-    VERIFY( SetPriorityClass( GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS ) );
-#else
-    // TODO:MAC SetPriorityClass equivalent
-    // TODO:LINUX SetPriorityClass equivalent
-#endif
-
     // start the worker and wait for it to be closed
     int ret;
     {


### PR DESCRIPTION
 - this interferes with scheduling on some devices (in particular Windows 10 with hybrid cores)
 - users can schedule with fewer threads (-jX) or set priority when invoking if they need reduced load or priority