### PR TITLE
[Improvement] Harden work-arounds for Windows anti-virus IO problems (Thanks to Jean-Sébastien Pelletier)

### DIFF
--- a/Code/Core/FileIO/FileStream.cpp
+++ b/Code/Core/FileIO/FileStream.cpp
@@ -9,6 +9,7 @@
 #include "Core/Env/Assert.h"
 #include "Core/Strings/AStackString.h"
 #include "Core/Strings/AString.h"
+#include "Core/Time/Timer.h"
 
 // system
 #include <stdio.h>
@@ -54,7 +55,7 @@ FileStream::~FileStream()
 
 // Open
 //------------------------------------------------------------------------------
-bool FileStream::Open( const char * fileName, uint32_t fileMode )
+bool FileStream::Open( const char * fileName, uint32_t fileMode, uint32_t timeoutMilliSecs )
 {
     ASSERT( !IsOpen() );
 
@@ -95,9 +96,16 @@ bool FileStream::Open( const char * fileName, uint32_t fileMode )
         flags |= FILE_ATTRIBUTE_TEMPORARY; // don't flush to disk if possible
     }
 
-    // for sharing violations, we'll retry a few times as per http://support.microsoft.com/kb/316609
-    size_t retryCount = 0;
-    while ( retryCount < 5 )
+    // for sharing violations, we'll retry a few times as per https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/316609
+    // On Windows, we can occasionally fail to open the file with error 128(SHARING_VIOLATION) but also sometimes on 1224 (ERROR_USER_MAPPED_FILE),
+    // due to things like anti-virus etc. Simply retry if that happens
+
+    const Timer timer;
+    DWORD sleepTime = 25; // Current sleep time when retrying
+    DWORD sleepTimeBackOffNextThreshold = 500; // Next time to increase the sleep time
+    const DWORD SLEEP_TIME_BACKOFF_INCREMENT = 500; // Increase the back-off threshold by 500ms each time we increase the sleep time
+    const DWORD MAX_SLEEP_TIME = 200; // Never more than 200 ms between each retry.
+    while ( true )
     {
         HANDLE h = CreateFile( fileName,            // _In_     LPCTSTR lpFileName,
                                desiredAccess,       // _In_     DWORD dwDesiredAccess,
@@ -117,22 +125,39 @@ bool FileStream::Open( const char * fileName, uint32_t fileMode )
         // problem opening file...
 
         // was it a sharing violation?
-        if ( GetLastError() == ERROR_SHARING_VIOLATION )
+        const DWORD errorCode = GetLastError();
+        if ( ( errorCode == ERROR_SHARING_VIOLATION ) ||
+             ( errorCode == ERROR_USER_MAPPED_FILE ) )
         {
             if ( ( fileMode & NO_RETRY_ON_SHARING_VIOLATION ) != 0 )
             {
                 break; // just fail
             }
 
-            ++retryCount;
-            Sleep( 100 ); // sleep and
-            continue; // try again as per http://support.microsoft.com/kb/316609
+            if ( timer.GetElapsedMS() > (float)timeoutMilliSecs )
+            {
+                break;
+            }
+
+            // Adjust CPU friendly sleep time using a simple back-off algorithm when it takes a while to open the file.
+            // The idea is to attempt to give more time to anti-virus to complete its task when the scan takes more time than usual.
+            if ( sleepTime < MAX_SLEEP_TIME && timer.GetElapsedMS() > (float)sleepTimeBackOffNextThreshold )
+            {
+                sleepTime = Math::Min( sleepTime * 2, MAX_SLEEP_TIME );
+                sleepTimeBackOffNextThreshold += SLEEP_TIME_BACKOFF_INCREMENT;
+            }
+
+            // sleep and try again as per https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/316609
+            Sleep( sleepTime );
+            continue;
         }
 
         // some other kind of error...
         break;
     }
 #elif defined( __APPLE__ ) || defined( __LINUX__ )
+    (void)timeoutMilliSecs;
+
     // Flags
     int32_t flags = O_CLOEXEC; // Ensure handles are not inherited by child processes
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH; // TODO:LINUX TODO:MAC Check these permissions

--- a/Code/Core/FileIO/FileStream.h
+++ b/Code/Core/FileIO/FileStream.h
@@ -22,7 +22,7 @@ public:
         NO_RETRY_ON_SHARING_VIOLATION = 0x80,
     };
 
