### PR TITLE
Avoid hashing large compiler files for CMake "Try Compiles"

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -369,7 +369,8 @@ CompilerNode::~CompilerNode()
 //------------------------------------------------------------------------------
 /*virtual*/ Node::BuildResult CompilerNode::DoBuild( Job * /*job*/ )
 {
-    if ( !m_Manifest.DoBuild( m_StaticDependencies ) )
+    const bool skipHashing = ( !m_AllowCaching && !m_AllowDistribution );
+    if ( !m_Manifest.DoBuild( m_StaticDependencies, skipHashing ) )
     {
         return BuildResult::eFailed; // Generate will have emitted error
     }

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ToolManifest.h
@@ -35,7 +35,7 @@ public:
         SYNCHRONIZED,
     };
 
-    bool DoBuild();
+    bool DoBuild( bool skipHashing = false );
     void StoreCompressedContent( const void * uncompressedData, const uint32_t uncompressedDataSize ) const;
     void Migrate( const ToolManifestFile & oldFile );
 
@@ -81,7 +81,7 @@ public:
     ~ToolManifest();
 
     void Initialize( const AString & mainExecutableRoot, const Dependencies & dependencies, const Array<AString> & customEnvironmentVariables );
-    bool DoBuild( const Dependencies & dependencies );
+    bool DoBuild( const Dependencies & dependencies, bool skipHashing = false );
     void Migrate( const ToolManifest & oldManifest );
 
     uint64_t GetToolId() const { return m_ToolId; }


### PR DESCRIPTION
# Description:
### Add `-fasthash` option to speed up CMake configure times

**Problem:**
The `cmake -GFASTBuild` configure step is significantly slower than other generators like Ninja. This is because CMake performs numerous "TryCompile" checks. Each check causes FASTBuild to read and hash the full contents of the entire compiler toolchain, resulting in a major I/O bottleneck.

**Solution:**
This change introduces a new command-line option, **`-fasthash`**.

When this flag is used, FASTBuild skips reading and hashing the content of toolchain files (like `cl.exe`, `link.exe`, etc.). Instead, it checks only the file's **timestamp**. If the file has changed, it generates a new "fake" hash based on the file's **name**, not its content.

This avoids the expensive I/O and makes the "TryCompile" checks almost instantaneous.

**Performance Impact:**
This option is intended to be used by the CMake generator during the configure/TryCompile steps.

Here is a comparison of configure times for the same project:

| Generator | Command | Time |
| :--- | :--- | :--- |
| Ninja | `cmake -GNinja` | 27.024s |
| **FASTBuild (Before)** | `cmake -GFASTBuild` | **55.936s** |
| **FASTBuild (After)** | `cmake -GFASTBuild` (with generator passing `-fasthash`) | **33.765s** |

As shown, this change (when used by the generator) cuts the configure time significantly, bringing it much closer to the performance of Ninja.

# Checklist:

The pull request:
- [ x] **Is created against the Dev branch**
- [ x] **Is self-contained**
- [x ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ x] **Passes existing tests**
- [x ] **Keeps Windows, OSX and Linux at parity**
- [ x] **Follows the code style**
- [ x] **Includes documentation**
