### PR TITLE
[Improvement] BFF parsing performance for Node resolution improved slightly

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.cpp
@@ -456,6 +456,24 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
                             bool required,
                             const GetNodeListOptions & options ) const
 {
+    StackArray<Node *, 128> nodePointers;
+    if ( !GetNodeList( nodeGraph, iter, propertyName, nodePointers, required, options ) )
+    {
+        return false;
+    }
+
+    nodes.Add( nodePointers );
+    return true;
+}
+
+//------------------------------------------------------------------------------
+bool Function::GetNodeList( NodeGraph & nodeGraph,
+                            const BFFToken * iter,
+                            const char * propertyName,
+                            Array<Node *> & nodes,
+                            bool required,
+                            const GetNodeListOptions & options ) const
+{
     ASSERT( propertyName );
 
     const BFFVariable * var = BFFStackFrame::GetVar( propertyName );
@@ -749,6 +767,25 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
                                        Dependencies & nodes,
                                        const GetNodeListOptions & options )
 {
+    StackArray<Node *, 128> nodePointers;
+    if ( !GetNodeList( nodeGraph, iter, function, propertyName, nodeNames, nodePointers, options ) )
+    {
+        return false;
+    }
+
+    nodes.Add( nodePointers );
+    return true;
+}
+
+//------------------------------------------------------------------------------
+/*static*/ bool Function::GetNodeList( NodeGraph & nodeGraph,
+                                       const BFFToken * iter,
+                                       const Function * function,
+                                       const char * propertyName,
+                                       const Array<AString> & nodeNames,
+                                       Array<Node *> & nodes,
+                                       const GetNodeListOptions & options )
+{
     // Start a fresh pass operation so we can see which nodes we already visited
     Node::StartSecondaryTagSweep();
 
@@ -779,6 +816,28 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     // Start a fresh pass operation so we can see which nodes we already visited
     Node::StartSecondaryTagSweep();
 
+    StackArray<Node *> nodePointers;
+    if ( !GetNodeListInternal( nodeGraph, iter, function, propertyName, nodeName, nodePointers, options ) )
+    {
+        return false;
+    }
+
+    nodes.Add( nodePointers );
+    return true;
+}
+
+//------------------------------------------------------------------------------
+/*static*/ bool Function::GetNodeList( NodeGraph & nodeGraph,
+                                       const BFFToken * iter,
+                                       const Function * function,
+                                       const char * propertyName,
+                                       const AString & nodeName,
+                                       Array<Node *> & nodes,
+                                       const GetNodeListOptions & options )
+{
+    // Start a fresh pass operation so we can see which nodes we already visited
+    Node::StartSecondaryTagSweep();
+
     return GetNodeListInternal( nodeGraph, iter, function, propertyName, nodeName, nodes, options );
 }
 
@@ -788,7 +847,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
                                                const Function * function,
                                                const char * propertyName,
                                                const AString & nodeName,
-                                               Dependencies & nodes,
+                                               Array<Node *> & nodes,
                                                const GetNodeListOptions & options )
 {
     // get node
@@ -797,7 +856,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     {
         // not found - create a new file node
         n = nodeGraph.CreateNode<FileNode>( nodeName, iter );
-        nodes.Add( n );
+        nodes.Append( n );
         n->SetSecondaryTag();
         return true;
     }
@@ -811,7 +870,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
                                                const Function * function,
                                                const char * propertyName,
                                                Node * n,
-                                               Dependencies & nodes,
+                                               Array<Node *> & nodes,
                                                const GetNodeListOptions & options )
 {
     ASSERT( n );
@@ -830,7 +889,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     if ( n->IsAFile() )
     {
         // found file - just use as is
-        nodes.Add( n );
+        nodes.Append( n );
         return true;
     }
 
@@ -838,7 +897,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
     if ( n->GetType() == Node::OBJECT_LIST_NODE )
     {
         // use as-is
-        nodes.Add( n );
+        nodes.Append( n );
         return true;
     }
 
@@ -849,7 +908,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::COPY_DIR_NODE )
         {
             // use as-is
-            nodes.Add( n );
+            nodes.Append( n );
             return true;
         }
     }
@@ -859,7 +918,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::REMOVE_DIR_NODE )
         {
             // use as-is
-            nodes.Add( n );
+            nodes.Append( n );
             return true;
         }
     }
@@ -869,7 +928,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::UNITY_NODE )
         {
             // use as-is
-            nodes.Add( n );
+            nodes.Append( n );
             return true;
         }
     }
@@ -879,7 +938,7 @@ bool Function::GetNodeList( NodeGraph & nodeGraph,
         if ( n->GetType() == Node::COMPILER_NODE )
         {
             // use as-is
-            nodes.Add( n );
+            nodes.Append( n );
             return true;
         }
     }
