### PR TITLE
[Fix] Prevent rebuilding when LightCache encoutering missing full-path includes (Thanks to Antoine Vugliano)

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Cache/LightCache.cpp
@@ -736,7 +736,7 @@ void LightCache::ProcessInclude( const AString & include, IncludeType type )
         }
     }
 
-    if ( file == nullptr || file->m_Exists == false )
+    if ( ( file == nullptr ) || ( file->m_Exists == false ) )
     {
         // Include not found. This is ok because:
         // a) The file might not be needed. If the include is within an inactive part of the file

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_MissingInclude/a.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_MissingInclude/a.cpp
@@ -1,0 +1,9 @@
+#if defined( NEVER_DEFINED )
+    // Relative
+    #include <IncludeThatDoesNotExist.h>
+
+    // Full (Windows style)
+    #include <C:\IncludeThatDoesNotExist.h>
+    // Full (OSX/Linux style)
+    #include </usr/lib/IncludeThatDoesNotExist.h>
+#endif

--- a/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_MissingInclude/fbuild.bff
+++ b/Code/Tools/FBuild/FBuildTest/Data/TestCache/LightCache_MissingInclude/fbuild.bff
@@ -1,0 +1,32 @@
+//
+// Ensure incldues that are not present don't cause rebuilds
+//
+//------------------------------------------------------------------------------
+#define ENABLE_LIGHT_CACHE // Shared compiler config will check this
+
+#include "..\..\testcommon.bff"
+Using( .StandardEnvironment )
+Settings {} // use Standard Environment
+
+ObjectList( 'ObjectList' )
+{
+    // Ensure we're using Clang
+    #if __WINDOWS__
+        Using( .ToolChain_Clang_Windows )
+    #elif __LINUX__
+        Using( .ToolChain_Clang_Linux )
+    #elif __OSX__
+        #if __ARM64__
+            Using( .ToolChain_Clang_ARMOSX )
+        #else
+            Using( .ToolChain_Clang_OSX )
+        #endif
+    #endif
+
+    .CompilerInputFiles = '$TestRoot$/Data/TestCache/LightCache_MissingInclude/a.cpp'
+    .CompilerOutputPath = '$Out$/Test/Cache/LightCache_MissingInclude/'
+
+    .CompilerOptions    = ' -c %1'
+                        + ' -o %2'
+                        + ' -Werror -Wfatal-errors'
+}


### PR DESCRIPTION
 - Handle full path includes that are not present the same way as relative includes we can't resolve and don't include them in dependencies.
 - Update merged fix for code style and add test coverage.