### PR TITLE
Aliases and PreBuildDependencies optimizations

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -1146,6 +1146,10 @@ bool Function::PopulateProperty( NodeGraph & nodeGraph,
             }
             break;
         }
+        case PT_CUSTOM_1:
+        {
+            return PopulateCustom( nodeGraph, iter, base, property, variable );
+        }
         default:
         {
             break;
@@ -1518,6 +1522,72 @@ bool Function::PopulateArrayOfStructs( NodeGraph & nodeGraph,
 
     Error::Error_1050_PropertyMustBeOfType( iter, this, variable->GetName().Get(), variable->GetType(), BFFVariable::VAR_STRUCT, BFFVariable::VAR_ARRAY_OF_STRUCTS );
     return false;
+}
+
+//------------------------------------------------------------------------------
+bool Function::PopulateCustom( NodeGraph & nodeGraph,
+                               const BFFToken * iter,
+                               void * base,
+                               const ReflectedProperty & property,
+                               const BFFVariable * variable ) const
+{
+    AStackString propertyName;
+    propertyName += '.';
+    propertyName += property.GetName();
+
+    // Get list of nodes
+    const bool required = ( property.HasMetaData<Meta_Required>() != nullptr );
+    Dependencies nodes;
+    GetNodeListOptions options;
+    options.m_AllowCopyDirNodes = true;
+    options.m_AllowUnityNodes = true;
+    options.m_AllowRemoveDirNodes = true;
+    options.m_AllowCompilerNodes = true;
+    options.m_RemoveDuplicates = true;
+    if ( !GetNodeList( nodeGraph,
+                       iter,
+                       propertyName.Get(),
+                       nodes,
+                       required,
+                       options ) )
+    {
+        return false; // GetNodeList will have emitted an error
+    }
+
+    if ( property.IsArray() )
+    {
+        Array<Node *> * dst = property.GetPtrToArray<Node *>( base );
+        dst->Clear();
+        dst->SetCapacity( nodes.GetSize() );
+        for ( const Dependency & dep : nodes )
+        {
+            dst->Append( dep.GetNode() );
+        }
+    }
+    else
+    {
+        Node ** dst = property.GetPtrToPropertyCustom<Node *>( base );
+        if ( nodes.IsEmpty() )
+        {
+            // If not required, can be not set
+            *dst = nullptr;
+        }
+        else if ( nodes.GetSize() == 1 )
+        {
+            *dst = nodes[ 0 ].GetNode();
+        }
+        else
+        {
+            // Property supports a single item, but an Array was provided
+            Error::Error_1050_PropertyMustBeOfType( iter,
+                                                    this,
+                                                    variable->GetName().Get(),
+                                                    BFFVariable::VAR_ARRAY_OF_STRINGS,
+                                                    BFFVariable::VAR_STRING );
+            return false;
+        }
+    }
+    return true;
 }
 
 // PopulateArrayOfStructsElement

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
@@ -180,6 +180,7 @@ protected:
     bool PopulateUInt32( const BFFToken * iter, void * base, const ReflectedProperty & property, const BFFVariable * variable ) const;
     bool PopulateArrayOfStructs( NodeGraph & nodeGraph, const BFFToken * iter, void * base, const ReflectedProperty & property, const BFFVariable * variable ) const;
     bool PopulateArrayOfStructsElement( NodeGraph & nodeGraph, const BFFToken * iter, void * structBase, const ReflectionInfo * structRI, const BFFVariable * srcVariable ) const;
+    bool PopulateCustom( NodeGraph & nodeGraph, const BFFToken * iter, void * base, const ReflectedProperty & property, const BFFVariable * variable ) const;
 
     bool PopulateStringHelper( NodeGraph & nodeGraph, const BFFToken * iter, const Meta_Path * pathMD, const Meta_File * fileMD, const Meta_AllowNonFile * allowNonFileMD, const BFFVariable * variable, Array<AString> & outStrings ) const;
     bool PopulateStringHelper( NodeGraph & nodeGraph, const BFFToken * iter, const Meta_Path * pathMD, const Meta_File * fileMD, const Meta_AllowNonFile * allowNonFileMD, const BFFVariable * variable, const AString & string, Array<AString> & outStrings ) const;

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/FunctionCopy.cpp
@@ -77,11 +77,11 @@ FunctionCopy::FunctionCopy()
     {
         return false; // GetNodeList will have emitted an error
     }
-    Array<AString> preBuildDependencyNames;
+    StackArray<Node *> preBuildDependencyNames;
     preBuildDependencyNames.SetCapacity( preBuildDependencies.GetSize() );
     for ( const Dependency & dep : preBuildDependencies )
     {
-        preBuildDependencyNames.Append( dep.GetNode()->GetName() );
+        preBuildDependencyNames.Append( dep.GetNode() );
     }
 
     // get source node

--- a/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.cpp
@@ -28,21 +28,9 @@ AliasNode::AliasNode()
 
 // Initialize
 //------------------------------------------------------------------------------
-/*virtual*/ bool AliasNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
+/*virtual*/ bool AliasNode::Initialize( NodeGraph & /*nodeGraph*/, const BFFToken * /*iter*/, const Function * /*function*/ )
 {
-    Dependencies targets( 32 );
-    GetNodeListOptions options;
-    options.m_AllowCopyDirNodes = true;
-    options.m_AllowUnityNodes = true;
-    options.m_AllowRemoveDirNodes = true;
-    options.m_AllowCompilerNodes = true;
-    options.m_RemoveDuplicates = true;
-    if ( !Function::GetNodeList( nodeGraph, iter, function, ".Targets", m_Targets, targets, options ) )
-    {
-        return false; // GetNodeList will have emitted an error
-    }
-
-    m_StaticDependencies = targets;
+    m_StaticDependencies.Add( m_Targets );
 
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/AliasNode.h
@@ -33,7 +33,7 @@ public:
 private:
     virtual BuildResult DoBuild( Job * job ) override;
 
-    Array<AString> m_Targets;
+    Array<Node *> m_Targets;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
@@ -60,10 +60,7 @@ CSNode::CSNode()
 /*virtual*/ bool CSNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .Compiler
     CompilerNode * compilerNode( nullptr );

--- a/Code/Tools/FBuild/FBuildCore/Graph/CSNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CSNode.h
@@ -51,7 +51,7 @@ private:
     Array<AString> m_CompilerInputExcludePattern;
     Array<AString> m_CompilerInputFiles;
     Array<AString> m_CompilerReferences;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 
     // Internal State
     uint32_t m_NumCompilerInputFiles;

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.cpp
@@ -38,10 +38,7 @@ CopyDirNode::CopyDirNode()
 /*virtual*/ bool CopyDirNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .CompilerInputPath
     Dependencies sourcePaths;
@@ -89,13 +86,6 @@ CopyDirNode::~CopyDirNode() = default;
 
     ASSERT( !m_StaticDependencies.IsEmpty() );
 
-    Array<AString> preBuildDependencyNames;
-    preBuildDependencyNames.SetCapacity( m_PreBuildDependencies.GetSize() );
-    for ( const Dependency & dep : m_PreBuildDependencies )
-    {
-        preBuildDependencyNames.Append( dep.GetNode()->GetName() );
-    }
-
     // Iterate all the DirectoryListNodes
     for ( const Dependency & dep : m_StaticDependencies )
     {
@@ -133,7 +123,7 @@ CopyDirNode::~CopyDirNode() = default;
             {
                 CopyFileNode * copyFileNode = nodeGraph.CreateNode<CopyFileNode>( dstFile );
                 copyFileNode->m_Source = srcFileNode->GetName();
-                copyFileNode->m_PreBuildDependencyNames = preBuildDependencyNames; // inherit PreBuildDependencies
+                copyFileNode->m_PreBuildDependencyNames = m_PreBuildDependencyNames; // inherit PreBuildDependencies
                 const BFFToken * token = nullptr;
                 if ( !copyFileNode->Initialize( nodeGraph, token, nullptr ) )
                 {

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyDirNode.h
@@ -35,7 +35,7 @@ private:
     Array<AString> m_SourceExcludePaths;
     bool m_SourcePathsRecurse = true;
 
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.cpp
@@ -37,10 +37,7 @@ CopyFileNode::CopyFileNode()
 /*virtual*/ bool CopyFileNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // Get node for Source of copy
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".Source", m_Source, m_StaticDependencies ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CopyFileNode.h
@@ -33,7 +33,7 @@ private:
     friend class CopyDirNode; // TODO: Remove
     AString m_Source;
     AString m_Dest;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.cpp
@@ -86,6 +86,30 @@ void Dependencies::Load( NodeGraph & nodeGraph, uint32_t numDeps, ConstMemoryStr
     }
 }
 
+//------------------------------------------------------------------------------
+void Dependencies::Add( const Array<Node *> & nodes )
+{
+    const size_t numDepsToAdd = nodes.GetSize();
+    if ( numDepsToAdd > 0 )
+    {
+        // Expand capacity if needed
+        const size_t requiredCapacity = ( GetSize() + numDepsToAdd );
+        if ( requiredCapacity > GetCapacity() )
+        {
+            GrowCapacity( requiredCapacity ); // Expand to exact capacity
+        }
+
+        // Add elements
+        Node ** srcPos = nodes.Begin();
+        Dependency * dstPos = GetDependencies( m_DependencyList ) + GetSize();
+        for ( size_t i = 0; i < numDepsToAdd; ++i )
+        {
+            INPLACE_NEW( dstPos++ ) Dependency( *srcPos++ );
+        }
+        m_DependencyList->m_Size += static_cast<uint32_t>( numDepsToAdd );
+    }
+}
+
 // GrowCapacity
 //------------------------------------------------------------------------------
 void Dependencies::GrowCapacity( size_t newCapacity )

--- a/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
@@ -77,6 +77,7 @@ public:
     void Add( Node * node );
     void Add( Node * node, uint64_t stamp, bool isWeak );
     void Add( const Dependencies & deps );
+    void Add( const Array<Node *> & nodes );
     Dependencies & operator=( const Dependencies & other );
 
     void Save( IOStream & stream ) const;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -68,10 +68,7 @@ ExecNode::ExecNode()
 /*virtual*/ bool ExecNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .ConcurrencyGroupName
     if ( !InitializeConcurrencyGroup( nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.h
@@ -52,7 +52,7 @@ private:
     bool m_ExecUseStdOutAsOutput;
     bool m_ExecAlways;
     bool m_ExecInputPathRecurse;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
     Array<AString> m_Environment;
     AString m_ConcurrencyGroupName;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -73,10 +73,7 @@ LinkerNode::LinkerNode()
 /*virtual*/ bool LinkerNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .ConcurrencyGroupName
     if ( !InitializeConcurrencyGroup( nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.h
@@ -111,7 +111,7 @@ protected:
     uint8_t m_ConcurrencyGroupIndex = 0; // Internal; placed here to use padding
     AString m_LinkerStampExe;
     AString m_LinkerStampExeArgs;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
     Array<AString> m_Environment;
     AString m_ConcurrencyGroupName;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.cpp
@@ -100,10 +100,7 @@ ListDependenciesNode::ListDependenciesNode()
 /*virtual*/ bool ListDependenciesNode::Initialize( NodeGraph & nodeGraph, const BFFToken * funcStartIter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, funcStartIter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // Get nodes for Source of dependency list
     if ( !Function::GetNodeList( nodeGraph, funcStartIter, function, ".Source", m_Source, m_StaticDependencies ) )

--- a/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ListDependenciesNode.h
@@ -31,7 +31,7 @@ private:
     AString m_Source;
     AString m_Dest;
     Array<AString> m_Patterns;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -596,15 +596,29 @@ void Node::SetLastBuildTime( uint32_t ms )
         }
         case PT_CUSTOM_1:
         {
-            const Node * node = *property.GetPtrToPropertyCustom<Node *>( base );
-            if ( node )
+            if ( property.IsArray() )
             {
-                const uint32_t nodeIndex = node->GetBuildPassTag();
-                stream.Write( nodeIndex );
+                const Array<Node *> & nodes = *property.GetPtrToArray<Node *>( base );
+                stream.Write( static_cast<uint32_t>( nodes.GetSize() ) );
+                for ( const Node * node : nodes )
+                {
+                    ASSERT( node ); // Arrays of Node pointers cannot contain nullptr
+                    const uint32_t nodeIndex = node->GetBuildPassTag();
+                    stream.Write( nodeIndex );
+                }
             }
             else
             {
-                stream.Write( INVALID_NODE_INDEX );
+                const Node * node = *property.GetPtrToPropertyCustom<Node *>( base );
+                if ( node )
+                {
+                    const uint32_t nodeIndex = node->GetBuildPassTag();
+                    stream.Write( nodeIndex );
+                }
+                else
+                {
+                    stream.Write( INVALID_NODE_INDEX );
+                }
             }
             return;
         }
@@ -736,12 +750,29 @@ void Node::SetLastBuildTime( uint32_t ms )
         }
         case PT_CUSTOM_1:
         {
-            uint32_t index;
-            VERIFY( stream.Read( index ) );
-            Node * node = ( index == INVALID_NODE_INDEX ) ? nullptr
-                                                          : nodeGraph.GetNodeByIndex( index );
-            Node ** propertyPtr = property.GetPtrToPropertyCustom<Node *>( base );
-            *propertyPtr = node;
+            if ( property.IsArray() )
+            {
+                uint32_t numNodes;
+                VERIFY( stream.Read( numNodes ) );
+                Array<Node *> & nodes = *property.GetPtrToArray<Node *>( base );
+                nodes.SetCapacity( numNodes );
+                for ( uint32_t i = 0; i < numNodes; ++i )
+                {
+                    uint32_t index;
+                    VERIFY( stream.Read( index ) );
+                    Node * node = nodeGraph.GetNodeByIndex( index );
+                    nodes.EmplaceBack( node );
+                }
+            }
+            else
+            {
+                uint32_t index;
+                VERIFY( stream.Read( index ) );
+                Node * node = ( index == INVALID_NODE_INDEX ) ? nullptr
+                                                              : nodeGraph.GetNodeByIndex( index );
+                Node ** propertyPtr = property.GetPtrToPropertyCustom<Node *>( base );
+                *propertyPtr = node;
+            }
             return;
         }
         default:

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -58,6 +58,10 @@ inline constexpr PropertyType GetPropertyType( CompilerInfoNode * const * )
 {
     return PT_CUSTOM_1;
 }
+inline constexpr PropertyType GetPropertyType( Node * const * )
+{
+    return PT_CUSTOM_1;
+}
 
 // FBuild
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -2092,11 +2092,25 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
         }
         case PT_CUSTOM_1:
         {
-            ASSERT( property.IsArray() == false );
-            const Node * oldNode = *property.GetPtrToPropertyCustom<Node *>( oldBase );
-            Node * newNode = FindNodeInternal( oldNode->GetName(), oldNode->GetNameHash() );
-            Node ** newNodeProperty = property.GetPtrToPropertyCustom<Node *>( newBase );
-            *newNodeProperty = newNode;
+            if ( property.IsArray() )
+            {
+                const Array<Node *> & oldNodes = *property.GetPtrToArray<Node *>( oldBase );
+                Array<Node *> & newNodes = *property.GetPtrToArray<Node *>( newBase );
+                newNodes.SetCapacity( oldNodes.GetSize() );
+                for ( const Node * oldNode : oldNodes )
+                {
+                    Node * newNode = FindNodeInternal( oldNode->GetName(), oldNode->GetNameHash() );
+                    ASSERT( newNode );
+                    newNodes.EmplaceBack( newNode );
+                }
+            }
+            else
+            {
+                const Node * oldNode = *property.GetPtrToPropertyCustom<Node *>( oldBase );
+                Node * newNode = FindNodeInternal( oldNode->GetName(), oldNode->GetNameHash() );
+                Node ** newNodeProperty = property.GetPtrToPropertyCustom<Node *>( newBase );
+                *newNodeProperty = newNode;
+            }
             break;
         }
         default: ASSERT( false ); // Unhandled
@@ -2257,14 +2271,34 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
         }
         case PT_CUSTOM_1:
         {
-            ASSERT( property.IsArray() == false );
-            const Node * nodeA = *property.GetPtrToPropertyCustom<Node *>( baseA );
-            const Node * nodeB = *property.GetPtrToPropertyCustom<Node *>( baseB );
-            const bool same = ( nodeA && nodeB ) ? ( nodeA->GetName() == nodeB->GetName() )
-                                                 : ( ( nodeA == nullptr ) && ( nodeB == nullptr ) );
-            if ( !same )
+            if ( property.IsArray() )
             {
-                return false;
+                const Array<Node *> & nodesA = *property.GetPtrToArray<Node *>( baseA );
+                const Array<Node *> & nodesB = *property.GetPtrToArray<Node *>( baseB );
+                if ( nodesA.GetSize() != nodesB.GetSize() )
+                {
+                    return false;
+                }
+                const size_t numNodes = nodesA.GetSize();
+                for ( size_t i = 0; i < numNodes; ++i )
+                {
+                    if ( nodesA[ i ]->GetName() != nodesB[ i ]->GetName() )
+                    {
+                        return false;
+                    }
+                }
+                break;
+            }
+            else
+            {
+                const Node * nodeA = *property.GetPtrToPropertyCustom<Node *>( baseA );
+                const Node * nodeB = *property.GetPtrToPropertyCustom<Node *>( baseB );
+                const bool same = ( nodeA && nodeB ) ? ( nodeA->GetName() == nodeB->GetName() )
+                                                     : ( ( nodeA == nullptr ) && ( nodeB == nullptr ) );
+                if ( !same )
+                {
+                    return false;
+                }
             }
             break;
         }

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -66,7 +66,7 @@ public:
     }
     ~NodeGraphHeader() = default;
 
-    inline static const uint8_t kCurrentVersion = 193;
+    inline static const uint8_t kCurrentVersion = 194;
 
     bool IsValid() const;
     bool IsCompatibleVersion() const { return m_Version == kCurrentVersion; }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.cpp
@@ -98,10 +98,7 @@ ObjectListNode::ObjectListNode()
 /*virtual*/ bool ObjectListNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .ConcurrencyGroupName
     if ( !InitializeConcurrencyGroup( nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectListNode.h
@@ -45,7 +45,6 @@ public:
     const AString & GetCompilerOptionsDeoptimized() const { return m_CompilerOptionsDeoptimized; }
     const AString & GetCompilerOptionsPCH() const { return m_PCHOptions; }
     const AString & GetPreprocessorOptions() const { return m_PreprocessorOptions; }
-    const Array<AString> & GetPreBuildDependencyNames() const { return m_PreBuildDependencyNames; }
     const Array<AString> & GetCompilerForceUsing() const { return m_CompilerForceUsing; }
     CompilerNode * GetCompiler() const { return m_CompilerNode; }
     CompilerNode * GetPreprocessor() const { return m_PreprocessorNode; }
@@ -120,7 +119,7 @@ protected:
     AString m_PCHOptions;
     AString m_Preprocessor;
     AString m_PreprocessorOptions;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
     AString m_ConcurrencyGroupName;
 
     // Internal State

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.cpp
@@ -41,10 +41,7 @@ RemoveDirNode::RemoveDirNode()
 /*virtual*/ bool RemoveDirNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // Convert RemovePaths paths to DirectoryListNodes
     Dependencies fileListDeps( m_RemovePaths.GetSize() );

--- a/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/RemoveDirNode.h
@@ -36,7 +36,7 @@ private:
     Array<AString> m_RemovePatterns;
     Array<AString> m_RemoveExcludePaths;
     Array<AString> m_RemoveExcludeFiles;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
@@ -65,10 +65,7 @@ TestNode::TestNode()
 /*virtual*/ bool TestNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     // .ConcurrencyGroupName
     if ( !InitializeConcurrencyGroup( nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.h
@@ -44,7 +44,7 @@ private:
     uint32_t m_TestTimeOut;
     bool m_TestAlwaysShowOutput;
     bool m_TestInputPathRecurse;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
     Array<AString> m_Environment;
     AString m_ConcurrencyGroupName;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/TextFileNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TextFileNode.cpp
@@ -41,13 +41,10 @@ TextFileNode::TextFileNode()
 
 // Initialize
 //------------------------------------------------------------------------------
-/*virtual*/ bool TextFileNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
+/*virtual*/ bool TextFileNode::Initialize( NodeGraph & /*nodeGraph*/, const BFFToken * /*iter*/, const Function * /*function*/ )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     return true;
 }

--- a/Code/Tools/FBuild/FBuildCore/Graph/TextFileNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TextFileNode.h
@@ -35,7 +35,7 @@ private:
     AString m_TextFileOutput;
     Array<AString> m_TextFileInputStrings;
     bool m_TextFileAlways;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
 };
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.cpp
@@ -178,10 +178,7 @@ UnityNode::UnityNode()
 /*virtual*/ bool UnityNode::Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function )
 {
     // .PreBuildDependencies
-    if ( !InitializePreBuildDependencies( nodeGraph, iter, function, m_PreBuildDependencyNames ) )
-    {
-        return false; // InitializePreBuildDependencies will have emitted an error
-    }
+    m_PreBuildDependencies.Add( m_PreBuildDependencyNames );
 
     Dependencies dirNodes( m_InputPaths.GetSize() );
     if ( !Function::GetDirectoryListNodeList( nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/UnityNode.h
@@ -104,7 +104,7 @@ protected:
     uint32_t m_MaxIsolatedFiles;
     AString m_IsolateListFile;
     Array<AString> m_ExcludePatterns;
-    Array<AString> m_PreBuildDependencyNames;
+    Array<Node *> m_PreBuildDependencyNames;
     bool m_UseRelativePaths_Experimental;
 
     // Temporary data


### PR DESCRIPTION
[Improvement] DB load/save time improved for complex Aliases and PreBuildDependencies
- lists of nodes are loaded and saved via index instead of string name
[Improvement] BFF parsing time reduced for complex Aliases and PreBuildDependencies
 - strings names are resolved to pointers once and kept as such instead of being converted to strings and re-resolved again later 
[Improvement] Memory usage reduced for complex Aliases and PreBuildDependencies
 - string names are no longer kept in memory during the build (are only used temporarily during initial bff parsing)
[Note] DB version changed

The reflection system can now reflect Arrays of Node pointers directly allowing things to be resolved, managed and serialized much more efficiently. This optimization can be applied to some additional properties in the future with the addition of some Metadata constraints on the lookup.