### PR TITLE
Fixes copy issues with Symlink files. (mostly -clean)

### DIFF
--- a/Code/Core/FileIO/FileIO.cpp
+++ b/Code/Core/FileIO/FileIO.cpp
@@ -221,6 +221,10 @@ public:
     // Special case symlinks.
     if ( S_ISLNK( stat_source.st_mode ) )
     {
+        if ( FileExists( dstFileName ) )
+        {
+            FileDelete( dstFileName );
+        }
         AString linkPath( stat_source.st_size + 1 );
         ssize_t length = readlink( srcFileName, linkPath.Get(), linkPath.GetReserved() );
         if ( length != stat_source.st_size )
@@ -901,7 +905,7 @@ public:
     // Fallback to regular low-resolution filetime setting
     return ( utimes( fileName.Get(), nullptr ) == 0 );
 #elif defined( __LINUX__ )
-    return ( utimensat( 0, fileName.Get(), nullptr, 0 ) == 0 );
+    return ( utimensat( 0, fileName.Get(), nullptr, AT_SYMLINK_NOFOLLOW ) == 0 );
 #else
     #error Unknown platform
 #endif


### PR DESCRIPTION
# Description:

The changes fix build failures due to symlinks failing to be recreated when already existing _(happens mainly during `-clean` builds). Because the `symlink` function does not have a flag to overwrite the existing file, we need to delete it if it already exists and then recreate it.

Notes:
- I've not selected the parity with OSX and Windows, since I'm unable to test or ensure that symlinks are handled properly on OSX right now.
- Test are currently lacking, I'll see if I can create them for Linux and OSX. 
- Not sure if any documentation changes are necessary.

# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [x] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [x] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [x] **Follows the code style**
- [ ] **Includes documentation**