-    bool Open( const char * fileName, uint32_t mode = FileStream::READ_ONLY );
+    bool Open( const char * fileName, uint32_t mode = FileStream::READ_ONLY, uint32_t timeoutMilliSecs = 2000 );
     void Close();
 
     bool IsOpen() const;

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2233,15 +2233,9 @@ bool ObjectNode::WriteTmpFile( Job * job, AString & tmpDirectory, AString & tmpF
     tmpFileName += fileName;
     if ( WorkerThread::CreateTempFile( tmpFileName, tmpFile ) == false )
     {
-        FileIO::WorkAroundForWindowsFilePermissionProblem( tmpFileName, FileStream::WRITE_ONLY, 10 ); // 10s max wait
-
-        // Try again
-        if ( WorkerThread::CreateTempFile( tmpFileName, tmpFile ) == false )
-        {
-            job->Error( "Failed to create temp file. Error: %s TmpFile: '%s' Target: '%s'", LAST_ERROR_STR, tmpFileName.Get(), GetName().Get() );
-            job->OnSystemError();
-            return false;
-        }
+        job->Error( "Failed to create temp file. Error: %s TmpFile: '%s' Target: '%s'", LAST_ERROR_STR, tmpFileName.Get(), GetName().Get() );
+        job->OnSystemError();
+        return false;
     }
     if ( tmpFile.Write( dataToWrite, dataToWriteSize ) != dataToWriteSize )
     {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/MultiBuffer.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/MultiBuffer.cpp
@@ -132,20 +132,14 @@ bool MultiBuffer::ExtractFile( size_t index, const AString & fileName ) const
     m_ReadStream->Seek( offset );
     const void * fileData = (void *)( (size_t)m_ReadStream->GetData() + offset );
 
-    FileStream fs;
-    if ( !fs.Open( fileName.Get(), FileStream::WRITE_ONLY ) )
-    {
-        // On Windows, we can occasionally fail to open the file with error 1224 (ERROR_USER_MAPPED_FILE), due to
-        // things like anti-virus etc. Simply retry if that happens
-        // Also, when a <LOCAL RACE> occurs, the local compilation process might not have exited at this point
-        // (we call ::TerminateProcess, which is async),which can cause failure below, because the file is still locked.
-        FileIO::WorkAroundForWindowsFilePermissionProblem( fileName, FileStream::WRITE_ONLY, 15 ); // 15 secs max wait
+    // On Windows, work around issues caused by security software locking files
+    // by having an extended retry period
+    const uint32_t extendedRetryTimeMS = 15'000;
 
-        // Try again
-        if ( !fs.Open( fileName.Get(), FileStream::WRITE_ONLY ) )
-        {
-            return false;
-        }
+    FileStream fs;
+    if ( !fs.Open( fileName.Get(), FileStream::WRITE_ONLY, extendedRetryTimeMS ) )
+    {
+        return false;
     }
     if ( fs.WriteBuffer( fileData, fileSize ) != fileSize )
     {

--- a/Code/Tools/FBuild/FBuildCore/Helpers/ResponseFile.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Helpers/ResponseFile.cpp
@@ -84,19 +84,17 @@ bool ResponseFile::CreateInternal( const AString & contents )
     // store in tmp folder, and give back to user
     WorkerThread::CreateTempFilePath( "args.rsp", m_ResponseFilePath );
 
+    // On Windows, work around issues caused by security software locking files
+    // by having an exctended retry period
+    const uint32_t extendedRetryTimeMS = 5'000;
+
     // write file to disk
     const uint32_t flags = FileStream::WRITE_ONLY | // we only want to write
                            FileStream::TEMP; // avoid flush to disk if possible
-    if ( !m_File.Open( m_ResponseFilePath.Get(), flags ) )
+    if ( !m_File.Open( m_ResponseFilePath.Get(), flags, extendedRetryTimeMS ) )
     {
-        FileIO::WorkAroundForWindowsFilePermissionProblem( m_ResponseFilePath, flags, 5 ); // 5s max wait
-
-        // Retry
-        if ( !m_File.Open( m_ResponseFilePath.Get(), flags ) )
-        {
-            FLOG_ERROR( "Failed to create response file '%s'", m_ResponseFilePath.Get() );
-            return false; // user must handle error
-        }
+        FLOG_ERROR( "Failed to create response file '%s'", m_ResponseFilePath.Get() );
+        return false; // user must handle error
     }
 
     const bool ok = ( m_File.Write( contents.Get(), contents.GetLength() ) == contents.GetLength() );

--- a/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.cpp
+++ b/Code/Tools/FBuild/FBuildCore/WorkerPool/WorkerThread.cpp
@@ -256,7 +256,12 @@ void WorkerThread::WaitForStop()
 {
     ASSERT( tmpFileName.IsEmpty() == false );
     ASSERT( PathUtils::IsFullPath( tmpFileName ) );
-    return file.Open( tmpFileName.Get(), FileStream::WRITE_ONLY );
+
+    // On Windows, work around issues caused by security software locking files
+    // by having an extended retry period
+    const uint32_t retryTimeMS = 15'000;
+
+    return file.Open( tmpFileName.Get(), FileStream::WRITE_ONLY, retryTimeMS );
 }
 
 // CreateThreadLocalTmpDir


### PR DESCRIPTION
 * Improved FileStream::Open logic
  -- Extend length of default timeout from 500ms to 2s
  -- Implement back off logic to reduce CPU usage to allow other processes (anti-virus) to complete work when they are the cause of locking violations
  -- Expose retry time so callers can extend it in scenarios which we've seen be particularly prone to problems with security software interference
 * Use improved logic in MultiBuffer to avoid edge-case failur
  -- Leverage the retry in FileStream::Open rather than using WorkAroundForWindowsFilePermissionProblem for us to be sure we actually have access to the file, avoiding some potential gaps in access and reducing total IO operations
