### PR TITLE
[Improvement] FBuildWorker will self-restart on Windows when updated even if -console mode is used

### DIFF
--- a/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/FBuildWorkerOptions.cpp
@@ -44,9 +44,6 @@ bool FBuildWorkerOptions::ProcessCommandLine( const AString & commandLine )
         if ( token == "-console" )
         {
             m_ConsoleMode = true;
-    #if defined( __WINDOWS__ )
-            m_UseSubprocess = false;
-    #endif
             continue;
         }
 #endif

--- a/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
+++ b/Code/Tools/FBuild/FBuildWorker/Worker/Worker.cpp
@@ -216,7 +216,10 @@ uint32_t Worker::WorkThread()
     }
 
     // Now that we will no longer interact with the UI, we can stop the message pump
-    m_MainWindow->StopMessagePump();
+    if ( m_MainWindow )
+    {
+        m_MainWindow->StopMessagePump();
+    }
 
     m_WorkerBrokerage.SetAvailability( false );
 


### PR DESCRIPTION
[Note] FBuildWorker -console on Windows no longer forces -nosubprocess