### PR TITLE
Fix CompilerInfoNodeSerialization

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.cpp
@@ -21,7 +21,7 @@ REFLECT_NODE_BEGIN( CompilerInfoNode, Node, MetaNone() )
     REFLECT( m_Compiler,            "Compiler",             MetaHidden() )
     REFLECT( m_NoStdInc,            "NoStdInc",             MetaHidden() )
     REFLECT( m_NoStdIncPP,          "NoStdIncPP",           MetaHidden() )
-    REFLECT( m_BuiltinIncludePaths, "BuiltinIncludePaths",  MetaHidden() )
+    REFLECT_ARRAY( m_BuiltinIncludePaths, "BuiltinIncludePaths", MetaHidden() )
 REFLECT_END( CompilerInfoNode )
 
 // CONSTRUCTOR

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 190;
+    inline static const uint8_t kCurrentVersion = 191;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }


### PR DESCRIPTION
 - Use the correct macro for reflecting m_BuiltinIncludePaths
 - Followup is needed to add some safety to prevent this error from being possible (should ideally be a compile-time failure)