### PR TITLE
[Fix] Avoid unnecessary rebuilds after bff edits when using Clang & LightCache

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.cpp
@@ -22,7 +22,7 @@ REFLECT_NODE_BEGIN( CompilerInfoNode, Node )
     REFLECT( m_Compiler, MetaHidden() )
     REFLECT( m_NoStdInc, MetaHidden() )
     REFLECT( m_NoStdIncPP, MetaHidden() )
-    REFLECT( m_BuiltinIncludePaths, MetaHidden() )
+    REFLECT( m_BuiltinIncludePaths, MetaHidden() + MetaIgnoreForComparison() )
 REFLECT_END( CompilerInfoNode )
 
 // CONSTRUCTOR
@@ -248,6 +248,17 @@ void CompilerInfoNode::EmitCompilationMessage( const AString & args ) const
     {
         FLOG_OUTPUT( output );
     }
+}
+
+//------------------------------------------------------------------------------
+/*virtual*/ void CompilerInfoNode::Migrate( const Node & oldNode )
+{
+    // Migrate Node level properties
+    Node::Migrate( oldNode );
+
+    // Migrate lazily evaluated properties
+    const CompilerInfoNode * oldCompilerInfoNode = oldNode.CastTo<CompilerInfoNode>();
+    m_BuiltinIncludePaths = oldCompilerInfoNode->m_BuiltinIncludePaths;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerInfoNode.h
@@ -27,6 +27,7 @@ private:
     virtual bool IsAFile() const override;
     virtual bool Initialize( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function ) override;
     virtual Node::BuildResult DoBuild( Job * job ) override;
+    virtual void Migrate( const Node & oldNode ) override;
 
     void EmitCompilationMessage( const AString & args ) const;
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCache.cpp
@@ -971,6 +971,23 @@ void TestCache::LightCache_NoRebuild() const
         CheckLightCacheStores( fBuild, 0 );
         CheckLightCacheHits( fBuild, 0 );
     }
+
+    // BFF edit no rebuild
+    {
+        FBuildTestOptions optionsCopy( options );
+        optionsCopy.m_ForceDBMigration_Debug = true;
+        FBuildForTest fBuild( optionsCopy );
+        TEST_ASSERT( fBuild.Initialize( dbFile ) );
+
+        // Build - Ensure CompilerInfo is built
+        TEST_ASSERT( fBuild.Build( "ObjectList" ) );
+
+        // Check stats: Seen, Built, Type
+        CheckStatsNode( 1, 0, Node::COMPILER_INFO_NODE );
+        CheckStatsNode( 1, 0, Node::OBJECT_NODE );
+        CheckLightCacheStores( fBuild, 0 );
+        CheckLightCacheHits( fBuild, 0 );
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- ensure the built-in include paths are ignored for comparison and correctly migrated in CompilerInfoNode as this property is evaluated during the build