### PR TITLE
[Improvement] Improve performance of .fdb migration after bff edits

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
@@ -79,6 +79,7 @@ public:
     void Add( const Dependencies & deps );
     void Add( const Array<Node *> & nodes );
     Dependencies & operator=( const Dependencies & other );
+    Dependencies & operator=( Dependencies && other );
 
     void Save( IOStream & stream ) const;
     void Load( NodeGraph & nodeGraph, uint32_t numDeps, ConstMemoryStream & stream );
@@ -215,6 +216,15 @@ inline Dependencies & Dependencies::operator=( const Dependencies & other )
 {
     Clear();
     Add( other );
+    return *this;
+}
+
+//------------------------------------------------------------------------------
+inline Dependencies & Dependencies::operator=( Dependencies && other )
+{
+    Clear();
+    m_DependencyList = other.m_DependencyList;
+    other.m_DependencyList = nullptr;
     return *this;
 }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.cpp
@@ -58,8 +58,22 @@
 
 #include <string.h>
 
-// Defines
 //------------------------------------------------------------------------------
+class NodeGraphMigrationCache
+{
+public:
+    NodeGraphMigrationCache( NodeGraph & newNodeGraph,
+                             const Array<Node *> & oldNodes );
+
+    Node * FindNewNode( const Node * oldNode );
+
+    // Non-copyable
+    NodeGraphMigrationCache & operator=( const NodeGraphMigrationCache & other ) = delete;
+
+private:
+    Array<Node *> m_OldToNewNodeMapping;
+    NodeGraph & m_NewNodeGraph;
+};
 
 // Static Data
 //------------------------------------------------------------------------------
@@ -1832,6 +1846,9 @@ void NodeGraph::Migrate( const NodeGraph & oldNodeGraph )
 
     s_BuildPassTag++;
 
+    // Pre-resolve node mappings
+    NodeGraphMigrationCache migrationCache( *this, oldNodeGraph.m_AllNodes );
+
     // NOTE: m_AllNodes can change during recursion, so we must take care to
     // iterate by index (array might move due to resizing). Any newly added
     // nodes will already be traversed so we only need to check the original
@@ -1840,13 +1857,16 @@ void NodeGraph::Migrate( const NodeGraph & oldNodeGraph )
     for ( size_t i = 0; i < numNodes; ++i )
     {
         Node & newNode = *m_AllNodes[ i ];
-        MigrateNode( oldNodeGraph, newNode, nullptr );
+        MigrateNode( migrationCache, oldNodeGraph, newNode, nullptr );
     }
 }
 
 // MigrateNode
 //------------------------------------------------------------------------------
-void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, const Node * oldNodeHint )
+void NodeGraph::MigrateNode( NodeGraphMigrationCache & migrationCache,
+                             const NodeGraph & oldNodeGraph,
+                             Node & newNode,
+                             const Node * oldNodeHint )
 {
     // Prevent visiting the same node twice
     if ( newNode.GetBuildPassTag() == s_BuildPassTag )
@@ -1864,11 +1884,11 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
     // Migrate children before parents
     for ( const Dependency & dep : newNode.m_PreBuildDependencies )
     {
-        MigrateNode( oldNodeGraph, *dep.GetNode(), nullptr );
+        MigrateNode( migrationCache, oldNodeGraph, *dep.GetNode(), nullptr );
     }
     for ( const Dependency & dep : newNode.m_StaticDependencies )
     {
-        MigrateNode( oldNodeGraph, *dep.GetNode(), nullptr );
+        MigrateNode( migrationCache, oldNodeGraph, *dep.GetNode(), nullptr );
     }
 
     // Get the matching node in the old DB
@@ -1903,7 +1923,7 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
     }
 
     // Have the properties on the node changed?
-    if ( AreNodesTheSame( oldNode, &newNode, newNodeRI ) == false )
+    if ( AreNodesTheSame( migrationCache, oldNode, &newNode, newNodeRI ) == false )
     {
         // Properties have changed. We need to rebuild with the new
         // properties.
@@ -1911,13 +1931,13 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
     }
 
     // PreBuildDependencies
-    if ( DoDependenciesMatch( oldNode->m_PreBuildDependencies, newNode.m_PreBuildDependencies ) == false )
+    if ( DoDependenciesMatch( migrationCache, oldNode->m_PreBuildDependencies, newNode.m_PreBuildDependencies ) == false )
     {
         return;
     }
 
     // StaticDependencies
-    if ( DoDependenciesMatch( oldNode->m_StaticDependencies, newNode.m_StaticDependencies ) == false )
+    if ( DoDependenciesMatch( migrationCache, oldNode->m_StaticDependencies, newNode.m_StaticDependencies ) == false )
     {
         return;
     }
