### PR TITLE
[Improvement] Reduce directory list node fdb costs for complex directory listings

### DIFF
--- a/Code/Core/Math/xxHash.cpp
+++ b/Code/Core/Math/xxHash.cpp
@@ -1,0 +1,22 @@
+// xxHash.cpp
+//------------------------------------------------------------------------------
+
+// Includes
+//------------------------------------------------------------------------------
+#include "xxHash.h"
+
+// Core
+#include "Core/Containers/Array.h"
+
+//------------------------------------------------------------------------------
+/*static*/ uint64_t xxHash3::Calc64( const Array<AString> & strings )
+{
+    xxHash3Accumulator acc;
+    for ( const AString & string : strings )
+    {
+        acc.AddData( string );
+    }
+    return acc.Finalize64();
+}
+
+//------------------------------------------------------------------------------

--- a/Code/Core/Math/xxHash.h
+++ b/Code/Core/Math/xxHash.h
@@ -7,6 +7,10 @@
 #include "Core/Env/Types.h"
 #include "Core/Strings/AString.h"
 
+// Forward Declaration
+//------------------------------------------------------------------------------
+template <class T> class Array;
+
 // avoid including xxhash header directly
 extern "C"
 {
@@ -50,6 +54,9 @@ public:
     static uint32_t Calc32( const AString & string ) { return static_cast<uint32_t>( Calc64Static( string.Get(), string.GetLength() ) ); }
     static uint64_t Calc64( const void * buffer, size_t len ) { return Calc64Static( buffer, len ); }
     static uint64_t Calc64( const AString & string ) { return Calc64Static( string.Get(), string.GetLength() ); }
+
+    // Convenience wrappers
+    static uint64_t Calc64( const Array<AString> & strings );
 
     // Functions for large inputs
     //  - Use dynamic dispatch on x86_64 to utilize AVX2 etc if available

--- a/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/DirectoryListNode.cpp
@@ -173,10 +173,17 @@ DirectoryListNode::~DirectoryListNode() = default;
     // Path and pattern
     result = path;
     result += '|';
-    if ( patterns )
+    if ( patterns && !patterns->IsEmpty() )
     {
-        result.AppendList( *patterns, '<' );
-        result += '|';
+        if ( patterns->GetSize() == 1 )
+        {
+            result += ( *patterns )[ 0 ];
+            result += '|';
+        }
+        else
+        {
+            result.AppendFormat( "%016" PRIx64 "|", xxHash3::Calc64( *patterns ) );
+        }
     }
 
     // Additional flags
@@ -196,22 +203,19 @@ DirectoryListNode::~DirectoryListNode() = default;
     // Excluded paths
     if ( !excludePaths.IsEmpty() )
     {
-        result += "|ePaths=";
-        result.AppendList( excludePaths, '<' );
+        result.AppendFormat( "|ePaths=%016" PRIx64 "|", xxHash3::Calc64( excludePaths ) );
     }
 
     // Excluded files
     if ( !excludeFiles.IsEmpty() )
     {
-        result += "|eFiles=";
-        result.AppendList( excludeFiles, '<' );
+        result.AppendFormat( "|eFiles=%016" PRIx64 "|", xxHash3::Calc64( excludeFiles ) );
     }
 
     // Excluded patterns
     if ( !excludePatterns.IsEmpty() )
     {
-        result += "|ePatterns=";
-        result.AppendList( excludePatterns, '<' );
+        result.AppendFormat( "|ePatterns=%016" PRIx64 "|", xxHash3::Calc64( excludePatterns ) );
     }
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 192;
+    inline static const uint8_t kCurrentVersion = 193;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }


### PR DESCRIPTION
- Replace various exclusions and patterns with hashes to avoid potentially absurdly long node names. This reduces the serialization cost and memory usage of these nodes.
[Note] DB version changed