### PR TITLE
Dependencies: guard operator= against self-assignment

### DIFF
--- a/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/Dependencies.h
@@ -214,17 +214,23 @@ inline void Dependencies::Add( const Dependencies & deps )
 //------------------------------------------------------------------------------
 inline Dependencies & Dependencies::operator=( const Dependencies & other )
 {
-    Clear();
-    Add( other );
+    if ( this != &other ) // Guard against self-assignment (Clear() would wipe the source)
+    {
+        Clear();
+        Add( other );
+    }
     return *this;
 }
 
 //------------------------------------------------------------------------------
 inline Dependencies & Dependencies::operator=( Dependencies && other )
 {
-    Clear();
-    m_DependencyList = other.m_DependencyList;
-    other.m_DependencyList = nullptr;
+    if ( this != &other ) // Guard against self-move (would free our own storage)
+    {
+        Clear();
+        m_DependencyList = other.m_DependencyList;
+        other.m_DependencyList = nullptr;
+    }
     return *this;
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestDependencies.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestDependencies.cpp
@@ -263,6 +263,66 @@ TEST_CASE( TestDependencies, OperatorEquals )
             TEST_ASSERT( d1[ index ].GetNode() == d2[ index ].GetNode() );
         }
     }
+
+    // Self-assignment (copy) must not wipe the list
+    {
+        Node * nodes[] = { (Node *)0x01, (Node *)0x02, (Node *)0x03 };
+        Dependencies d;
+        d.Add( nodes[ 0 ], 0x1111, false );
+        d.Add( nodes[ 1 ], 0x2222, true );
+        d.Add( nodes[ 2 ], 0x3333, false );
+
+        const size_t sizeBefore = d.GetSize();
+        const size_t capacityBefore = d.GetCapacity();
+
+        // Assign to self (via a non-const reference so the compiler doesn't fold it away)
+        PRAGMA_DISABLE_PUSH_MSVC( 26496 ) // 'self' is intentionally non-const as we want that
+        Dependencies & self = d;
+        PRAGMA_DISABLE_POP_MSVC
+        d = self;
+
+        TEST_ASSERT( d.GetSize() == sizeBefore );
+        TEST_ASSERT( d.GetCapacity() == capacityBefore );
+        TEST_ASSERT( d[ 0 ].GetNode() == nodes[ 0 ] );
+        TEST_ASSERT( d[ 1 ].GetNode() == nodes[ 1 ] );
+        TEST_ASSERT( d[ 2 ].GetNode() == nodes[ 2 ] );
+        TEST_ASSERT( d[ 0 ].GetNodeStamp() == 0x1111 );
+        TEST_ASSERT( d[ 1 ].GetNodeStamp() == 0x2222 );
+        TEST_ASSERT( d[ 2 ].GetNodeStamp() == 0x3333 );
+        TEST_ASSERT( d[ 0 ].IsWeak() == false );
+        TEST_ASSERT( d[ 1 ].IsWeak() == true );
+        TEST_ASSERT( d[ 2 ].IsWeak() == false );
+    }
+
+    // Self-assignment (move) must not free our own storage
+    {
+        Node * nodes[] = { (Node *)0x04, (Node *)0x05, (Node *)0x06 };
+        Dependencies d;
+        d.Add( nodes[ 0 ], 0x4444, true );
+        d.Add( nodes[ 1 ], 0x5555, false );
+        d.Add( nodes[ 2 ], 0x6666, true );
+
+        const size_t sizeBefore = d.GetSize();
+        const size_t capacityBefore = d.GetCapacity();
+
+        // Move-assign to self (via a non-const reference so the compiler doesn't fold it away)
+        PRAGMA_DISABLE_PUSH_MSVC( 26496 ) // 'self' is intentionally non-const as we want that
+        Dependencies & self = d;
+        PRAGMA_DISABLE_POP_MSVC
+        d = Move( self );
+
+        TEST_ASSERT( d.GetSize() == sizeBefore );
+        TEST_ASSERT( d.GetCapacity() == capacityBefore );
+        TEST_ASSERT( d[ 0 ].GetNode() == nodes[ 0 ] );
+        TEST_ASSERT( d[ 1 ].GetNode() == nodes[ 1 ] );
+        TEST_ASSERT( d[ 2 ].GetNode() == nodes[ 2 ] );
+        TEST_ASSERT( d[ 0 ].GetNodeStamp() == 0x4444 );
+        TEST_ASSERT( d[ 1 ].GetNodeStamp() == 0x5555 );
+        TEST_ASSERT( d[ 2 ].GetNodeStamp() == 0x6666 );
+        TEST_ASSERT( d[ 0 ].IsWeak() == true );
+        TEST_ASSERT( d[ 1 ].IsWeak() == false );
+        TEST_ASSERT( d[ 2 ].IsWeak() == true );
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Description:

Add an if ( this != &other ) guard to both operators. Extend TestDependencies.OperatorEquals with populated self-copy and self-move cases asserting size, capacity, node order, stamps, and weak flags all survive.

Fixes: #1199 

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [x] **Has accompanying tests**
- [x] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
