### PR TITLE
[Fix] Correctly detect corrupt cache items when < 12 bytes in size

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Helpers/Compressor.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/Compressor.cpp
@@ -42,6 +42,13 @@ Compressor::~Compressor()
 /*static*/ bool Compressor::IsValidData( const void * data, size_t dataSize )
 {
     ASSERT( data );
+
+    // Validate minimum size before accessing header
+    if ( dataSize < sizeof( Header ) )
+    {
+        return false;
+    }
+
     const Header * header = (const Header *)data;
     if ( header->m_CompressionType > eZstd )
     {


### PR DESCRIPTION
 - ensure we have at least sizeof(Header) bytes so we can safely read the header