@@ -1941,7 +1961,7 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
         {
             // See if the dependency already exists in the new DB
             const Node * oldDepNode = oldDep.GetNode();
-            Node * newDepNode = FindNodeInternal( oldDepNode->GetName(), oldDepNode->GetNameHash() );
+            Node * newDepNode = migrationCache.FindNewNode( oldDepNode );
 
             // If the dependency exists, but has changed type, then dependencies
             // cannot be transferred.
@@ -1976,13 +1996,11 @@ void NodeGraph::MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, con
                 VERIFY( newDepNode->Initialize( *this, token, nullptr ) );
 
                 // Continue recursing
-                MigrateNode( oldNodeGraph, *newDepNode, oldDepNode );
+                MigrateNode( migrationCache, oldNodeGraph, *newDepNode, oldDepNode );
             }
         }
-        if ( newDeps.IsEmpty() == false )
-        {
-            newNode.m_DynamicDependencies.Add( newDeps );
-        }
+        ASSERT( newDeps.GetSize() == oldDeps.GetSize() );
+        newNode.m_DynamicDependencies = Move( newDeps );
     }
 
     // If we get here, then everything about the node is unchanged from the
@@ -2119,7 +2137,10 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
 
 // AreNodesTheSame
 //------------------------------------------------------------------------------
