### PR TITLE
Fix 32-bit shift UB in Linux CPU-affinity mask helpers

### DIFF
--- a/Code/Core/Env/CPUInfo.cpp
+++ b/Code/Core/Env/CPUInfo.cpp
@@ -100,7 +100,7 @@ namespace
         {
             if ( CPU_ISSET( i, &cpuSet ) )
             {
-                mask |= ( 1 << i );
+                mask |= ( 1ULL << i );
             }
         }
     #endif
@@ -117,7 +117,7 @@ namespace
         CPU_ZERO( &cpuSet );
         for ( size_t i = 0; i < 64; ++i )
         {
-            if ( mask & ( 1 << i ) )
+            if ( mask & ( 1ULL << i ) )
             {
                 CPU_SET( i, &cpuSet );
             }


### PR DESCRIPTION
# Description:

Issue: 1 << i (32-bit) in the Linux affinity read/set loops is UB for i ≥ 32 and aliases cores 32–63 onto 0–31, giving a wrong affinity mask on >32-core machines.

Fix: Use a 64-bit shift 1ULL << i in both loops (GetCurrentThreadAffinityMask and SetCurrentThreadAffinityMask), matching the existing 1ULL usage elsewhere in the file. No behavior change on ≤32-core systems.

Fixes: #1197 

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
