### PR TITLE
[Improvement] LightCache respects UseRelativePath when generating cache keys

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.h
@@ -72,6 +72,7 @@ protected:
     Array<const IncludedFile *> m_AllIncludedFiles; // List of files seen during parsing
     Array<const IncludedFile *> m_IncludeStack; // Stack of includes, for file relative checks
     Array<const IncludeDefine *> m_IncludeDefines; // Macros describing files to include
+    AString m_BasePath; // Base path if using relative paths
     AString m_Errors; // Did we encounter some code we couldn't parse?
 };
 

--- a/Code/Tools/FBuild/FBuildTest/Data/TestObject/CacheUsingRelativePaths/fbuild-lightcache.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestObject/CacheUsingRelativePaths/fbuild-lightcache.bff
@@ -1,0 +1,3 @@
+
+.UseLightCache_Experimental = true
+#include "fbuild.bff"


### PR DESCRIPTION
 - when generating the "source" hash, use relative filenames for the files if UseRelativePaths_Experimental is enabled on the Compiler()