### PR TITLE
[Fix] Save errno before close() clobbers it in SystemMutex::TryLock

### DIFF
--- a/Code/Core/Process/SystemMutex.cpp
+++ b/Code/Core/Process/SystemMutex.cpp
@@ -65,8 +65,9 @@ bool SystemMutex::TryLock()
     int rc = flock( handle, LOCK_EX | LOCK_NB );
     if ( rc )
     {
+        const int flockErrno = errno;
         VERIFY( close( handle ) == 0 );
-        if ( errno == EWOULDBLOCK || errno == EAGAIN )
+        if ( flockErrno == EWOULDBLOCK || flockErrno == EAGAIN )
         {
             return false; // locked by another process
         }


### PR DESCRIPTION
# Description:                                                                                                                                          
                                                                                                                                                             
   In `SystemMutex::TryLock` on Linux, when `flock()` fails because another process holds the lock, `errno` is set to `EWOULDBLOCK`/`EAGAIN`. However   `close(handle)` is called before checking `errno`, and a successful `close()` clobbers it. The subsequent check on line 69 then reads an undefined `errno` value and may fail to detect the "already locked" condition, causing `TryLock` to incorrectly report an unexpected failure instead of returning   
    `false`.                                                                                                                                                 
                                                                                                                                                             
   The fix saves `errno` from `flock()` before calling `close()`.                                                                                            
                                                                                                                                                             
   # Checklist:                                                                                                                                              
                                                                                                                                                             
   The pull request:                                                                                                                                         
   - [x] **Is created against the Dev branch**                                                                                                               
   - [x] **Is self-contained**                                                                                                                               
   - [x] **Compiles on Windows, OSX and Linux**                                                                                                              
   - [ ] **Has accompanying tests**                                                                                                                          
   - [x] **Passes existing tests**                                                                                                                           
   - [x] **Keeps Windows, OSX and Linux at parity**                                                                                                          
   - [x] **Follows the code style**                                                                                                                          
   - [ ] **Includes documentation**  