### PR TITLE
Make ObjectNode keep a hash of ObjectListNode properties

### DIFF
--- a/Code/Core/Math/xxHash.h
+++ b/Code/Core/Math/xxHash.h
@@ -99,6 +99,12 @@ public:
                                       data,
                                       dataSize );
     }
+    void AddData( const AString & string )
+    {
+        const uint32_t len = string.GetLength();
+        AddData( &len, sizeof( len ) );
+        AddData( string.Get(), len );
+    }
     void AddDataBig( const void * data, size_t dataSize )
     {
         ASSERT( mFinalized == false );
@@ -118,6 +124,10 @@ public:
         mFinalized = true;
 #endif
         return xxHashLib_XXH3_64bits_digest( reinterpret_cast<xxHashLib_XXH3_state_s *>( m_State ) );
+    }
+    uint32_t Finalize32()
+    {
+        return static_cast<uint32_t>( Finalize64() );
     }
 
 protected:

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -68,6 +68,7 @@ protected:
     virtual BuildResult DoBuild( Job * job ) override;
 
     // internal helpers
+    void CalculateOwnerObjectListHash();
     bool CreateDynamicObjectNode( NodeGraph & nodeGraph,
                                   const AString & inputFileName,
                                   const AString & baseDir,
@@ -127,7 +128,7 @@ protected:
     AString m_ExtraSourceDependenciesPath;
     uint32_t m_ObjectListInputStartIndex = 0;
     uint32_t m_ObjectListInputEndIndex = 0;
-    uint32_t m_PCHOptionsHash = 0;
+    uint32_t m_OwnerObjectListHash = 0;
     ObjectNode::CompilerFlags m_CompilerFlags;
     ObjectNode::CompilerFlags m_PreprocessorFlags;
 };

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -75,7 +75,7 @@ REFLECT_NODE_BEGIN( ObjectNode, Node, MetaNone() )
     REFLECT( m_PreprocessorFlags.m_Flags,           "PreprocessorFlags",                MetaHidden() )
     REFLECT( m_PCHCacheKey,                         "PCHCacheKey",                      MetaHidden() + MetaIgnoreForComparison() )
     REFLECT( m_OwnerObjectList,                     "OwnerObjectList",                  MetaHidden() )
-    REFLECT( m_PCHOptionsHash,                      "PCHOptionsHash",                   MetaHidden() )
+    REFLECT( m_OwnerObjectListHash,                 "OwnerObjectListHash",              MetaHidden() )
 REFLECT_END( ObjectNode )
 
 // CONSTRUCTOR
@@ -92,7 +92,7 @@ ObjectNode::ObjectNode()
 /*virtual*/ bool ObjectNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     ASSERT( m_OwnerObjectList ); // Must be set before we get here
-    ASSERT( !IsCreatingPCH() || m_PCHOptionsHash );
+    ASSERT( m_OwnerObjectListHash );
 
     // .PreBuildDependencies (OwnerObjectList will have handled checks/errors)
     m_PreBuildDependencies = m_OwnerObjectList->GetPreBuildDependencies();

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -297,7 +297,7 @@ protected:
     // Internal State
     CompilerFlags m_CompilerFlags;
     CompilerFlags m_PreprocessorFlags;
-    uint32_t m_PCHOptionsHash = 0; // Hash of PCHOptions from OwnerObjectList
+    uint32_t m_OwnerObjectListHash = 0; // Hash of relevant options from OwnerObjectList
     uint64_t m_PCHCacheKey = 0;
     uint64_t m_LightCacheKey = 0;
     ObjectListNode * m_OwnerObjectList = nullptr;


### PR DESCRIPTION
 - keep a hash of all dependent properties in all scenarios, not just the PCH properties when building a PCH