### PR TITLE
TestManager: Improve test framework

### DIFF
--- a/Code/TestFramework/TestGroup.h
+++ b/Code/TestFramework/TestGroup.h
@@ -92,7 +92,8 @@ __declspec( noreturn ) void TestNoReturn();
 #define REGISTER_TESTS_BEGIN( testGroupName )                       \
     void testGroupName##Register()                                  \
     {                                                               \
-        TestManager::RegisterTestGroup( new testGroupName );        \
+        static bool registered = TestManager::RegisterTestGroup( new testGroupName ); \
+        (void)registered;                                           \
     }                                                               \
     const char * testGroupName::GetName() const                     \
     {                                                               \

--- a/Code/TestFramework/TestManager.h
+++ b/Code/TestFramework/TestManager.h
@@ -25,11 +25,16 @@ public:
     TestManager();
     ~TestManager();
 
-    // run all tests, or tests from a group
-    bool RunTests();
+    // Run tests:
+    //   - all tests (default), or
+    //   - filtered subset (if -Filter=filter set on cmdline)
+    // Run all tests
+    //   - once by default, or
+    //   - repeatedly (if runCount > 1, or with -RunCount=x on cmdline)
+    bool RunTests( uint32_t runCount = 1 );
 
     // tests register (using the test declaration macros) via this interface
-    static void RegisterTestGroup( TestGroup * testGroup );
+    [[nodiscard]] static bool RegisterTestGroup( TestGroup * testGroup );
 
     // When tests are being executed, they are wrapped with these
     void TestBegin( TestGroup * testGroup, const char * testName );
@@ -45,6 +50,8 @@ public:
                                 ... ) FORMAT_STRING( 4, 5 );
 
 private:
+    static void FreeRegisteredTests();
+    [[nodiscard]] bool RunTestsInternal();
     void ParseCommandLineArgs();
 
     Timer m_Timer;
@@ -52,6 +59,7 @@ private:
     // Behavior control options
     bool mListTestsForDiscovery = false; // List tests instead of running them
     Array<AString> m_TestFilters; // Run only specified TestGroups of Tests
+    uint32_t m_RunCount = 1;
 
     // Track allocations for tests to catch leaks
 #ifdef MEMTRACKER_ENABLED


### PR DESCRIPTION
- remove asymmetry between registration and deregistration to avoid confusing failures if tests are modified temporarily for debugging
- add -RunCount=x command line argument that can be used to repeat tests
- add runCount argument to RunTests() function so that runcount can also be tweaked that way for when that is more convenient

