### PR TITLE
[Improvement] Redude .fdb redundancy

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -596,8 +596,15 @@ void Node::SetLastBuildTime( uint32_t ms )
         case PT_CUSTOM_1:
         {
             const Node * node = *property.GetPtrToPropertyCustom<Node *>( base );
-            const uint32_t nodeIndex = node->GetBuildPassTag();
-            stream.Write( nodeIndex );
+            if ( node )
+            {
+                const uint32_t nodeIndex = node->GetBuildPassTag();
+                stream.Write( nodeIndex );
+            }
+            else
+            {
+                stream.Write( INVALID_NODE_INDEX );
+            }
             return;
         }
         default:
@@ -730,8 +737,8 @@ void Node::SetLastBuildTime( uint32_t ms )
         {
             uint32_t index;
             VERIFY( stream.Read( index ) );
-            Node * node = nodeGraph.GetNodeByIndex( index );
-            ASSERT( node );
+            Node * node = ( index == INVALID_NODE_INDEX ) ? nullptr
+                                                          : nodeGraph.GetNodeByIndex( index );
             Node ** propertyPtr = property.GetPtrToPropertyCustom<Node *>( base );
             *propertyPtr = node;
             return;

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -49,6 +49,10 @@ inline constexpr PropertyType GetPropertyType( ObjectListNode * const * )
 {
     return PT_CUSTOM_1;
 }
+inline constexpr PropertyType GetPropertyType( CompilerNode * const * )
+{
+    return PT_CUSTOM_1;
+}
 
 // FBuild
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -2258,7 +2258,9 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
             ASSERT( property.IsArray() == false );
             const Node * nodeA = *property.GetPtrToPropertyCustom<Node *>( baseA );
             const Node * nodeB = *property.GetPtrToPropertyCustom<Node *>( baseB );
-            if ( nodeA->GetName() != nodeB->GetName() )
+            const bool same = ( nodeA && nodeB ) ? ( nodeA->GetName() == nodeB->GetName() )
+                                                 : ( ( nodeA == nullptr ) && ( nodeB == nullptr ) );
+            if ( !same )
             {
                 return false;
             }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 186;
+    inline static const uint8_t kCurrentVersion = 187;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -46,7 +46,8 @@ public:
     const AString & GetPreprocessorOptions() const { return m_PreprocessorOptions; }
     const Array<AString> & GetPreBuildDependencyNames() const { return m_PreBuildDependencyNames; }
     const Array<AString> & GetCompilerForceUsing() const { return m_CompilerForceUsing; }
-    const AString & GetCompiler() const { return m_Compiler; }
+    CompilerNode * GetCompiler() const { return m_CompilerNode; }
+    CompilerNode * GetPreprocessor() const { return m_PreprocessorNode; }
     bool GetDeoptimizeWritableFiles() const { return m_DeoptimizeWritableFiles; }
     bool GetDeoptimizeWritableFilesWithToken() const { return m_DeoptimizeWritableFilesWithToken; }
     const AString & GetPrecompiledHeaderName() const { return m_PrecompiledHeaderName; }
@@ -77,7 +78,6 @@ protected:
                                    const Function * function,
                                    const ObjectNode::CompilerFlags flags,
                                    const ObjectNode::CompilerFlags preprocessorFlags,
-                                   const AString & preprocessor,
                                    const AString & objectName,
                                    const AString & objectInput );
 
@@ -115,6 +115,8 @@ protected:
     AString m_ConcurrencyGroupName;
 
     // Internal State
+    CompilerNode * m_CompilerNode = nullptr;
+    CompilerNode * m_PreprocessorNode = nullptr;
     AString m_PrecompiledHeaderName;
 #if defined( __WINDOWS__ )
     AString m_PrecompiledHeaderCPPFile;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -292,9 +292,7 @@ protected:
 
     // Exposed Properties
     friend class ObjectListNode;
-    AString m_Compiler;
     AString m_CompilerInputFile;
-    AString m_Preprocessor;
 
     // Internal State
     CompilerFlags m_CompilerFlags;

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CompilationDatabase.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CompilationDatabase.cpp
@@ -97,12 +97,12 @@ void CompilationDatabase::VisitNodes( const NodeGraph & nodeGraph,
             }
             case Node::OBJECT_LIST_NODE:
             {
-                HandleObjectListNode( nodeGraph, node->CastTo<ObjectListNode>() );
+                HandleObjectListNode( node->CastTo<ObjectListNode>() );
                 break;
             }
             case Node::LIBRARY_NODE:
             {
-                HandleObjectListNode( nodeGraph, node->CastTo<LibraryNode>() );
+                HandleObjectListNode( node->CastTo<LibraryNode>() );
                 break;
             }
             default: break;
@@ -112,13 +112,13 @@ void CompilationDatabase::VisitNodes( const NodeGraph & nodeGraph,
 
 // HandleObjectListNode
 //------------------------------------------------------------------------------
-void CompilationDatabase::HandleObjectListNode( const NodeGraph & nodeGraph, ObjectListNode * node )
+void CompilationDatabase::HandleObjectListNode( ObjectListNode * node )
 {
     ObjectListContext ctx;
     ctx.m_DB = this;
     ctx.m_ObjectListNode = node;
 
-    const Node * compilerNode = nodeGraph.FindNode( node->GetCompiler() );
+    const CompilerNode * compilerNode = node->GetCompiler();
 
     // Check for MSVC
     const bool isMSVC = compilerNode &&

--- a/Code/Tools/FBuild/FBuildCore/Helpers/CompilationDatabase.h
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/CompilationDatabase.h
@@ -40,7 +40,7 @@ protected:
     };
 
     void VisitNodes( const NodeGraph & nodeGraph, const Dependencies & dependencies );
-    void HandleObjectListNode( const NodeGraph & nodeGraph, ObjectListNode * node );
+    void HandleObjectListNode( ObjectListNode * node );
     static void HandleInputFile( const AString & inputFile, const AString & baseDir, void * userData );
     void HandleInputFile( const AString & inputFile, const AString & baseDir, ObjectListContext * ctx );
 


### PR DESCRIPTION
 - track/serialize "pointers" to Compiler and Preprocessor instead of duplicating strings and performing repeated avoidable lookups
[Note] DB version changed