### PR TITLE
Test improvements:

### DIFF
--- a/Code/Core/Env/Assert.cpp
+++ b/Code/Core/Env/Assert.cpp
@@ -110,15 +110,6 @@ bool IsDebuggerAttached()
         ( *s_AssertCallback )( buffer );
     }
 
-    if ( IsDebuggerAttached() == false )
-    {
-        #if defined( __WINDOWS__ )
-        // TODO:LINUX Fix MessageBox use
-        // TODO:OSX Fix MessageBox use
-        const int res = MessageBox( nullptr, buffer, "Assertion Failed - Break Execution?", MB_YESNO | MB_ICONERROR );
-        return ( res == IDYES );
-        #endif
-    }
     return true; // break execution
     #else
     (void)message;

--- a/Code/TestFramework/TestFramework.bff
+++ b/Code/TestFramework/TestFramework.bff
@@ -25,9 +25,6 @@
         //--------------------------------------------------------------------------
         ObjectList( '$ProjectName$-Lib-$Platform$-$BuildConfigName$' )
         {
-            // Test framework uses exceptions
-            .CompilerOptions            + .UseExceptions
-
             // Input (Unity)
             .CompilerInputUnity         = '$ProjectName$-Unity-$Platform$-$BuildConfigName$'
 

--- a/Code/TestFramework/TestGroup.h
+++ b/Code/TestFramework/TestGroup.h
@@ -22,7 +22,7 @@ protected:
 
     // Run before and after each test
     virtual void PreTest() const {}
-    virtual void PostTest( bool /*passed*/ ) const {}
+    virtual void PostTest() const {}
 
     // Memory Leak checks can be disabled for individual tests
     static void SetMemoryLeakCheckEnabled( bool enabled ) { sMemoryLeakCheckEnabled = enabled; }

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.cpp
@@ -51,20 +51,13 @@ FBuildTest::FBuildTest()
 
 // PostTest
 //------------------------------------------------------------------------------
-/*virtual*/ void FBuildTest::PostTest( bool passed ) const
+/*virtual*/ void FBuildTest::PostTest() const
 {
     VERIFY( FileIO::SetCurrentDir( m_OriginalWorkingDir ) );
 
     FBuildStats::SetIgnoreCompilerNodeDeps( false );
 
     Tracing::RemoveCallbackOutput( LoggingCallback );
-
-    // Print the output on failure, unless in the debugger
-    // (we print as we go if the debugger is attached)
-    if ( ( passed == false ) && ( s_DebuggerAttached == false ) )
-    {
-        OUTPUT( "%s", s_RecordedOutput.Get() );
-    }
 }
 
 // EnsureFileDoesNotExist
@@ -269,9 +262,8 @@ bool FBuildTest::LoggingCallback( const char * message )
 {
     MutexHolder mh( s_OutputMutex );
     s_RecordedOutput.Append( message, AString::StrLen( message ) );
-    // If in the debugger, print the output normally as well, otherwise
-    // suppress and only print on failure
-    return s_DebuggerAttached;
+
+    return true; // Caller should also print to stdout
 }
 
 // CONSTRUCTOR - FBuildTestOptions

--- a/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
+++ b/Code/Tools/FBuild/FBuildTest/Tests/FBuildTest.h
@@ -24,7 +24,7 @@ protected:
     FBuildTest();
 
     virtual void PreTest() const override;
-    virtual void PostTest( bool pased ) const override;
+    virtual void PostTest() const override;
 
     // helpers to manage generated files
     void EnsureFileDoesNotExist( const char * fileName ) const;

--- a/External/SDK/Clang/Linux/Clang10.bff
+++ b/External/SDK/Clang/Linux/Clang10.bff
@@ -83,9 +83,6 @@ Compiler( 'Compiler-Clang10' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang14.bff
+++ b/External/SDK/Clang/Linux/Clang14.bff
@@ -83,9 +83,6 @@ Compiler( 'Compiler-Clang14' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang15.bff
+++ b/External/SDK/Clang/Linux/Clang15.bff
@@ -85,9 +85,6 @@ Compiler( 'Compiler-Clang15' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang18.bff
+++ b/External/SDK/Clang/Linux/Clang18.bff
@@ -87,9 +87,6 @@ Compiler( 'Compiler-Clang18' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang6.bff
+++ b/External/SDK/Clang/Linux/Clang6.bff
@@ -83,9 +83,6 @@ Compiler( 'Compiler-Clang6' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/Linux/Clang_CI.bff
+++ b/External/SDK/Clang/Linux/Clang_CI.bff
@@ -84,9 +84,6 @@ Compiler( 'Compiler-Clang' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/OSX/Clang12.bff
+++ b/External/SDK/Clang/OSX/Clang12.bff
@@ -46,10 +46,12 @@ Compiler( 'Compiler-Clang12' )
 
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$Clang12_BasePath$/ar'
@@ -64,9 +66,6 @@ Compiler( 'Compiler-Clang12' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 .ToolChain_Clang_OSX =

--- a/External/SDK/Clang/OSX/Clang8.bff
+++ b/External/SDK/Clang/OSX/Clang8.bff
@@ -49,10 +49,12 @@ Compiler( 'Compiler-Clang8' )
 
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$Clang8_BasePath$/ar'
@@ -69,9 +71,6 @@ Compiler( 'Compiler-Clang8' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/Clang/OSX/Clang_CI.bff
+++ b/External/SDK/Clang/OSX/Clang_CI.bff
@@ -44,10 +44,12 @@ Compiler( 'Compiler-Clang12' )
 
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '/usr/bin/ar'
@@ -62,9 +64,6 @@ Compiler( 'Compiler-Clang12' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 .ToolChain_Clang_OSX =

--- a/External/SDK/Clang/Windows/Clang10.bff
+++ b/External/SDK/Clang/Windows/Clang10.bff
@@ -115,9 +115,6 @@ Compiler( 'Compiler-Clang10-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -164,6 +161,7 @@ Compiler( 'Compiler-Clang10-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang11.bff
+++ b/External/SDK/Clang/Windows/Clang11.bff
@@ -153,9 +153,6 @@ Compiler( 'Compiler-Clang11-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -202,6 +199,7 @@ Compiler( 'Compiler-Clang11-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang14.bff
+++ b/External/SDK/Clang/Windows/Clang14.bff
@@ -153,9 +153,6 @@ Compiler( 'Compiler-Clang14-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -202,6 +199,7 @@ Compiler( 'Compiler-Clang14-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang15.bff
+++ b/External/SDK/Clang/Windows/Clang15.bff
@@ -157,9 +157,6 @@ Compiler( 'Compiler-Clang15-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -188,6 +185,7 @@ Compiler( 'Compiler-Clang15-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang17.bff
+++ b/External/SDK/Clang/Windows/Clang17.bff
@@ -165,9 +165,6 @@ Compiler( 'Compiler-Clang17-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -196,6 +193,7 @@ Compiler( 'Compiler-Clang17-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang18.bff
+++ b/External/SDK/Clang/Windows/Clang18.bff
@@ -167,9 +167,6 @@ Compiler( 'Compiler-Clang18-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -198,6 +195,7 @@ Compiler( 'Compiler-Clang18-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang19.bff
+++ b/External/SDK/Clang/Windows/Clang19.bff
@@ -167,9 +167,6 @@ Compiler( 'Compiler-Clang19-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -198,6 +195,7 @@ Compiler( 'Compiler-Clang19-NonCL' )
 
     .CompilerOptions                = ' -x c++ -o"%2" "%1" $CommonCompilerOptions$'
                                     + ' -std=c++17'                     // Enable c++17 features
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c -o"%2" "%1" $CommonCompilerOptions$'
 ]
 

--- a/External/SDK/Clang/Windows/Clang8.bff
+++ b/External/SDK/Clang/Windows/Clang8.bff
@@ -115,9 +115,6 @@ Compiler( 'Compiler-Clang8-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -145,6 +142,7 @@ Compiler( 'Compiler-Clang8-NonCL' )
 
                                     // No RTTI
                                     + ' -fno-rtti'
+                                    + ' -fno-exceptions'
 
                                     // Warnings that are not useful
                                     + ' -Wno-#pragma-messages'          // warning : %s [-W#pragma-messages]

--- a/External/SDK/Clang/Windows/Clang9.bff
+++ b/External/SDK/Clang/Windows/Clang9.bff
@@ -115,9 +115,6 @@ Compiler( 'Compiler-Clang9-NonCL' )
     .CompilerOptionsC               = ' /TC -o"%2" "%1" $CommonCompilerOptions$'
     .PCHOptions                     = ' /TP $CommonCompilerOptions$ "%1" /Fo"%3" /Fp"%2" /Yc"PrecompiledHeader.h"'
                                     + ' /std:c++17'                     // Enable c++17 features
-
-    // Exception Control
-    .UseExceptions                  = ' /EHs'
 ]
 
 // ToolChain
@@ -145,6 +142,7 @@ Compiler( 'Compiler-Clang9-NonCL' )
 
                                     // No RTTI
                                     + ' -fno-rtti'
+                                    + ' -fno-exceptions'
 
                                     // Warnings that are not useful
                                     + ' -Wno-#pragma-messages'          // warning : %s [-W#pragma-messages]

--- a/External/SDK/GCC/Linux/GCC11.bff
+++ b/External/SDK/GCC/Linux/GCC11.bff
@@ -46,11 +46,13 @@ Compiler( 'Compiler-GCC11' )
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$GCC11_BasePath$/x86_64-linux-gnu-ar'
@@ -63,9 +65,6 @@ Compiler( 'Compiler-GCC11' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/GCC/Linux/GCC13.bff
+++ b/External/SDK/GCC/Linux/GCC13.bff
@@ -46,11 +46,13 @@ Compiler( 'Compiler-GCC13' )
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$GCC13_BasePath$/x86_64-linux-gnu-ar'
@@ -63,9 +65,6 @@ Compiler( 'Compiler-GCC13' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/GCC/Linux/GCC7.bff
+++ b/External/SDK/GCC/Linux/GCC7.bff
@@ -46,11 +46,13 @@ Compiler( 'Compiler-GCC7' )
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$GCC7_BasePath$/x86_64-linux-gnu-ar'
@@ -63,9 +65,6 @@ Compiler( 'Compiler-GCC7' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/GCC/Linux/GCC9.bff
+++ b/External/SDK/GCC/Linux/GCC9.bff
@@ -46,11 +46,13 @@ Compiler( 'Compiler-GCC9' )
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '$GCC9_BasePath$/x86_64-linux-gnu-ar'
@@ -63,9 +65,6 @@ Compiler( 'Compiler-GCC9' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/GCC/Linux/GCC_CI.bff
+++ b/External/SDK/GCC/Linux/GCC_CI.bff
@@ -45,10 +45,14 @@ Compiler( 'Compiler-GCC' )
     .CompilerOptions                = ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
                                     + ' -fdiagnostics-color=auto'
+                                    + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
     .CompilerOptionsC               = ' -x c $CommonCompilerOptions$'
     .PCHOptions                     = ' -x c++-header'
                                     + ' -std=c++17 $CommonCompilerOptions$'
                                     + ' -Wno-invalid-offsetof' // we get the offset of members in non-POD types
+                                    + ' -fno-rtti'      // No RTTI
+                                    + ' -fno-exceptions'
 
     // Librarian
     .Librarian                      = '/usr/bin/ar'
@@ -61,9 +65,6 @@ Compiler( 'Compiler-GCC' )
     // File Extensions
     .LibExtension                   = '.a'
     .ExeExtension                   = ''
-
-    // Exception Control
-    .UseExceptions                  = ' -fexceptions'
 ]
 
 //------------------------------------------------------------------------------

--- a/External/SDK/VisualStudio/VS2019.bff
+++ b/External/SDK/VisualStudio/VS2019.bff
@@ -169,9 +169,6 @@ Compiler( 'Compiler-VS2019-x64' )
     // File Extensions
     .LibExtension                   = '.lib'
     .ExeExtension                   = '.exe'
-
-    // Exception Control
-    .UseExceptions                  = ' /EHsc'
 ]
 
 // PATH environment variable

--- a/External/SDK/VisualStudio/VS2022.bff
+++ b/External/SDK/VisualStudio/VS2022.bff
@@ -186,9 +186,6 @@ Compiler( 'Compiler-VS2022-ARM64' )
     // File Extensions
     .LibExtension                   = '.lib'
     .ExeExtension                   = '.exe'
-
-    // Exception Control
-    .UseExceptions                  = ' /EHsc'
 ]
 
 


### PR DESCRIPTION
 - Test terminate on first failure and no longer attempt to continue running subsequent tests.  Attempting to continue after a failure can often results in issues from the first failure lingering and causing subsequent failues. Stopping on first failure it makes it much easier to see what failed.
 - Remove use of exceptions. Attempting to catch arbitrary exceptions is fraught and difficult to manage reliable in a cross-platform way.
 - Disable output buffering for tests. Ensure that anything printed to the stdout is more reliably present on failures such as crashes.
 - Disable popup dialog on assert when not running in the debugger. Asserts now always debug break no matter the context.
 - Remove other behavioral differences in terms of how output is manager when running in the debugger or not.