-/*static*/ bool NodeGraph::AreNodesTheSame( const void * baseA, const void * baseB, const ReflectionInfo * ri )
+/*static*/ bool NodeGraph::AreNodesTheSame( NodeGraphMigrationCache & migrationCache,
+                                            const void * baseA,
+                                            const void * baseB,
+                                            const ReflectionInfo * ri )
 {
     // Are all properties the same?
     do
@@ -2128,7 +2149,7 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
         for ( ReflectionIter it = ri->Begin(); it != end; ++it )
         {
             // Is this property the same?
-            if ( AreNodesTheSame( baseA, baseB, *it ) == false )
+            if ( AreNodesTheSame( migrationCache, baseA, baseB, *it ) == false )
             {
                 return false;
             }
@@ -2143,7 +2164,10 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
 
 // AreNodesTheSame
 //------------------------------------------------------------------------------
-/*static*/ bool NodeGraph::AreNodesTheSame( const void * baseA, const void * baseB, const ReflectedProperty & property )
+/*static*/ bool NodeGraph::AreNodesTheSame( NodeGraphMigrationCache & migrationCache,
+                                            const void * baseA,
+                                            const void * baseB,
+                                            const ReflectedProperty & property )
 {
     if ( property.HasMetaData<Meta_IgnoreForComparison>() )
     {
@@ -2254,7 +2278,10 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
                 }
                 for ( uint32_t i = 0; i < numElementsA; ++i )
                 {
-                    if ( AreNodesTheSame( propertyStruct.GetStructInArray( baseA, i ), propertyStruct.GetStructInArray( baseB, i ), propertyStruct.GetStructReflectionInfo() ) == false )
+                    if ( AreNodesTheSame( migrationCache,
+                                          propertyStruct.GetStructInArray( baseA, i ),
+                                          propertyStruct.GetStructInArray( baseB, i ),
+                                          propertyStruct.GetStructReflectionInfo() ) == false )
                     {
                         return false;
                     }
@@ -2262,7 +2289,10 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
             }
             else
             {
-                if ( AreNodesTheSame( propertyStruct.GetStructBase( baseA ), propertyStruct.GetStructBase( baseB ), propertyStruct.GetStructReflectionInfo() ) == false )
+                if ( AreNodesTheSame( migrationCache,
+                                      propertyStruct.GetStructBase( baseA ),
+                                      propertyStruct.GetStructBase( baseB ),
+                                      propertyStruct.GetStructReflectionInfo() ) == false )
                 {
                     return false;
                 }
@@ -2282,6 +2312,11 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
                 const size_t numNodes = nodesA.GetSize();
                 for ( size_t i = 0; i < numNodes; ++i )
                 {
+                    const Node * n = migrationCache.FindNewNode( nodesA[ i ] );
+                    if ( n == nodesB[ i ] )
+                    {
+                        continue; // Same
+                    }
                     if ( nodesA[ i ]->GetName() != nodesB[ i ]->GetName() )
                     {
                         return false;
@@ -2310,7 +2345,9 @@ void NodeGraph::MigrateProperty( const void * oldBase, void * newBase, const Ref
 
 // DoDependenciesMatch
 //------------------------------------------------------------------------------
-bool NodeGraph::DoDependenciesMatch( const Dependencies & depsA, const Dependencies & depsB )
+bool NodeGraph::DoDependenciesMatch( NodeGraphMigrationCache & migrationCache,
+                                     const Dependencies & depsA,
+                                     const Dependencies & depsB )
 {
     if ( depsA.GetSize() != depsB.GetSize() )
     {
@@ -2330,6 +2367,11 @@ bool NodeGraph::DoDependenciesMatch( const Dependencies & depsA, const Dependenc
         {
             return false;
         }
+        const Node * node = migrationCache.FindNewNode( nodeA );
+        if ( node == nodeB )
+        {
+            continue;
+        }
         if ( nodeA->GetName() != nodeB->GetName() )
         {
             return false;
@@ -2337,6 +2379,44 @@ bool NodeGraph::DoDependenciesMatch( const Dependencies & depsA, const Dependenc
     }
 
     return true;
+}
+
+//------------------------------------------------------------------------------
+NodeGraphMigrationCache::NodeGraphMigrationCache( NodeGraph & newNodeGraph,
+                                                  const Array<Node *> & oldNodes )
+    : m_NewNodeGraph( newNodeGraph )
+{
+    // Init pointer table with nullptrs
+    const size_t numNodes = oldNodes.GetSize();
+    m_OldToNewNodeMapping.SetSize( numNodes );
+    memset( m_OldToNewNodeMapping.Begin(), 0, ( numNodes * sizeof( Node * ) ) );
+
+    // Set back indices into table
+    for ( uint32_t i = 0; i < numNodes; ++i )
+    {
+        oldNodes[ i ]->SetBuildPassTag( i );
+    }
+}
+
+//------------------------------------------------------------------------------
+Node * NodeGraphMigrationCache::FindNewNode( const Node * oldNode )
+{
+    // Lookup existing entry
+    const uint32_t index = oldNode->GetBuildPassTag();
+    Node * newNode = m_OldToNewNodeMapping[ index ];
+
+    // Already set?
+    if ( newNode )
+    {
+        ASSERT( oldNode->GetName() == newNode->GetName() );
+    }
+    else
+    {
+        // Init entry on first use
+        newNode = m_NewNodeGraph.FindNodeInternal( oldNode->GetName(), oldNode->GetNameHash() );
+        m_OldToNewNodeMapping[ index ] = newNode;
+    }
+    return newNode;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/NodeGraph.h
@@ -36,6 +36,7 @@ class LibraryNode;
 class LinkerNode;
 class ListDependenciesNode;
 class Node;
+class NodeGraphMigrationCache;
 class ObjectListNode;
 class ObjectNode;
 class ReflectionInfo;
@@ -150,6 +151,7 @@ public:
 
 private:
     friend class FBuild;
+    friend class NodeGraphMigrationCache;
 
     bool ParseFromRoot( const char * bffFile );
 
@@ -213,12 +215,23 @@ private:
 
     // DB Migration
     void Migrate( const NodeGraph & oldNodeGraph );
-    void MigrateNode( const NodeGraph & oldNodeGraph, Node & newNode, const Node * oldNode );
+    void MigrateNode( NodeGraphMigrationCache & migrationCache,
+                      const NodeGraph & oldNodeGraph,
+                      Node & newNode,
+                      const Node * oldNode );
     void MigrateProperties( const void * oldBase, void * newBase, const ReflectionInfo * ri );
     void MigrateProperty( const void * oldBase, void * newBase, const ReflectedProperty & property );
-    static bool AreNodesTheSame( const void * baseA, const void * baseB, const ReflectionInfo * ri );
-    static bool AreNodesTheSame( const void * baseA, const void * baseB, const ReflectedProperty & property );
-    static bool DoDependenciesMatch( const Dependencies & depsA, const Dependencies & depsB );
+    static bool AreNodesTheSame( NodeGraphMigrationCache & migrationCache,
+                                 const void * baseA,
+                                 const void * baseB,
+                                 const ReflectionInfo * ri );
+    static bool AreNodesTheSame( NodeGraphMigrationCache & migrationCache,
+                                 const void * baseA,
+                                 const void * baseB,
+                                 const ReflectedProperty & property );
+    static bool DoDependenciesMatch( NodeGraphMigrationCache & migrationCache,
+                                     const Dependencies & depsA,
+                                     const Dependencies & depsB );
 
     Node ** m_NodeMap;
     uint32_t m_NodeMapMaxKey; // Always equals to some power of 2 minus 1, can be used as mask.


### PR DESCRIPTION
 - Cache lookup of old to new node lookups as we go to avoid performing the same lookup redundantly
 - Avoid string comparisons when comparing checking equality of node names by leveraging this same cache (the cache is populated from the name)
 - Move dependencies instead of copying them, avoiding some memory allocations