@@ -1537,7 +1596,7 @@ bool Function::PopulateCustom( NodeGraph & nodeGraph,
 
     // Get list of nodes
     const bool required = ( property.HasMetaData<Meta_Required>() != nullptr );
-    Dependencies nodes;
+    StackArray<Node *, 128> nodes;
     GetNodeListOptions options;
     options.m_AllowCopyDirNodes = true;
     options.m_AllowUnityNodes = true;
@@ -1559,10 +1618,7 @@ bool Function::PopulateCustom( NodeGraph & nodeGraph,
         Array<Node *> * dst = property.GetPtrToArray<Node *>( base );
         dst->Clear();
         dst->SetCapacity( nodes.GetSize() );
-        for ( const Dependency & dep : nodes )
-        {
-            dst->Append( dep.GetNode() );
-        }
+        dst->Append( nodes );
     }
     else
     {
@@ -1574,7 +1630,7 @@ bool Function::PopulateCustom( NodeGraph & nodeGraph,
         }
         else if ( nodes.GetSize() == 1 )
         {
-            *dst = nodes[ 0 ].GetNode();
+            *dst = nodes[ 0 ];
         }
         else
         {

--- a/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
+++ b/Code/Tools/FBuild/FBuildCore/BFF/Functions/Function.h
@@ -122,8 +122,22 @@ public:
                              const BFFToken * iter,
                              const Function * function,
                              const char * propertyName,
+                             const Array<AString> & nodeNames,
+                             Array<Node *> & nodes,
+                             const GetNodeListOptions & options = GetNodeListOptions() );
+    static bool GetNodeList( NodeGraph & nodeGraph,
+                             const BFFToken * iter,
+                             const Function * function,
+                             const char * propertyName,
                              const AString & nodeName,
                              Dependencies & nodes,
+                             const GetNodeListOptions & options = GetNodeListOptions() );
+    static bool GetNodeList( NodeGraph & nodeGraph,
+                             const BFFToken * iter,
+                             const Function * function,
+                             const char * propertyName,
+                             const AString & nodeName,
+                             Array<Node *> & nodes,
                              const GetNodeListOptions & options = GetNodeListOptions() );
 
 protected:
@@ -132,14 +146,14 @@ protected:
                                      const Function * function,
                                      const char * propertyName,
                                      const AString & nodeName,
-                                     Dependencies & nodes,
+                                     Array<Node *> & nodes,
                                      const GetNodeListOptions & options );
     static bool GetNodeListInternal( NodeGraph & nodeGraph,
                                      const BFFToken * iter,
                                      const Function * function,
                                      const char * propertyName,
                                      Node * node,
-                                     Dependencies & nodes,
+                                     Array<Node *> & nodes,
                                      const GetNodeListOptions & options );
 
     AString m_Name;
@@ -155,6 +169,12 @@ protected:
                       const BFFToken * iter,
                       const char * name,
                       Dependencies & nodes,
+                      bool required = false,
+                      const GetNodeListOptions & options = GetNodeListOptions() ) const;
+    bool GetNodeList( NodeGraph & nodeGraph,
+                      const BFFToken * iter,
+                      const char * name,
+                      Array<Node *> & nodes,
                       bool required = false,
                       const GetNodeListOptions & options = GetNodeListOptions() ) const;
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CompilerNode.cpp
@@ -77,7 +77,7 @@ CompilerNode::CompilerNode()
     ASSERT( compilerExeFile.GetSize() == 1 ); // Should not be possible to expand to > 1 thing
 
     // .ExtraFiles
-    Dependencies extraFiles( 32 );
+    Dependencies extraFiles;
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".ExtraFiles", m_ExtraFiles, extraFiles ) )
     {
         return false; // GetNodeList will have emitted an error

--- a/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/LinkerNode.cpp
@@ -136,7 +136,7 @@ LinkerNode::LinkerNode()
     }
 
     // Assembly Resources
-    Dependencies assemblyResources( 32 );
+    Dependencies assemblyResources;
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".LinkerAssemblyResources", m_LinkerAssemblyResources, assemblyResources ) )
     {
         return false; // GetNodeList will have emitted error

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.cpp
@@ -1202,33 +1202,6 @@ void Node::ReplaceDummyName( const AString & newName )
     }
 }
 
-// InitializePreBuildDependencies
-//------------------------------------------------------------------------------
-bool Node::InitializePreBuildDependencies( NodeGraph & nodeGraph, const BFFToken * iter, const Function * function, const Array<AString> & preBuildDependencyNames )
-{
-    if ( preBuildDependencyNames.IsEmpty() )
-    {
-        return true;
-    }
-
-    // Pre-size hint
-    m_PreBuildDependencies.SetCapacity( preBuildDependencyNames.GetSize() );
-
-    // Expand
-    GetNodeListOptions options;
-    options.m_AllowCopyDirNodes = true;
-    options.m_AllowUnityNodes = true;
-    options.m_AllowRemoveDirNodes = true;
-    options.m_AllowCompilerNodes = true;
-    options.m_RemoveDuplicates = true;
-    if ( !Function::GetNodeList( nodeGraph, iter, function, ".PreBuildDependencies", preBuildDependencyNames, m_PreBuildDependencies, options ) )
-    {
-        return false; // GetNodeList will have emitted an error
-    }
-
-    return true;
-}
-
 // InitializeConcurrencyGroup
 //------------------------------------------------------------------------------
 bool Node::InitializeConcurrencyGroup( NodeGraph & nodeGraph,

--- a/Code/Tools/FBuild/FBuildCore/Graph/Node.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Node.h
@@ -265,10 +265,6 @@ protected:
 
     virtual void Migrate( const Node & oldNode );
 
-    bool InitializePreBuildDependencies( NodeGraph & nodeGraph,
-                                         const BFFToken * iter,
-                                         const Function * function,
-                                         const Array<AString> & preBuildDependencyNames );
     bool InitializeConcurrencyGroup( NodeGraph & nodeGraph,
                                      const BFFToken * iter,
                                      const Function * function,

--- a/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/XCodeProjectNode.cpp
@@ -129,7 +129,7 @@ XCodeProjectNode::XCodeProjectNode()
     }
 
     // .ProjectFiles
-    Dependencies fileNodes( m_ProjectFiles.GetSize() );
+    Dependencies fileNodes;
     if ( !Function::GetNodeList( nodeGraph, iter, function, ".ProjectFiles", m_ProjectFiles, fileNodes ) )
     {
         return false; // GetNodeList will have emitted an error


### PR DESCRIPTION
 - Reduce memory allocations in GetNodeList function calls. Build temporary lists mostly on stack and assign in a final allocation to destination, reducing or eliminating temporary allocations.